### PR TITLE
test(e2e): verify opensandbox runtime with codex via CI sidecar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,9 +256,9 @@ jobs:
         env:
           DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           DASHSCOPE_MODEL: qwen3.6-plus
-          # codex (dashscope provider) speaks the OpenAI wire API → route it
-          # through DashScope's OpenAI-compatible endpoint.
-          DASHSCOPE_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
+          # codex speaks the OpenAI wire API → point it at DashScope's
+          # OpenAI-compatible endpoint via OPENAI_BASE_URL.
+          OPENAI_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
           # Copies the in-sandbox agent workspace out before t.TempDir cleanup
           # so the upload step below can surface it for post-mortem.
           SKILL_UP_E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-opensandbox-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,17 +245,19 @@ jobs:
 
       - name: Run e2e tests (opensandbox runtime)
         if: steps.secrets.outputs.available == 'true'
-        # Only the claude_code opensandbox path is wired up here; the codex
-        # variant can be added once its provider routing is verified.
-        run: go test -tags e2e -timeout 1800s -count=1 -v -run TestAgent_ClaudeCode_OpenSandboxRuntime ./e2e
+        # Exercise the codex agent here: claude_code already has real-model
+        # coverage in the none-runtime job, whereas codex is otherwise only
+        # tested against a fake binary. This run is its sole real coverage.
+        run: go test -tags e2e -timeout 1800s -count=1 -v -run TestAgent_Codex_OpenSandboxRuntime ./e2e
         env:
-          SKILL_UP_FULL_E2E: "1"
           DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           DASHSCOPE_MODEL: qwen3.6-plus
-          # claude_code + dashscope provider → routed through the Anthropic-compat endpoint.
-          ANTHROPIC_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
-          ANTHROPIC_BASE_URL: https://dashscope.aliyuncs.com/apps/anthropic
-          ANTHROPIC_MODEL: qwen3.6-plus
+          # codex (dashscope provider) speaks the OpenAI wire API → route it
+          # through DashScope's OpenAI-compatible endpoint.
+          DASHSCOPE_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
+          # Copies the in-sandbox agent workspace out before t.TempDir cleanup
+          # so the upload step below can surface it for post-mortem.
+          SKILL_UP_E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-opensandbox-artifacts
 
       - name: Upload OpenSandbox server log
         if: always() && steps.secrets.outputs.available == 'true'
@@ -263,6 +265,15 @@ jobs:
         with:
           name: opensandbox-server-log
           path: ${{ runner.temp }}/opensandbox-server.log
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload opensandbox e2e workspace artifacts
+        if: always() && steps.secrets.outputs.available == 'true' && hashFiles('e2e-opensandbox-artifacts/**') != ''
+        uses: actions/upload-artifact@v5
+        with:
+          name: e2e-opensandbox-workspaces
+          path: e2e-opensandbox-artifacts/
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,10 +254,11 @@ jobs:
         # tested against a fake binary. This run is its sole real coverage.
         run: go test -tags e2e -timeout 1800s -count=1 -v -run TestAgent_Codex_OpenSandboxRuntime ./e2e
         env:
-          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           DASHSCOPE_MODEL: qwen3.6-plus
-          # codex speaks the OpenAI wire API → point it at DashScope's
-          # OpenAI-compatible endpoint via OPENAI_BASE_URL.
+          # codex speaks the OpenAI wire API → supply its key and endpoint via
+          # OPENAI_API_KEY / OPENAI_BASE_URL (DashScope's OpenAI-compatible
+          # endpoint, authenticated with the DashScope key).
+          OPENAI_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           OPENAI_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
           # Copies the in-sandbox agent workspace out before t.TempDir cleanup
           # so the upload step below can surface it for post-mortem.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,122 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  e2e-opensandbox:
+    name: E2E (opensandbox runtime)
+    runs-on: ubuntu-latest
+    # Pulling the execd + sandbox images and bootstrapping the agent inside the
+    # sandbox is slower than the none-runtime job; give it generous headroom.
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v6
+
+      # The opensandbox runtime is self-hosted on the runner (see below), so no
+      # OPENSANDBOX_* secret is needed — but the agent under test still calls a
+      # real model, which needs DASHSCOPE_API_KEY. Fork PRs lack it: skip early.
+      - name: Check secret availability
+        id: secrets
+        env:
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+        run: |
+          if [ -z "$DASHSCOPE_API_KEY" ]; then
+            echo "::notice::Skipping opensandbox e2e: DASHSCOPE_API_KEY not provisioned (likely a fork PR)."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-go@v6
+        if: steps.secrets.outputs.available == 'true'
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Install uv
+        if: steps.secrets.outputs.available == 'true'
+        uses: astral-sh/setup-uv@v8
+
+      - name: Install OpenSandbox server
+        if: steps.secrets.outputs.available == 'true'
+        run: |
+          uv tool install opensandbox-server
+          # uv tool install drops console scripts under ~/.local/bin.
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Start OpenSandbox server
+        if: steps.secrets.outputs.available == 'true'
+        env:
+          # Image the sandbox containers boot from. node:22 is a full Debian
+          # image that already ships node 22 + npm + curl + git, so skill-up's
+          # in-sandbox agent bootstrap is a near no-op. Bare ubuntu:latest does
+          # not work — it lacks curl/git/node and the bootstrap fails.
+          OPENSANDBOX_IMAGE: node:22
+          # execd is the bootstrap binary OpenSandbox injects into every
+          # sandbox. Keep it roughly aligned with the installed server version;
+          # bump if the server log reports an execd compatibility error.
+          OPENSANDBOX_EXECD_IMAGE: opensandbox/execd:v1.0.16
+        run: |
+          docker version
+          api_key="ci-$(openssl rand -hex 16)"
+          config="$RUNNER_TEMP/sandbox.toml"
+          # network_mode = "host" lets the natively-running server and the
+          # sandbox containers it spawns all share the runner's loopback, so
+          # the e2e process reaches both without bridge endpoint rewriting.
+          cat > "$config" <<EOF
+          [server]
+          host = "127.0.0.1"
+          port = 8080
+          api_key = "$api_key"
+
+          [runtime]
+          type = "docker"
+          execd_image = "$OPENSANDBOX_EXECD_IMAGE"
+
+          [docker]
+          network_mode = "host"
+          EOF
+          log="$RUNNER_TEMP/opensandbox-server.log"
+          nohup opensandbox-server --config "$config" > "$log" 2>&1 &
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8080/health 2>/dev/null | grep -q healthy; then
+              echo "OpenSandbox server is healthy"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "::error::OpenSandbox server did not become healthy within 120s"
+              cat "$log"
+              exit 1
+            fi
+            sleep 2
+          done
+          {
+            echo "OPENSANDBOX_API_KEY=$api_key"
+            echo "OPENSANDBOX_BASE_URL=http://127.0.0.1:8080"
+            echo "OPENSANDBOX_IMAGE=$OPENSANDBOX_IMAGE"
+          } >> "$GITHUB_ENV"
+
+      - name: Run e2e tests (opensandbox runtime)
+        if: steps.secrets.outputs.available == 'true'
+        # Only the claude_code opensandbox path is wired up here; the codex
+        # variant can be added once its provider routing is verified.
+        run: go test -tags e2e -timeout 1800s -count=1 -v -run TestAgent_ClaudeCode_OpenSandboxRuntime ./e2e
+        env:
+          SKILL_UP_FULL_E2E: "1"
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          DASHSCOPE_MODEL: qwen3.6-plus
+          # claude_code + dashscope provider → routed through the Anthropic-compat endpoint.
+          ANTHROPIC_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          ANTHROPIC_BASE_URL: https://dashscope.aliyuncs.com/apps/anthropic
+          ANTHROPIC_MODEL: qwen3.6-plus
+
+      - name: Upload OpenSandbox server log
+        if: always() && steps.secrets.outputs.available == 'true'
+        uses: actions/upload-artifact@v5
+        with:
+          name: opensandbox-server-log
+          path: ${{ runner.temp }}/opensandbox-server.log
+          if-no-files-found: ignore
+          retention-days: 14
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,10 @@ jobs:
       - name: Install OpenSandbox server
         if: steps.secrets.outputs.available == 'true'
         run: |
-          uv tool install opensandbox-server
+          # Pin the server version: it must stay compatible with the execd
+          # image pinned in the next step, and an unpinned "latest" would let
+          # an unrelated future release silently change behavior or break CI.
+          uv tool install 'opensandbox-server==0.1.13'
           # uv tool install drops console scripts under ~/.local/bin.
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
@@ -200,8 +203,9 @@ jobs:
           # not work — it lacks curl/git/node and the bootstrap fails.
           OPENSANDBOX_IMAGE: node:22
           # execd is the bootstrap binary OpenSandbox injects into every
-          # sandbox. Keep it roughly aligned with the installed server version;
-          # bump if the server log reports an execd compatibility error.
+          # sandbox. Pinned together with opensandbox-server 0.1.13 above;
+          # bump both in lockstep if the server log reports an execd
+          # compatibility error.
           OPENSANDBOX_EXECD_IMAGE: opensandbox/execd:v1.0.16
         run: |
           docker version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Install uv
         if: steps.secrets.outputs.available == 'true'
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install OpenSandbox server
         if: steps.secrets.outputs.available == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,12 +254,12 @@ jobs:
         # tested against a fake binary. This run is its sole real coverage.
         run: go test -tags e2e -timeout 1800s -count=1 -v -run TestAgent_Codex_OpenSandboxRuntime ./e2e
         env:
-          DASHSCOPE_MODEL: qwen3.6-plus
-          # codex speaks the OpenAI wire API → supply its key and endpoint via
-          # OPENAI_API_KEY / OPENAI_BASE_URL (DashScope's OpenAI-compatible
-          # endpoint, authenticated with the DashScope key).
+          # codex speaks the OpenAI wire API → supply its key, endpoint and
+          # model via OPENAI_* (DashScope's OpenAI-compatible endpoint,
+          # authenticated with the DashScope key).
           OPENAI_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           OPENAI_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
+          OPENAI_MODEL: qwen3.6-plus
           # Copies the in-sandbox agent workspace out before t.TempDir cleanup
           # so the upload step below can surface it for post-mortem.
           SKILL_UP_E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-opensandbox-artifacts

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -773,8 +773,8 @@ func isOpenSandboxReadyFailure(stderr string) bool {
 // against a real OpenSandbox runtime. Mirrors TestAgent_Codex_OpenSandboxRuntime
 // so both supported engines have end-to-end coverage of the opensandbox bridge.
 func TestAgent_ClaudeCode_OpenSandboxRuntime(t *testing.T) {
-	skipIfClaudeUnavailable(t)
-
+	// No skipIfClaudeUnavailable here: the opensandbox runtime bootstraps the
+	// claude CLI inside the sandbox, so the host runner does not need it.
 	sandboxAPIKey := openSandboxE2EAPIKey()
 	if sandboxAPIKey == "" {
 		t.Skip("OPENSANDBOX_API_KEY not set, skipping claude_code opensandbox test")

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -47,6 +47,16 @@ func openSandboxE2EBaseURL() string {
 	return "https://agent-sandbox.example.com"
 }
 
+// openSandboxE2EImage returns the sandbox image reference for e2e tests.
+// Internal CI overrides via OPENSANDBOX_IMAGE; the placeholder default keeps
+// the open-source repo free of vendor-specific image URIs.
+func openSandboxE2EImage() string {
+	if image := os.Getenv("OPENSANDBOX_IMAGE"); image != "" {
+		return image
+	}
+	return "registry.example.com/agentic-execution:placeholder"
+}
+
 func dashScopeE2EAPIKey() string {
 	if apiKey := os.Getenv("DASHSCOPE_API_KEY"); apiKey != "" {
 		return apiKey
@@ -684,8 +694,7 @@ expect:
 environment:
   type: opensandbox
   workspace_mount: /workspace
-  # Placeholder image reference; replace with a valid OpenSandbox image in your environment.
-  image: registry.example.com/agentic-execution:placeholder
+  image: `+openSandboxE2EImage()+`
   ready_timeout_seconds: 300
   kwargs:
     base_url: `+openSandboxE2EBaseURL()+`
@@ -758,6 +767,121 @@ report:
 func isOpenSandboxReadyFailure(stderr string) bool {
 	return strings.Contains(stderr, "failed to create opensandbox") &&
 		strings.Contains(stderr, "did not become ready")
+}
+
+// TestAgent_ClaudeCode_OpenSandboxRuntime exercises the claude_code engine
+// against a real OpenSandbox runtime. Mirrors TestAgent_Codex_OpenSandboxRuntime
+// so both supported engines have end-to-end coverage of the opensandbox bridge.
+func TestAgent_ClaudeCode_OpenSandboxRuntime(t *testing.T) {
+	skipIfClaudeUnavailable(t)
+
+	sandboxAPIKey := openSandboxE2EAPIKey()
+	if sandboxAPIKey == "" {
+		t.Skip("OPENSANDBOX_API_KEY not set, skipping claude_code opensandbox test")
+	}
+	anthropicAPIKey := os.Getenv("ANTHROPIC_API_KEY")
+	if anthropicAPIKey == "" {
+		// Fall back to DASHSCOPE_API_KEY so CI that wires DashScope's
+		// Anthropic-compatible endpoint into ANTHROPIC_BASE_URL still runs.
+		anthropicAPIKey = dashScopeE2EAPIKey()
+	}
+	if anthropicAPIKey == "" {
+		t.Skip("ANTHROPIC_API_KEY/DASHSCOPE_API_KEY not set, skipping claude_code opensandbox test")
+	}
+
+	evalDir := t.TempDir()
+	writeFile(t, filepath.Join(evalDir, "SKILL.md"), "# ClaudeCode OpenSandbox E2E\n")
+	writeFile(t, filepath.Join(evalDir, "evals", "cases", "ok.yaml"), `id: ok
+title: ClaudeCode OpenSandbox smoke
+input:
+  prompt: Return a short acknowledgement.
+constraints:
+  timeout_seconds: 600
+  max_turns: 1
+expect:
+  must_not_contain:
+    - __skill_up_forbidden__
+`)
+
+	evalPath := filepath.Join(evalDir, "evals", "eval.yaml")
+	writeFile(t, evalPath, `schema_version: v1alpha1
+environment:
+  type: opensandbox
+  workspace_mount: /workspace
+  image: `+openSandboxE2EImage()+`
+  ready_timeout_seconds: 300
+  kwargs:
+    base_url: `+openSandboxE2EBaseURL()+`
+    request_timeout_seconds: "900"
+mcp:
+  servers: []
+skills: []
+engine:
+  name: claude_code
+  model:
+    provider: dashscope
+    name: `+dashScopeE2EModel()+`
+cases:
+  files:
+    - evals/cases/ok.yaml
+  defaults:
+    timeout_seconds: 600
+    max_turns: 1
+  parallelism: 1
+  retry_policy:
+    max_retries: 0
+benchmark:
+  enabled: false
+judge:
+  type: rule_based
+report:
+  formats: [json]
+  artifacts: [transcript]
+`)
+
+	outputDir := t.TempDir()
+	env := []string{
+		"OPENSANDBOX_API_KEY=" + sandboxAPIKey,
+		"ANTHROPIC_API_KEY=" + anthropicAPIKey,
+	}
+	if baseURL := os.Getenv("ANTHROPIC_BASE_URL"); baseURL != "" {
+		env = append(env, "ANTHROPIC_BASE_URL="+baseURL)
+	}
+	if model := os.Getenv("ANTHROPIC_MODEL"); model != "" {
+		env = append(env, "ANTHROPIC_MODEL="+model)
+	}
+
+	result := Run(t, RunConfig{
+		Timeout: 10 * 60e9,
+		Env:     env,
+	}, "run", evalPath, "--output-dir", outputDir)
+
+	if result.ExitCode == ExitCodeTimeout {
+		t.Skip("claude_code opensandbox run timed out")
+	}
+	if isOpenSandboxReadyFailure(result.Stderr) {
+		t.Skipf("opensandbox did not become ready: %s", result.Stderr)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("claude_code opensandbox run failed: exit=%d\nstdout=%s\nstderr=%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	resultPath := filepath.Join(outputDir, "iteration-1", "result.json")
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("failed to read result.json: %v", err)
+	}
+	if !strings.Contains(string(data), `"engine_name": "claude_code"`) || !strings.Contains(string(data), `"status": "PASS"`) {
+		t.Fatalf("unexpected result.json:\n%s", string(data))
+	}
+	responsePath := filepath.Join(outputDir, "iteration-1", "ok", "with_skill", "outputs", "response.md")
+	response, err := os.ReadFile(responsePath)
+	if err != nil {
+		t.Fatalf("failed to read response.md: %v", err)
+	}
+	if strings.TrimSpace(string(response)) == "" {
+		t.Fatalf("response.md is empty")
+	}
 }
 
 // TestAgent_ClaudeCode_WithAPIKey tests claude-code with real API key.

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -57,13 +57,6 @@ func openSandboxE2EImage() string {
 	return "registry.example.com/agentic-execution:placeholder"
 }
 
-func dashScopeE2EAPIKey() string {
-	if apiKey := os.Getenv("DASHSCOPE_API_KEY"); apiKey != "" {
-		return apiKey
-	}
-	return os.Getenv("OPENAI_API_KEY")
-}
-
 func dashScopeE2EModel() string {
 	if model := os.Getenv("DASHSCOPE_MODEL"); model != "" {
 		return model
@@ -660,14 +653,15 @@ func TestAgent_Codex_OpenSandboxRuntime(t *testing.T) {
 	if sandboxAPIKey == "" {
 		t.Skip("OPENSANDBOX_API_KEY not set, skipping codex opensandbox test")
 	}
-	dashscopeAPIKey := dashScopeE2EAPIKey()
-	if dashscopeAPIKey == "" {
-		t.Skip("DASHSCOPE_API_KEY/OPENAI_API_KEY not set, skipping codex opensandbox test")
+	// codex speaks the OpenAI wire API; its key and endpoint come from
+	// OPENAI_API_KEY / OPENAI_BASE_URL (external config). The eval declares
+	// `provider: dashscope`, so skill-up resolves DASHSCOPE_API_KEY /
+	// DASHSCOPE_BASE_URL — the run env below re-exports these values under
+	// those names.
+	codexAPIKey := os.Getenv("OPENAI_API_KEY")
+	if codexAPIKey == "" {
+		t.Skip("OPENAI_API_KEY not set, skipping codex opensandbox test")
 	}
-	// codex speaks the OpenAI wire API; its endpoint comes from OPENAI_BASE_URL
-	// (external config). The eval declares `provider: dashscope`, so skill-up
-	// resolves DASHSCOPE_BASE_URL — the run env below re-exports this value
-	// under that name.
 	codexBaseURL := os.Getenv("OPENAI_BASE_URL")
 	if codexBaseURL == "" {
 		t.Skip("OPENAI_BASE_URL not set, skipping codex opensandbox test")
@@ -731,7 +725,7 @@ report:
 		Timeout: 10 * 60e9,
 		Env: []string{
 			"OPENSANDBOX_API_KEY=" + sandboxAPIKey,
-			"DASHSCOPE_API_KEY=" + dashscopeAPIKey,
+			"DASHSCOPE_API_KEY=" + codexAPIKey,
 			"DASHSCOPE_BASE_URL=" + codexBaseURL,
 			"DASHSCOPE_MODEL=" + dashScopeE2EModel(),
 		},

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -794,15 +794,13 @@ func TestAgent_ClaudeCode_OpenSandboxRuntime(t *testing.T) {
 	if sandboxAPIKey == "" {
 		t.Skip("OPENSANDBOX_API_KEY not set, skipping claude_code opensandbox test")
 	}
+	// claude_code authenticates with ANTHROPIC_API_KEY. Whether that key is a
+	// real Anthropic key or a DashScope key for the Anthropic-compatible
+	// endpoint is an external configuration choice (the CI workflow sets it);
+	// the test does not reach into other providers' env vars.
 	modelAPIKey := os.Getenv("ANTHROPIC_API_KEY")
 	if modelAPIKey == "" {
-		// Fall back to the DashScope key; a DashScope key authenticates both
-		// the OpenAI- and Anthropic-compatible endpoints. Only the key is
-		// borrowed here — the base URL is pinned below, never inherited.
-		modelAPIKey = dashScopeE2EAPIKey()
-	}
-	if modelAPIKey == "" {
-		t.Skip("ANTHROPIC_API_KEY/DASHSCOPE_API_KEY not set, skipping claude_code opensandbox test")
+		t.Skip("ANTHROPIC_API_KEY not set, skipping claude_code opensandbox test")
 	}
 
 	evalDir := t.TempDir()

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -57,16 +57,6 @@ func openSandboxE2EImage() string {
 	return "registry.example.com/agentic-execution:placeholder"
 }
 
-func dashScopeE2EModel() string {
-	if model := os.Getenv("DASHSCOPE_MODEL"); model != "" {
-		return model
-	}
-	if model := os.Getenv("OPENAI_MODEL"); model != "" {
-		return model
-	}
-	return "qwen3.6-plus"
-}
-
 func TestAgent_Codex_NoneRuntime_WorkspaceDiffGitContexts(t *testing.T) {
 	t.Parallel()
 
@@ -653,11 +643,10 @@ func TestAgent_Codex_OpenSandboxRuntime(t *testing.T) {
 	if sandboxAPIKey == "" {
 		t.Skip("OPENSANDBOX_API_KEY not set, skipping codex opensandbox test")
 	}
-	// codex speaks the OpenAI wire API; its key and endpoint come from
-	// OPENAI_API_KEY / OPENAI_BASE_URL (external config). The eval declares
-	// `provider: dashscope`, so skill-up resolves DASHSCOPE_API_KEY /
-	// DASHSCOPE_BASE_URL — the run env below re-exports these values under
-	// those names.
+	// codex speaks the OpenAI wire API. The eval declares `provider: openai`,
+	// so skill-up resolves the key, endpoint and model name straight from
+	// OPENAI_API_KEY / OPENAI_BASE_URL / OPENAI_MODEL — all external config,
+	// no in-test defaults or cross-provider re-exports.
 	codexAPIKey := os.Getenv("OPENAI_API_KEY")
 	if codexAPIKey == "" {
 		t.Skip("OPENAI_API_KEY not set, skipping codex opensandbox test")
@@ -665,6 +654,10 @@ func TestAgent_Codex_OpenSandboxRuntime(t *testing.T) {
 	codexBaseURL := os.Getenv("OPENAI_BASE_URL")
 	if codexBaseURL == "" {
 		t.Skip("OPENAI_BASE_URL not set, skipping codex opensandbox test")
+	}
+	codexModel := os.Getenv("OPENAI_MODEL")
+	if codexModel == "" {
+		t.Skip("OPENAI_MODEL not set, skipping codex opensandbox test")
 	}
 
 	evalDir := t.TempDir()
@@ -697,8 +690,8 @@ skills: []
 engine:
   name: codex
   model:
-    provider: dashscope
-    name: `+dashScopeE2EModel()+`
+    provider: openai
+    name: `+codexModel+`
 cases:
   files:
     - evals/cases/ok.yaml
@@ -725,9 +718,8 @@ report:
 		Timeout: 10 * 60e9,
 		Env: []string{
 			"OPENSANDBOX_API_KEY=" + sandboxAPIKey,
-			"DASHSCOPE_API_KEY=" + codexAPIKey,
-			"DASHSCOPE_BASE_URL=" + codexBaseURL,
-			"DASHSCOPE_MODEL=" + dashScopeE2EModel(),
+			"OPENAI_API_KEY=" + codexAPIKey,
+			"OPENAI_BASE_URL=" + codexBaseURL,
 		},
 	}, "run", evalPath, "--output-dir", outputDir)
 
@@ -774,22 +766,23 @@ func TestAgent_ClaudeCode_OpenSandboxRuntime(t *testing.T) {
 	if sandboxAPIKey == "" {
 		t.Skip("OPENSANDBOX_API_KEY not set, skipping claude_code opensandbox test")
 	}
-	// claude_code authenticates with ANTHROPIC_API_KEY. Whether that key is a
-	// real Anthropic key or a DashScope key for the Anthropic-compatible
-	// endpoint is an external configuration choice (the CI workflow sets it);
-	// the test does not reach into other providers' env vars.
+	// claude_code speaks the Anthropic wire API. The eval declares
+	// `provider: anthropic`, so skill-up resolves the key, endpoint and model
+	// name straight from ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL /
+	// ANTHROPIC_MODEL — all external config, no in-test defaults. Whether the
+	// key is a real Anthropic key or a DashScope key for the Anthropic-
+	// compatible endpoint is the CI workflow's choice.
 	modelAPIKey := os.Getenv("ANTHROPIC_API_KEY")
 	if modelAPIKey == "" {
 		t.Skip("ANTHROPIC_API_KEY not set, skipping claude_code opensandbox test")
 	}
-	// claude_code speaks the Anthropic wire API; its endpoint comes from
-	// ANTHROPIC_BASE_URL (external config). The eval declares
-	// `provider: dashscope`, so skill-up resolves DASHSCOPE_BASE_URL — the run
-	// env below re-exports this value under that name so an inherited
-	// OpenAI-compatible DASHSCOPE_BASE_URL cannot leak in.
 	modelBaseURL := os.Getenv("ANTHROPIC_BASE_URL")
 	if modelBaseURL == "" {
 		t.Skip("ANTHROPIC_BASE_URL not set, skipping claude_code opensandbox test")
+	}
+	modelName := os.Getenv("ANTHROPIC_MODEL")
+	if modelName == "" {
+		t.Skip("ANTHROPIC_MODEL not set, skipping claude_code opensandbox test")
 	}
 
 	evalDir := t.TempDir()
@@ -822,8 +815,8 @@ skills: []
 engine:
   name: claude_code
   model:
-    provider: dashscope
-    name: `+dashScopeE2EModel()+`
+    provider: anthropic
+    name: `+modelName+`
 cases:
   files:
     - evals/cases/ok.yaml
@@ -846,20 +839,13 @@ report:
 	// Surface the in-sandbox agent artifacts (stdout.json / response.md /
 	// transcript) as CI artifacts so a failure inside the sandbox is debuggable.
 	preserveWorkspaceArtifacts(t, outputDir)
-	env := []string{
-		"OPENSANDBOX_API_KEY=" + sandboxAPIKey,
-		"DASHSCOPE_API_KEY=" + modelAPIKey,
-		"DASHSCOPE_BASE_URL=" + modelBaseURL,
-		"ANTHROPIC_API_KEY=" + modelAPIKey,
-		"ANTHROPIC_BASE_URL=" + modelBaseURL,
-	}
-	if model := os.Getenv("ANTHROPIC_MODEL"); model != "" {
-		env = append(env, "ANTHROPIC_MODEL="+model)
-	}
-
 	result := Run(t, RunConfig{
 		Timeout: 10 * 60e9,
-		Env:     env,
+		Env: []string{
+			"OPENSANDBOX_API_KEY=" + sandboxAPIKey,
+			"ANTHROPIC_API_KEY=" + modelAPIKey,
+			"ANTHROPIC_BASE_URL=" + modelBaseURL,
+		},
 	}, "run", evalPath, "--output-dir", outputDir)
 
 	if result.ExitCode == ExitCodeTimeout {

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -726,6 +726,9 @@ report:
 `)
 
 	outputDir := t.TempDir()
+	// Surface the in-sandbox agent artifacts (stdout.json / response.md /
+	// transcript) as CI artifacts so a failure inside the sandbox is debuggable.
+	preserveWorkspaceArtifacts(t, outputDir)
 	result := Run(t, RunConfig{
 		Timeout: 10 * 60e9,
 		Env: []string{
@@ -840,6 +843,9 @@ report:
 `)
 
 	outputDir := t.TempDir()
+	// Surface the in-sandbox agent artifacts (stdout.json / response.md /
+	// transcript) as CI artifacts so a failure inside the sandbox is debuggable.
+	preserveWorkspaceArtifacts(t, outputDir)
 	env := []string{
 		"OPENSANDBOX_API_KEY=" + sandboxAPIKey,
 		"ANTHROPIC_API_KEY=" + anthropicAPIKey,

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -64,28 +64,6 @@ func dashScopeE2EAPIKey() string {
 	return os.Getenv("OPENAI_API_KEY")
 }
 
-func dashScopeE2EBaseURL() string {
-	if baseURL := os.Getenv("DASHSCOPE_BASE_URL"); baseURL != "" {
-		return baseURL
-	}
-	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
-		return baseURL
-	}
-	return "https://dashscope.aliyuncs.com/compatible-mode/v1"
-}
-
-// dashScopeAnthropicE2EBaseURL returns an Anthropic-wire-compatible base URL
-// for claude_code e2e tests. Defaults to DashScope's Anthropic-compatible
-// endpoint; override via ANTHROPIC_BASE_URL. This is intentionally separate
-// from dashScopeE2EBaseURL (OpenAI-compatible, used by codex) so the two
-// engines never share an endpoint.
-func dashScopeAnthropicE2EBaseURL() string {
-	if baseURL := os.Getenv("ANTHROPIC_BASE_URL"); baseURL != "" {
-		return baseURL
-	}
-	return "https://dashscope.aliyuncs.com/apps/anthropic"
-}
-
 func dashScopeE2EModel() string {
 	if model := os.Getenv("DASHSCOPE_MODEL"); model != "" {
 		return model
@@ -686,6 +664,14 @@ func TestAgent_Codex_OpenSandboxRuntime(t *testing.T) {
 	if dashscopeAPIKey == "" {
 		t.Skip("DASHSCOPE_API_KEY/OPENAI_API_KEY not set, skipping codex opensandbox test")
 	}
+	// codex speaks the OpenAI wire API; its endpoint comes from OPENAI_BASE_URL
+	// (external config). The eval declares `provider: dashscope`, so skill-up
+	// resolves DASHSCOPE_BASE_URL — the run env below re-exports this value
+	// under that name.
+	codexBaseURL := os.Getenv("OPENAI_BASE_URL")
+	if codexBaseURL == "" {
+		t.Skip("OPENAI_BASE_URL not set, skipping codex opensandbox test")
+	}
 
 	evalDir := t.TempDir()
 	writeFile(t, filepath.Join(evalDir, "SKILL.md"), "# Codex OpenSandbox E2E\n")
@@ -746,7 +732,7 @@ report:
 		Env: []string{
 			"OPENSANDBOX_API_KEY=" + sandboxAPIKey,
 			"DASHSCOPE_API_KEY=" + dashscopeAPIKey,
-			"DASHSCOPE_BASE_URL=" + dashScopeE2EBaseURL(),
+			"DASHSCOPE_BASE_URL=" + codexBaseURL,
 			"DASHSCOPE_MODEL=" + dashScopeE2EModel(),
 		},
 	}, "run", evalPath, "--output-dir", outputDir)
@@ -801,6 +787,15 @@ func TestAgent_ClaudeCode_OpenSandboxRuntime(t *testing.T) {
 	modelAPIKey := os.Getenv("ANTHROPIC_API_KEY")
 	if modelAPIKey == "" {
 		t.Skip("ANTHROPIC_API_KEY not set, skipping claude_code opensandbox test")
+	}
+	// claude_code speaks the Anthropic wire API; its endpoint comes from
+	// ANTHROPIC_BASE_URL (external config). The eval declares
+	// `provider: dashscope`, so skill-up resolves DASHSCOPE_BASE_URL — the run
+	// env below re-exports this value under that name so an inherited
+	// OpenAI-compatible DASHSCOPE_BASE_URL cannot leak in.
+	modelBaseURL := os.Getenv("ANTHROPIC_BASE_URL")
+	if modelBaseURL == "" {
+		t.Skip("ANTHROPIC_BASE_URL not set, skipping claude_code opensandbox test")
 	}
 
 	evalDir := t.TempDir()
@@ -857,19 +852,12 @@ report:
 	// Surface the in-sandbox agent artifacts (stdout.json / response.md /
 	// transcript) as CI artifacts so a failure inside the sandbox is debuggable.
 	preserveWorkspaceArtifacts(t, outputDir)
-	// The eval uses `provider: dashscope`, so skill-up resolves the model
-	// endpoint from DASHSCOPE_BASE_URL and hands it to claude_code as
-	// ANTHROPIC_BASE_URL. Pin DASHSCOPE_BASE_URL to the Anthropic-compatible
-	// endpoint here so an inherited OpenAI-compatible DASHSCOPE_BASE_URL (set
-	// by the codex opensandbox CI job) cannot leak in and turn an endpoint
-	// mismatch into what looks like an OpenSandbox regression.
-	anthropicBaseURL := dashScopeAnthropicE2EBaseURL()
 	env := []string{
 		"OPENSANDBOX_API_KEY=" + sandboxAPIKey,
 		"DASHSCOPE_API_KEY=" + modelAPIKey,
-		"DASHSCOPE_BASE_URL=" + anthropicBaseURL,
+		"DASHSCOPE_BASE_URL=" + modelBaseURL,
 		"ANTHROPIC_API_KEY=" + modelAPIKey,
-		"ANTHROPIC_BASE_URL=" + anthropicBaseURL,
+		"ANTHROPIC_BASE_URL=" + modelBaseURL,
 	}
 	if model := os.Getenv("ANTHROPIC_MODEL"); model != "" {
 		env = append(env, "ANTHROPIC_MODEL="+model)

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -74,6 +74,18 @@ func dashScopeE2EBaseURL() string {
 	return "https://dashscope.aliyuncs.com/compatible-mode/v1"
 }
 
+// dashScopeAnthropicE2EBaseURL returns an Anthropic-wire-compatible base URL
+// for claude_code e2e tests. Defaults to DashScope's Anthropic-compatible
+// endpoint; override via ANTHROPIC_BASE_URL. This is intentionally separate
+// from dashScopeE2EBaseURL (OpenAI-compatible, used by codex) so the two
+// engines never share an endpoint.
+func dashScopeAnthropicE2EBaseURL() string {
+	if baseURL := os.Getenv("ANTHROPIC_BASE_URL"); baseURL != "" {
+		return baseURL
+	}
+	return "https://dashscope.aliyuncs.com/apps/anthropic"
+}
+
 func dashScopeE2EModel() string {
 	if model := os.Getenv("DASHSCOPE_MODEL"); model != "" {
 		return model
@@ -782,13 +794,14 @@ func TestAgent_ClaudeCode_OpenSandboxRuntime(t *testing.T) {
 	if sandboxAPIKey == "" {
 		t.Skip("OPENSANDBOX_API_KEY not set, skipping claude_code opensandbox test")
 	}
-	anthropicAPIKey := os.Getenv("ANTHROPIC_API_KEY")
-	if anthropicAPIKey == "" {
-		// Fall back to DASHSCOPE_API_KEY so CI that wires DashScope's
-		// Anthropic-compatible endpoint into ANTHROPIC_BASE_URL still runs.
-		anthropicAPIKey = dashScopeE2EAPIKey()
+	modelAPIKey := os.Getenv("ANTHROPIC_API_KEY")
+	if modelAPIKey == "" {
+		// Fall back to the DashScope key; a DashScope key authenticates both
+		// the OpenAI- and Anthropic-compatible endpoints. Only the key is
+		// borrowed here — the base URL is pinned below, never inherited.
+		modelAPIKey = dashScopeE2EAPIKey()
 	}
-	if anthropicAPIKey == "" {
+	if modelAPIKey == "" {
 		t.Skip("ANTHROPIC_API_KEY/DASHSCOPE_API_KEY not set, skipping claude_code opensandbox test")
 	}
 
@@ -846,12 +859,19 @@ report:
 	// Surface the in-sandbox agent artifacts (stdout.json / response.md /
 	// transcript) as CI artifacts so a failure inside the sandbox is debuggable.
 	preserveWorkspaceArtifacts(t, outputDir)
+	// The eval uses `provider: dashscope`, so skill-up resolves the model
+	// endpoint from DASHSCOPE_BASE_URL and hands it to claude_code as
+	// ANTHROPIC_BASE_URL. Pin DASHSCOPE_BASE_URL to the Anthropic-compatible
+	// endpoint here so an inherited OpenAI-compatible DASHSCOPE_BASE_URL (set
+	// by the codex opensandbox CI job) cannot leak in and turn an endpoint
+	// mismatch into what looks like an OpenSandbox regression.
+	anthropicBaseURL := dashScopeAnthropicE2EBaseURL()
 	env := []string{
 		"OPENSANDBOX_API_KEY=" + sandboxAPIKey,
-		"ANTHROPIC_API_KEY=" + anthropicAPIKey,
-	}
-	if baseURL := os.Getenv("ANTHROPIC_BASE_URL"); baseURL != "" {
-		env = append(env, "ANTHROPIC_BASE_URL="+baseURL)
+		"DASHSCOPE_API_KEY=" + modelAPIKey,
+		"DASHSCOPE_BASE_URL=" + anthropicBaseURL,
+		"ANTHROPIC_API_KEY=" + modelAPIKey,
+		"ANTHROPIC_BASE_URL=" + anthropicBaseURL,
 	}
 	if model := os.Getenv("ANTHROPIC_MODEL"); model != "" {
 		env = append(env, "ANTHROPIC_MODEL="+model)


### PR DESCRIPTION
## Summary

Adds executed CI coverage for the OpenSandbox runtime. Until now the
opensandbox path never ran in CI — the existing codex opensandbox test
always skipped for lack of an external sandbox service. This PR adds a CI
job that self-hosts the OpenSandbox server on the runner, so the path is
exercised on every PR.

The opensandbox job runs the **codex** agent: claude_code already has
real-model coverage in the none-runtime e2e job, whereas codex is otherwise
only exercised against a fake binary — so this is its sole real coverage and
adds one more agent overall.

## Changes

- `.github/workflows/ci.yml`: new `e2e-opensandbox` job. Installs
  `opensandbox-server` via `uv`, starts it as a background process (Docker
  runtime, host network, host `docker.sock`), health-checks it, then runs
  `TestAgent_Codex_OpenSandboxRuntime` against `http://127.0.0.1:8080`.
- `e2e/agent_test.go`: new `TestAgent_ClaudeCode_OpenSandboxRuntime`
  (mirrors the codex test; runnable locally / in future CI) and an
  `openSandboxE2EImage()` helper that reads `OPENSANDBOX_IMAGE`.
- Both opensandbox tests preserve the in-sandbox agent workspace as a CI
  artifact for post-mortem when execution fails inside the sandbox.

## Test plan

- [ ] `make test` / `make verify` pass
- [x] `go test -tags e2e -run OpenSandbox ./e2e` passes locally (skips
      cleanly without `OPENSANDBOX_API_KEY`)
- [ ] New `e2e-opensandbox` CI job is green on this PR

## Notes for reviewers

- The sandbox image is `node:22`: skill-up bootstraps the agent CLI inside
  the sandbox (`nvm`/`node`/`npm install`), which needs `curl`/`git`/`node`.
  Bare `ubuntu:latest` lacks these. Override via `OPENSANDBOX_IMAGE`.
- The OpenSandbox server is self-hosted, so no `OPENSANDBOX_*` secret is
  needed — but the agent still calls a real model, so the job gates on
  `DASHSCOPE_API_KEY` and skips on fork PRs (same pattern as the e2e job).
- `execd_image` is pinned to `opensandbox/execd:v1.0.16`; bump if the
  server log reports an execd compatibility error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)