### PR TITLE
fix(agent): skip nvm bootstrap when claude/codex is already on PATH

### DIFF
--- a/internal/agent/claude_code.go
+++ b/internal/agent/claude_code.go
@@ -69,7 +69,7 @@ func buildClaudeMCPInstallCmd(server runtime.MCPServerConfig) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return nodeRuntimeCommand(cmd), nil
+	return nodeRuntimeCommandWithGuard("claude", cmd), nil
 }
 
 func defaultClaudeCodeInstallCmd() string {
@@ -115,7 +115,7 @@ func (a *ClaudeCodeAgent) Run(ctx context.Context, rt Runtime, opts ExecOptions,
 	ctx = observability.ContextWithConfiguredAgentSpanAttributes(ctx, opts.Env)
 
 	instruction := BuildInstructionFromMessages(messages)
-	cmd := nodeRuntimeCommand(buildClaudePrintCmd(sessionID, a.effectiveModelName(ctx), instruction))
+	cmd := nodeRuntimeCommandWithGuard("claude", buildClaudePrintCmd(sessionID, a.effectiveModelName(ctx), instruction))
 
 	result, err := rt.Exec(ctx, cmd, opts)
 	sessionResult := a.buildSessionResult(ctx, rt, opts, instruction, start, result)

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -126,7 +126,7 @@ func buildCodexMCPInstallCmd(server runtime.MCPServerConfig) (string, error) {
 	default:
 		return "", fmt.Errorf("mcp server %q transport %q is not supported by codex", server.Name, server.Transport)
 	}
-	return nodeRuntimeCommand(cmd.String()), nil
+	return nodeRuntimeCommandWithGuard("codex", cmd.String()), nil
 }
 
 func buildCodexMCPRemoteInstallCmd(server runtime.MCPServerConfig) (string, error) {
@@ -161,7 +161,7 @@ func buildCodexMCPRemoteInstallCmd(server runtime.MCPServerConfig) (string, erro
 		return "", fmt.Errorf("mcp server %q endpoint is invalid: %w", server.Name, err)
 	}
 	cmd.WriteString(endpoint)
-	return nodeRuntimeCommand(cmd.String()), nil
+	return nodeRuntimeCommandWithGuard("codex", cmd.String()), nil
 }
 
 func buildCodexMCPRemoteBridgeScript(server runtime.MCPServerConfig) (string, error) {
@@ -226,7 +226,7 @@ func (a *CodexAgent) Run(ctx context.Context, rt Runtime, opts ExecOptions, mess
 	}
 	lastMessagePath := filepath.Join(rt.Workspace(), ".skill-up", "codex-last-message.txt")
 	cmd := "mkdir -p " + shellQuote(filepath.Dir(lastMessagePath)) + "\n" +
-		nodeRuntimeCommand(buildCodexRunCmdWithLastMessage(instruction, a.effectiveModelName(ctx), a.runProviderConfig(ctx), sandboxFlag, lastMessagePath))
+		nodeRuntimeCommandWithGuard("codex", buildCodexRunCmdWithLastMessage(instruction, a.effectiveModelName(ctx), a.runProviderConfig(ctx), sandboxFlag, lastMessagePath))
 
 	envVars := a.credentialEnvVars(credential.EnvOpenAIAPIKey, credential.EnvOpenAIBaseURL)
 	opts = a.mergeExecOptionsEnv(ctx, opts, envVars, a.buildAgentObservabilityAttrs(nil))

--- a/internal/agent/node_install.go
+++ b/internal/agent/node_install.go
@@ -54,7 +54,7 @@ func nodeBootstrapLines(nodeVersion string) []string {
 		"  nvm install " + shellQuote(nodeVersion),
 		"  nvm use " + shellQuote(nodeVersion),
 		"fi",
-		"if command -v nvm >/dev/null 2>&1; then nvm use " + shellQuote(nodeVersion) + "; fi",
+		"if [ \"$node_major\" -lt " + shellQuote(nodeVersion) + " ] && command -v nvm >/dev/null 2>&1; then nvm use " + shellQuote(nodeVersion) + "; fi",
 		`export npm_config_prefix="$agent_npm_prefix"`,
 		`mkdir -p "$npm_config_prefix/bin"`,
 		`export PATH="$npm_config_prefix/bin:$PATH"`,
@@ -62,8 +62,25 @@ func nodeBootstrapLines(nodeVersion string) []string {
 }
 
 func nodeRuntimeCommand(command string) string {
+	return nodeRuntimeCommandWithGuard("", command)
+}
+
+// nodeRuntimeCommandWithGuard wraps command with the Node/nvm bootstrap,
+// but skips the bootstrap entirely when cliBin is already on PATH. This lets
+// host-style runtimes (environment.type: none) reuse a locally-installed
+// claude / codex without forcing an nvm switch.
+func nodeRuntimeCommandWithGuard(cliBin, command string) string {
 	lines := []string{"set -e"}
-	lines = append(lines, nodeBootstrapLines(agentNodeDefaultVersion)...)
+	bootstrap := nodeBootstrapLines(agentNodeDefaultVersion)
+	if cliBin == "" {
+		lines = append(lines, bootstrap...)
+	} else {
+		lines = append(lines, "if ! command -v "+shellQuote(cliBin)+" >/dev/null 2>&1; then")
+		for _, l := range bootstrap {
+			lines = append(lines, "  "+l)
+		}
+		lines = append(lines, "fi")
+	}
 	lines = append(lines, command)
 	return strings.Join(lines, "\n")
 }

--- a/internal/agent/node_install_test.go
+++ b/internal/agent/node_install_test.go
@@ -43,3 +43,31 @@ func TestNodeBootstrapLinesUsesDefaultVersion(t *testing.T) {
 		t.Fatalf("node bootstrap command does not use default version %s:\n%s", agentNodeDefaultVersion, cmd)
 	}
 }
+
+func TestNodeRuntimeCommandGuardSkipsBootstrapWhenCLIPresent(t *testing.T) {
+	t.Parallel()
+
+	cmd := nodeRuntimeCommandWithGuard("claude", "claude --help")
+	if !strings.Contains(cmd, "if ! command -v 'claude' >/dev/null 2>&1; then") {
+		t.Fatalf("guarded runtime command missing CLI guard:\n%s", cmd)
+	}
+	// Bootstrap must live inside the guarded block, not at top level — verify
+	// the trailing `fi` precedes the actual command invocation.
+	guardClose := strings.Index(cmd, "\nfi\n")
+	cmdIdx := strings.Index(cmd, "claude --help")
+	if guardClose < 0 || cmdIdx < guardClose {
+		t.Fatalf("guarded runtime command should run cli after closing the guard block:\n%s", cmd)
+	}
+}
+
+func TestNodeRuntimeCommandWithoutGuardKeepsBootstrap(t *testing.T) {
+	t.Parallel()
+
+	cmd := nodeRuntimeCommand("echo hi")
+	if strings.Contains(cmd, "if ! command -v") && strings.Contains(cmd, ">/dev/null 2>&1; then\n  export NVM_DIR") {
+		t.Fatalf("unguarded runtime command should not wrap bootstrap in a CLI guard:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, "nvm install '"+agentNodeDefaultVersion+"'") {
+		t.Fatalf("unguarded runtime command should still emit bootstrap:\n%s", cmd)
+	}
+}


### PR DESCRIPTION
## Summary

- `environment.type: none` runs no longer force an nvm bootstrap. The Node/nvm bootstrap is now wrapped in `if ! command -v <cli>`, so when `claude` / `codex` is already on PATH (the common host-development case) nvm is never sourced or switched.
- The bootstrap's trailing `nvm use 22` is loosened to fire only when `node_major < 22`. A system Node >= 22 is left alone instead of being forced onto v22.
- Run paths and all MCP-install builders go through the new guarded helper. Install commands themselves (`defaultClaudeCodeInstallCmd`, `defaultCodexInstallCmd`) keep the unguarded bootstrap because they own the case where the CLI really is missing.

### Why

Before this change, `skill-up run` on a host with Node v24 (no v22 installed) hard-failed with `version "v22" is not yet installed` — even though `claude` / `codex` were perfectly callable locally. That contradicts the implicit contract of `environment.type: none`, which is "use the host as-is."

## Test plan

- [x] `go test -race ./internal/agent/...`
- [x] `golangci-lint run ./internal/agent/...` — 0 issues
- [x] End-to-end via `bin/skill-up run` against the local `aone-bazel` skill with `engine: claude_code` (no model, no base_url) — PASS, transcript captured, no nvm activity in the script.
- [x] Same case with `--engine codex` — PASS.
- [x] Reverified after uninstalling Node v22 locally (only v24 present) — both engines still PASS.
- [x] New unit tests:
  - `TestNodeRuntimeCommandGuardSkipsBootstrapWhenCLIPresent` — guarded helper wraps the bootstrap in `if ! command -v 'claude' >/dev/null 2>&1; then ... fi`.
  - `TestNodeRuntimeCommandWithoutGuardKeepsBootstrap` — unguarded helper still emits the bootstrap unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)