### PR TITLE
docs: remove personal absolute paths from code-stats README

### DIFF
--- a/examples/code-stats/README.md
+++ b/examples/code-stats/README.md
@@ -30,7 +30,7 @@ code-stats/
 ```bash
 # Run evaluation using skill-creator workflow
 claude -p "$(cat <<'EOF'
-Create a skill evaluation for /Users/zhaoping/work/skill-up/examples/code-stats using skill-creator.
+Create a skill evaluation for ./examples/code-stats using skill-creator.
 EOF
 )"
 ```
@@ -38,8 +38,7 @@ EOF
 ### With skill-up (Go framework)
 
 ```bash
-# Build and run
-cd /Users/zhaoping/work/skill-up
+# Build and run (from repo root)
 make build
 ./bin/skill-up run ./examples/code-stats/evals/eval.yaml
 ```


### PR DESCRIPTION
## Summary
- Replace `/Users/zhaoping/work/skill-up` references in [examples/code-stats/README.md](examples/code-stats/README.md) with relative paths so the example is portable.

## Test plan
- [x] `grep -rEn "zhaoping|/Users/" .` returns no matches
- [x] pre-commit lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)