### PR TITLE
feat(mcp): support mocked MCP servers

### DIFF
--- a/docs/guide/writing-evals.md
+++ b/docs/guide/writing-evals.md
@@ -69,7 +69,7 @@ environment:
 mcp:
   servers:
     - name: github                # MCP server name
-      mode: real                  # `real` is supported; `mocked` is reserved
+      mode: real                  # real / mocked
       transport: http             # http / stdio; inferred from endpoint/command if omitted
       config_ref: evals/fixtures/mcp/github.yaml  # Path to config file
 
@@ -113,7 +113,7 @@ report:
 
 ### MCP configuration
 
-MCP currently supports `mode: real`, which installs a real MCP server into Agents such as `claude_code`, `qodercli`, or `codex`. `mode: mocked` is reserved and currently raises an error to avoid silently shipping a non-mocked server.
+MCP supports `mode: real` and `mode: mocked`. `real` installs a real MCP server into Agents such as `claude_code`, `qodercli`, or `codex`; `mocked` makes `internal/mcp` generate a local stdio mock server that is then installed into the Agent like any other MCP server.
 
 HTTP MCP servers can be declared inline or pulled in via `config_ref`:
 
@@ -147,6 +147,34 @@ mcp:
       transport: stdio
       command: /usr/bin/python3
       args: [evals/fixtures/mcp/marker_server.py]
+```
+
+A mocked MCP server can use the built-in `filesystem` mock server directly:
+
+```yaml
+mcp:
+  servers:
+    - name: filesystem
+      mode: mocked
+```
+
+Or define tool responses through `config_ref`:
+
+```yaml
+mcp:
+  servers:
+    - name: project-mgmt
+      mode: mocked
+      config_ref: evals/fixtures/mcp/project-mgmt.yaml
+```
+
+```yaml
+tool_responses:
+  create_publish_plan_simple:
+    default:
+      id: 999
+      name: "{{params.name}}"
+      status: ONGOING
 ```
 
 Environment-variable references support both `${VAR}` and full-value `$VAR` forms; the variable name must match `[A-Za-z_][A-Za-z0-9_]*`. Variables listed in `required_env` are injected into the Agent process; full env-var references inside `headers` are also recorded by name so the Agent can pick the right transport mechanism when installing the MCP server.

--- a/docs/zh/guide/writing-evals.md
+++ b/docs/zh/guide/writing-evals.md
@@ -69,7 +69,7 @@ environment:
 mcp:
   servers:
     - name: github                # MCP Server 名称
-      mode: real                  # 当前支持 real；mocked 暂未实现
+      mode: real                  # real / mocked
       transport: http             # http / stdio；未指定时按 endpoint/command 推断
       config_ref: evals/fixtures/mcp/github.yaml  # 配置文件路径
 
@@ -113,7 +113,7 @@ report:
 
 ### MCP 配置说明
 
-MCP 当前支持 `mode: real`，用于把真实 MCP Server 安装到 `claude_code`、`qodercli` 或 `codex` 等 Agent。`mode: mocked` 是预留模式，当前会明确报错，避免误以为 mock server 已经启动。
+MCP 支持 `mode: real` 和 `mode: mocked`。`real` 用于把真实 MCP Server 安装到 `claude_code`、`qodercli` 或 `codex` 等 Agent；`mocked` 会由 `internal/mcp` 生成本地 stdio Mock Server，并按普通 MCP 配置安装到 Agent。
 
 HTTP MCP 可以直接在 `eval.yaml` 中声明，也可以用 `config_ref` 引用 `evals/fixtures/mcp/*.yaml`：
 
@@ -147,6 +147,34 @@ mcp:
       transport: stdio
       command: /usr/bin/python3
       args: [evals/fixtures/mcp/marker_server.py]
+```
+
+mocked MCP 可以直接使用内置的 `filesystem` Mock Server：
+
+```yaml
+mcp:
+  servers:
+    - name: filesystem
+      mode: mocked
+```
+
+也可以通过 `config_ref` 定义工具响应：
+
+```yaml
+mcp:
+  servers:
+    - name: project-mgmt
+      mode: mocked
+      config_ref: evals/fixtures/mcp/project-mgmt.yaml
+```
+
+```yaml
+tool_responses:
+  create_publish_plan_simple:
+    default:
+      id: 999
+      name: "{{params.name}}"
+      status: ONGOING
 ```
 
 环境变量引用支持 `${VAR}` 和完整值 `$VAR` 两种形式，变量名必须匹配 `[A-Za-z_][A-Za-z0-9_]*`。`required_env` 会把变量注入 Agent 运行环境；`headers` 中完整的环境变量引用会额外记录变量名，供 Agent 安装 MCP 时选择合适的传递方式。

--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -77,6 +77,40 @@ func TestMCP_StdioMarkerAgents(t *testing.T) {
 	}
 }
 
+func TestMCP_MockedMarkerAgents(t *testing.T) {
+	skipIfNotFullE2E(t)
+
+	evalPath := filepath.Join(getProjectRoot(), "e2e", "testdata", "mcp-mocked-marker", "evals", "eval.yaml")
+	for _, tc := range []struct {
+		name   string
+		engine string
+		model  string
+	}{
+		{name: "claude_code", engine: "claude_code", model: "anthropic/qwen3.6-plus"},
+		{name: "qodercli", engine: "qodercli", model: "qoder/auto"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.engine == "claude_code" {
+				skipIfClaudeUnavailable(t)
+				skipClaudeCodeIfIncompatibleEndpoint(t)
+			}
+			if tc.engine == "qodercli" {
+				skipIfQoderCLIUnavailable(t)
+			}
+
+			runEvalWithRetries(t, mcpEvalRun{
+				evalPath:   evalPath,
+				engine:     tc.engine,
+				model:      tc.model,
+				outputRoot: e2eOutputDir(t),
+				outputName: "mcp-mocked-marker-" + tc.name,
+				attempts:   2,
+				timeout:    240 * time.Second,
+			})
+		})
+	}
+}
+
 func skipIfSandboxMCPUnavailable(t *testing.T) {
 	t.Helper()
 	var missing []string

--- a/e2e/testdata/mcp-mocked-marker/SKILL.md
+++ b/e2e/testdata/mcp-mocked-marker/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mcp-mocked-marker
+description: MCP mocked marker smoke skill used by skill-up e2e tests.
+---
+
+# MCP mocked marker
+
+Use the configured MCP marker tool when asked.

--- a/e2e/testdata/mcp-mocked-marker/evals/cases/smoke.yaml
+++ b/e2e/testdata/mcp-mocked-marker/evals/cases/smoke.yaml
@@ -1,0 +1,12 @@
+id: mcp-mocked-marker-smoke
+title: Mocked MCP marker tool call
+
+input:
+  prompt: |
+    Use the MCP tool named echo_marker from the marker server.
+    Return only the text returned by that MCP tool.
+    Do not guess the answer.
+
+expect:
+  must_contain:
+    - skill-up-mcp-mocked-fixture-marker

--- a/e2e/testdata/mcp-mocked-marker/evals/eval.yaml
+++ b/e2e/testdata/mcp-mocked-marker/evals/eval.yaml
@@ -1,0 +1,31 @@
+schema_version: v1alpha1
+
+environment:
+  type: none
+
+mcp:
+  servers:
+    - name: marker
+      mode: mocked
+      config_ref: evals/fixtures/mcp/marker.yaml
+
+skills: []
+
+engine:
+  name: claude_code
+  model:
+    provider: anthropic
+    name: qwen3.6-plus
+
+cases:
+  files:
+    - evals/cases/smoke.yaml
+  defaults:
+    timeout_seconds: 180
+    max_turns: 1
+  parallelism: 1
+
+report:
+  formats: [json]
+  artifacts:
+    - transcript

--- a/e2e/testdata/mcp-mocked-marker/evals/fixtures/mcp/marker.yaml
+++ b/e2e/testdata/mcp-mocked-marker/evals/fixtures/mcp/marker.yaml
@@ -1,0 +1,3 @@
+tool_responses:
+  echo_marker:
+    default: skill-up-mcp-mocked-fixture-marker

--- a/internal/agent/cli.go
+++ b/internal/agent/cli.go
@@ -35,10 +35,6 @@ func (a *CLIAgent) InstallMCP(ctx context.Context, rt Runtime, mcpCfg runtime.MC
 	workspace := rt.Workspace()
 
 	for _, server := range mcpCfg.Servers {
-		if server.Mode == "mocked" {
-			continue
-		}
-
 		data := struct {
 			Name      string
 			Transport string

--- a/internal/agent/mcp.go
+++ b/internal/agent/mcp.go
@@ -24,10 +24,6 @@ type mcpInstallCommandBuilder func(runtime.MCPServerConfig) (string, error)
 
 func installMCPServers(ctx context.Context, rt Runtime, mcpCfg runtime.MCPConfig, build mcpInstallCommandBuilder) error {
 	for _, server := range mcpCfg.Servers {
-		if server.Mode == "mocked" {
-			continue
-		}
-
 		cmd, err := build(server)
 		if err != nil {
 			return err

--- a/internal/credential/credential_test.go
+++ b/internal/credential/credential_test.go
@@ -355,6 +355,11 @@ func TestResolveJudgeInitParams_FallsBackToRunnerWhenJudgeModelEmpty(t *testing.
 }
 
 func TestResolveJudgeInitParams_FallsBackToRunnerBaseURLBeforeCredentialFallback(t *testing.T) {
+	// Clear env vars that would override runner fallback.
+	for _, key := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL"} {
+		t.Setenv(key, "")
+	}
+
 	runner := AgentInitParams{
 		Kind:          AgentKindRunner,
 		Engine:        "claude-code",

--- a/internal/mcp/mock_server.go
+++ b/internal/mcp/mock_server.go
@@ -62,10 +62,9 @@ func buildMockedServerScript(serverName string, fileCfg mcpServerFile) (string, 
 // stdio framing layer (Content-Length headers and newline-delimited JSON), with
 // defensive guards against malformed input and oversized messages.
 const mcpProtocolScript = `
-let buffer = "";
-process.stdin.setEncoding("utf8");
+let buffer = Buffer.alloc(0);
 process.stdin.on("data", chunk => {
-  buffer += chunk;
+  buffer = Buffer.concat([buffer, chunk]);
   for (;;) {
     const message = readMessage();
     if (!message) break;
@@ -75,7 +74,7 @@ process.stdin.on("data", chunk => {
 function readMessage() {
   const headerEnd = buffer.indexOf("\r\n\r\n");
   if (headerEnd >= 0) {
-    const header = buffer.slice(0, headerEnd);
+    const header = buffer.slice(0, headerEnd).toString("utf8");
     const match = /content-length:\s*(\d+)/i.exec(header);
     if (!match) {
       const lineEnd = buffer.indexOf("\n");
@@ -83,10 +82,10 @@ function readMessage() {
       return readLineMessage(lineEnd);
     }
     const length = Number(match[1]);
-    if (length > 10 * 1024 * 1024) { buffer = ""; return null; }
+    if (length > 10 * 1024 * 1024) { buffer = Buffer.alloc(0); return null; }
     const start = headerEnd + 4;
     if (buffer.length < start + length) return null;
-    const body = buffer.slice(start, start + length);
+    const body = buffer.slice(start, start + length).toString("utf8");
     buffer = buffer.slice(start + length);
     try { return { payload: JSON.parse(body), framed: true }; } catch { return null; }
   }
@@ -95,7 +94,7 @@ function readMessage() {
   return readLineMessage(lineEnd);
 }
 function readLineMessage(lineEnd) {
-  const line = buffer.slice(0, lineEnd).trim();
+  const line = buffer.slice(0, lineEnd).toString("utf8").trim();
   buffer = buffer.slice(lineEnd + 1);
   if (!line) return null;
   try { return { payload: JSON.parse(line), framed: false }; } catch { return null; }
@@ -225,8 +224,26 @@ function sendText(id, text, framed) {
 function resolvePath(input) {
   if (!input) throw new Error("path is required");
   const raw = String(input);
-  const resolved = path.resolve(process.cwd(), raw);
-  const root = process.cwd();
+  const root = fs.realpathSync(process.cwd());
+  // path.resolve is purely lexical, so a symlinked parent component would
+  // pass a startsWith check while Node still follows it on disk. Resolve the
+  // deepest existing ancestor through realpath and re-check the canonical
+  // path; the non-existing tail (for write_file) cannot contain symlinks.
+  let existing = path.resolve(root, raw);
+  let suffix = "";
+  for (;;) {
+    try {
+      existing = fs.realpathSync(existing);
+      break;
+    } catch (e) {
+      if (e.code !== "ENOENT") throw e;
+      suffix = suffix ? path.join(path.basename(existing), suffix) : path.basename(existing);
+      const parent = path.dirname(existing);
+      if (parent === existing) throw new Error("path outside workspace: " + raw);
+      existing = parent;
+    }
+  }
+  const resolved = suffix ? path.join(existing, suffix) : existing;
   if (resolved !== root && !resolved.startsWith(root + path.sep)) {
     throw new Error("path outside workspace: " + raw);
   }

--- a/internal/mcp/mock_server.go
+++ b/internal/mcp/mock_server.go
@@ -1,0 +1,261 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/alibaba/skill-up/internal/config"
+	"github.com/alibaba/skill-up/internal/runtime"
+)
+
+const (
+	mockNodeCommand         = "node"
+	fixturesJSONPlaceholder = "__FIXTURES_JSON__"
+)
+
+func buildMockedRuntimeServerConfig(server config.MCPServer, fileCfg mcpServerFile, configRef string) (runtime.MCPServerConfig, error) {
+	if transport := strings.TrimSpace(server.Transport); transport != "" && transport != transportStdio {
+		return runtime.MCPServerConfig{}, fmt.Errorf("mcp server %q mocked mode only supports stdio transport", server.Name)
+	}
+	if transport := strings.TrimSpace(fileCfg.Transport); transport != "" && transport != transportStdio {
+		return runtime.MCPServerConfig{}, fmt.Errorf("mcp server %q mocked mode only supports stdio transport", server.Name)
+	}
+	if strings.TrimSpace(server.Endpoint) != "" || strings.TrimSpace(fileCfg.Endpoint) != "" {
+		return runtime.MCPServerConfig{}, fmt.Errorf("mcp server %q mocked mode does not support endpoint", server.Name)
+	}
+	if strings.TrimSpace(server.Command) != "" || strings.TrimSpace(fileCfg.Command) != "" || len(server.Args) > 0 || len(fileCfg.Args) > 0 {
+		return runtime.MCPServerConfig{}, fmt.Errorf("mcp server %q mocked mode generates its own stdio server command", server.Name)
+	}
+
+	script, err := buildMockedServerScript(server.Name, fileCfg)
+	if err != nil {
+		return runtime.MCPServerConfig{}, err
+	}
+
+	return buildRuntimeServerConfig(server, runtimeServerFields{
+		transport: transportStdio,
+		command:   mockNodeCommand,
+		args:      []string{"-e", script},
+		configRef: configRef,
+		env:       map[string]string{},
+		headers:   map[string]string{},
+		headerEnv: map[string]string{},
+	}), nil
+}
+
+func buildMockedServerScript(serverName string, fileCfg mcpServerFile) (string, error) {
+	if len(fileCfg.ToolResponses) > 0 {
+		fixtures, err := json.Marshal(map[string]any{"toolResponses": fileCfg.ToolResponses})
+		if err != nil {
+			return "", fmt.Errorf("mcp server %q mock fixture is invalid: %w", serverName, err)
+		}
+		return strings.Replace(genericMockServerScript, fixturesJSONPlaceholder, string(fixtures), 1), nil
+	}
+	if serverName == "filesystem" {
+		return filesystemMockServerScript, nil
+	}
+	return "", fmt.Errorf("mcp server %q mocked mode requires config_ref tool_responses or a built-in mock server name", serverName)
+}
+
+// mcpProtocolScript is shared by all mock server scripts. It provides the MCP
+// stdio framing layer (Content-Length headers and newline-delimited JSON), with
+// defensive guards against malformed input and oversized messages.
+const mcpProtocolScript = `
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => {
+  buffer += chunk;
+  for (;;) {
+    const message = readMessage();
+    if (!message) break;
+    handleMessage(message.payload, message.framed);
+  }
+});
+function readMessage() {
+  const headerEnd = buffer.indexOf("\r\n\r\n");
+  if (headerEnd >= 0) {
+    const header = buffer.slice(0, headerEnd);
+    const match = /content-length:\s*(\d+)/i.exec(header);
+    if (!match) {
+      const lineEnd = buffer.indexOf("\n");
+      if (lineEnd < 0) return null;
+      return readLineMessage(lineEnd);
+    }
+    const length = Number(match[1]);
+    if (length > 10 * 1024 * 1024) { buffer = ""; return null; }
+    const start = headerEnd + 4;
+    if (buffer.length < start + length) return null;
+    const body = buffer.slice(start, start + length);
+    buffer = buffer.slice(start + length);
+    try { return { payload: JSON.parse(body), framed: true }; } catch { return null; }
+  }
+  const lineEnd = buffer.indexOf("\n");
+  if (lineEnd < 0) return null;
+  return readLineMessage(lineEnd);
+}
+function readLineMessage(lineEnd) {
+  const line = buffer.slice(0, lineEnd).trim();
+  buffer = buffer.slice(lineEnd + 1);
+  if (!line) return null;
+  try { return { payload: JSON.parse(line), framed: false }; } catch { return null; }
+}
+function send(id, result, framed) {
+  const body = JSON.stringify({ jsonrpc: "2.0", id, result });
+  if (framed) {
+    process.stdout.write("Content-Length: " + Buffer.byteLength(body) + "\r\n\r\n" + body);
+    return;
+  }
+  process.stdout.write(body + "\n");
+}
+function sendError(id, code, message, framed) {
+  const body = JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+  if (framed) {
+    process.stdout.write("Content-Length: " + Buffer.byteLength(body) + "\r\n\r\n" + body);
+    return;
+  }
+  process.stdout.write(body + "\n");
+}
+`
+
+const genericMockServerScript = `
+const fixtures = ` + fixturesJSONPlaceholder + `;
+const tools = Object.keys(fixtures.toolResponses || {});
+` + mcpProtocolScript + `
+function handleMessage(message, framed) {
+  if (!message || message.id === undefined) return;
+  if (message.method === "initialize") {
+    send(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "skill-up-mock", version: "0.1.0" } }, framed);
+    return;
+  }
+  if (message.method === "tools/list") {
+    send(message.id, { tools: tools.map(name => ({ name, description: "Mocked MCP tool " + name, inputSchema: { type: "object", additionalProperties: true } })) }, framed);
+    return;
+  }
+  if (message.method === "tools/call") {
+    const name = message.params && message.params.name;
+    if (!Object.prototype.hasOwnProperty.call(fixtures.toolResponses || {}, name)) {
+      sendError(message.id, -32602, "unknown mocked tool " + name, framed);
+      return;
+    }
+    const args = (message.params && message.params.arguments) || {};
+    const response = render(selectResponse(fixtures.toolResponses[name]), args);
+    const text = typeof response === "string" ? response : JSON.stringify(response);
+    send(message.id, { content: [{ type: "text", text }] }, framed);
+    return;
+  }
+  send(message.id, {}, framed);
+}
+function selectResponse(fixture) {
+  if (fixture && Object.prototype.hasOwnProperty.call(fixture, "default")) return fixture.default;
+  return fixture;
+}
+function render(value, params) {
+  if (typeof value === "string") {
+    return value.replace(/\{\{\s*params\.([A-Za-z0-9_.$-]+)(?:\s*\|\s*default:\s*['"]([^'"]*)['"])?\s*\}\}/g, (_match, path, fallback) => {
+      const found = getPath(params, path);
+      if (found === undefined || found === null || found === "") return fallback === undefined ? "" : fallback;
+      return String(found);
+    });
+  }
+  if (Array.isArray(value)) return value.map(item => render(item, params));
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [key, item] of Object.entries(value)) out[key] = render(item, params);
+    return out;
+  }
+  return value;
+}
+function getPath(value, path) {
+  return path.split(".").reduce((acc, key) => acc == null ? undefined : acc[key], value);
+}
+`
+
+const filesystemMockServerScript = `
+const fs = require("fs");
+const path = require("path");
+` + mcpProtocolScript + `
+function handleMessage(message, framed) {
+  if (!message || message.id === undefined) return;
+  if (message.method === "initialize") {
+    send(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "skill-up-filesystem-mock", version: "0.1.0" } }, framed);
+    return;
+  }
+  if (message.method === "tools/list") {
+    send(message.id, { tools: [
+      { name: "list_directory", description: "List files under a directory.", inputSchema: { type: "object", additionalProperties: true } },
+      { name: "read_file", description: "Read a file or directory tree.", inputSchema: { type: "object", additionalProperties: true } },
+      { name: "write_file", description: "Write a file.", inputSchema: { type: "object", additionalProperties: true } }
+    ] }, framed);
+    return;
+  }
+  if (message.method !== "tools/call") {
+    send(message.id, {}, framed);
+    return;
+  }
+  const name = message.params && message.params.name;
+  const args = (message.params && message.params.arguments) || {};
+  try {
+    if (name === "list_directory") {
+      sendText(message.id, listDirectory(resolvePath(args.path || args.directory || ".")), framed);
+      return;
+    }
+    if (name === "read_file") {
+      sendText(message.id, readPath(resolvePath(args.path || args.file_path || args.file || ".")), framed);
+      return;
+    }
+    if (name === "write_file") {
+      const target = resolvePath(args.path || args.file_path || args.file);
+      try {
+        if (fs.lstatSync(target).isSymbolicLink()) throw new Error("symbolic links are not allowed: " + path.relative(process.cwd(), target));
+      } catch (e) { if (e.code !== "ENOENT") throw e; }
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, String(args.content === undefined ? "" : args.content));
+      sendText(message.id, "wrote " + path.relative(process.cwd(), target), framed);
+      return;
+    }
+    sendError(message.id, -32602, "unknown mocked tool " + name, framed);
+  } catch (err) {
+    sendError(message.id, -32000, err && err.message ? err.message : String(err), framed);
+  }
+}
+function sendText(id, text, framed) {
+  send(id, { content: [{ type: "text", text }] }, framed);
+}
+function resolvePath(input) {
+  if (!input) throw new Error("path is required");
+  const raw = String(input);
+  const resolved = path.resolve(process.cwd(), raw);
+  const root = process.cwd();
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    throw new Error("path outside workspace: " + raw);
+  }
+  return resolved;
+}
+function listDirectory(target) {
+  const stat = fs.lstatSync(target);
+  if (stat.isSymbolicLink()) throw new Error("symbolic links are not allowed: " + path.relative(process.cwd(), target));
+  const entries = fs.readdirSync(target, { withFileTypes: true });
+  return entries.filter(entry => !entry.isSymbolicLink()).map(entry => entry.name + (entry.isDirectory() ? "/" : "")).sort().join("\n");
+}
+function readPath(target) {
+  const stat = fs.lstatSync(target);
+  if (stat.isSymbolicLink()) throw new Error("symbolic links are not allowed: " + path.relative(process.cwd(), target));
+  if (stat.isDirectory()) return readDirectory(target).join("\n\n");
+  return fs.readFileSync(target, "utf8");
+}
+function readDirectory(root) {
+  const out = [];
+  for (const name of fs.readdirSync(root).sort()) {
+    const target = path.join(root, name);
+    const stat = fs.lstatSync(target);
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isDirectory()) {
+      out.push(...readDirectory(target));
+      continue;
+    }
+    out.push("--- " + path.relative(process.cwd(), target) + " ---\n" + fs.readFileSync(target, "utf8"));
+  }
+  return out;
+}
+`

--- a/internal/mcp/mock_server_test.go
+++ b/internal/mcp/mock_server_test.go
@@ -1,0 +1,213 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type mockProc struct {
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+}
+
+func startMockServer(t *testing.T, script, dir string) *mockProc {
+	t.Helper()
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node is required for mock server tests")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	cmd := exec.CommandContext(ctx, "node", "-e", script)
+	cmd.Dir = dir
+	cmd.Stderr = os.Stderr
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start node: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		_ = cmd.Wait()
+	})
+	return &mockProc{stdin: stdin, stdout: bufio.NewReader(stdout)}
+}
+
+func (p *mockProc) writeFramed(t *testing.T, msg any) {
+	t.Helper()
+	body, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if _, err := fmt.Fprintf(p.stdin, "Content-Length: %d\r\n\r\n", len(body)); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := p.stdin.Write(body); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+}
+
+func (p *mockProc) readFramed(t *testing.T) map[string]any {
+	t.Helper()
+	length := -1
+	for {
+		line, err := p.stdout.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read response header: %v", err)
+		}
+		header := strings.TrimRight(line, "\r\n")
+		if header == "" {
+			break
+		}
+		if name, val, ok := strings.Cut(header, ":"); ok && strings.EqualFold(strings.TrimSpace(name), "content-length") {
+			length, err = strconv.Atoi(strings.TrimSpace(val))
+			if err != nil {
+				t.Fatalf("bad content-length %q: %v", val, err)
+			}
+		}
+	}
+	if length < 0 {
+		t.Fatal("response missing Content-Length header")
+	}
+	body := make([]byte, length)
+	if _, err := io.ReadFull(p.stdout, body); err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode response %q: %v", body, err)
+	}
+	return out
+}
+
+func toolCallText(t *testing.T, resp map[string]any) string {
+	t.Helper()
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("response has no result: %v", resp)
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("result has no content: %v", result)
+	}
+	first, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("content[0] is not an object: %v", content[0])
+	}
+	text, _ := first["text"].(string)
+	return text
+}
+
+// TestMockedGenericServer_FramedNonASCIIRoundTrip exercises Content-Length
+// framed messages whose body contains multibyte characters: the byte length in
+// the header must not be confused with the UTF-16 unit count of the buffer.
+func TestMockedGenericServer_FramedNonASCIIRoundTrip(t *testing.T) {
+	script, err := buildMockedServerScript("echo-server", mcpServerFile{
+		ToolResponses: map[string]any{
+			"echo": map[string]any{"default": "{{params.text}}"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildMockedServerScript: %v", err)
+	}
+
+	proc := startMockServer(t, script, t.TempDir())
+	proc.writeFramed(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+	proc.readFramed(t)
+
+	const marker = "日本語-マーカー-✅"
+	proc.writeFramed(t, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{
+			"name":      "echo",
+			"arguments": map[string]any{"text": marker},
+		},
+	})
+	if got := toolCallText(t, proc.readFramed(t)); got != marker {
+		t.Fatalf("framed non-ASCII tool call returned %q, want %q", got, marker)
+	}
+}
+
+// TestMockedFilesystemServer_RejectsSymlinkEscape verifies that a symlinked
+// parent component cannot be used to read files outside the workspace.
+func TestMockedFilesystemServer_RejectsSymlinkEscape(t *testing.T) {
+	script, err := buildMockedServerScript("filesystem", mcpServerFile{})
+	if err != nil {
+		t.Fatalf("buildMockedServerScript: %v", err)
+	}
+
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("top secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "escape")); err != nil {
+		t.Skipf("symlinks not supported: %v", err)
+	}
+
+	proc := startMockServer(t, script, workspace)
+	proc.writeFramed(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+	proc.readFramed(t)
+
+	proc.writeFramed(t, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{
+			"name":      "read_file",
+			"arguments": map[string]any{"path": "escape/secret.txt"},
+		},
+	})
+	resp := proc.readFramed(t)
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected an error for symlink escape, got %v", resp)
+	}
+	if msg, _ := errObj["message"].(string); !strings.Contains(msg, "outside workspace") {
+		t.Fatalf("error message = %q, want it to mention outside workspace", msg)
+	}
+}
+
+// TestMockedFilesystemServer_ReadsWorkspaceFile is the positive counterpart:
+// a regular file inside the workspace is still readable.
+func TestMockedFilesystemServer_ReadsWorkspaceFile(t *testing.T) {
+	script, err := buildMockedServerScript("filesystem", mcpServerFile{})
+	if err != nil {
+		t.Fatalf("buildMockedServerScript: %v", err)
+	}
+
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "note.txt"), []byte("hello workspace"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := startMockServer(t, script, workspace)
+	proc.writeFramed(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+	proc.readFramed(t)
+
+	proc.writeFramed(t, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{
+			"name":      "read_file",
+			"arguments": map[string]any{"path": "note.txt"},
+		},
+	})
+	if got := toolCallText(t, proc.readFramed(t)); got != "hello workspace" {
+		t.Fatalf("read_file returned %q, want %q", got, "hello workspace")
+	}
+}

--- a/internal/mcp/provisioner.go
+++ b/internal/mcp/provisioner.go
@@ -66,6 +66,9 @@ func (p Provisioner) resolveServer(server config.MCPServer, lookupEnv func(strin
 	if err != nil {
 		return runtime.MCPServerConfig{}, err
 	}
+	if server.Mode == modeMocked {
+		return buildMockedRuntimeServerConfig(server, fileCfg, configRef)
+	}
 
 	endpoint, endpointEnv, err := resolveEndpoint(server, fileCfg, lookupEnv)
 	if err != nil {
@@ -101,7 +104,7 @@ func validateServerMode(server config.MCPServer) error {
 	case "":
 		return fmt.Errorf("mcp server %q mode is required", server.Name)
 	case modeMocked:
-		return fmt.Errorf("mcp server %q uses mocked mode, but MCP mock server provisioning is not implemented", server.Name)
+		return nil
 	case modeReal:
 		return nil
 	default:
@@ -205,13 +208,14 @@ func (p Provisioner) resolveConfigRef(configRef string) string {
 }
 
 type mcpServerFile struct {
-	Transport   string            `yaml:"transport"`
-	Command     string            `yaml:"command"`
-	Args        []string          `yaml:"args"`
-	Endpoint    string            `yaml:"endpoint"`
-	Env         map[string]string `yaml:"env"`
-	RequiredEnv []string          `yaml:"required_env"`
-	Headers     map[string]string `yaml:"headers"`
+	Transport     string            `yaml:"transport"`
+	Command       string            `yaml:"command"`
+	Args          []string          `yaml:"args"`
+	Endpoint      string            `yaml:"endpoint"`
+	Env           map[string]string `yaml:"env"`
+	RequiredEnv   []string          `yaml:"required_env"`
+	Headers       map[string]string `yaml:"headers"`
+	ToolResponses map[string]any    `yaml:"tool_responses"`
 }
 
 func loadServerFile(path string) (mcpServerFile, error) {

--- a/internal/mcp/provisioner_test.go
+++ b/internal/mcp/provisioner_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/alibaba/skill-up/internal/config"
 )
 
+const nodeCommand = "node"
+
 func TestProvisioner_RealServerFromConfigRefResolvesAuthEnv(t *testing.T) {
 	t.Parallel()
 
@@ -166,10 +168,10 @@ func TestProvisioner_RealStdioServerFromConfig(t *testing.T) {
 		t.Fatalf("run env = %#v, want empty", env)
 	}
 	server := resolved.Servers[0]
-	if server.Transport != "stdio" {
+	if server.Transport != transportStdio {
 		t.Fatalf("Transport = %q, want stdio", server.Transport)
 	}
-	if server.Command != "node" {
+	if server.Command != nodeCommand {
 		t.Fatalf("Command = %q, want node", server.Command)
 	}
 	if strings.Join(server.Args, "|") != "marker-server.mjs|secret-marker" {
@@ -193,7 +195,7 @@ func TestProvisioner_RealStdioServerFromConfigRef(t *testing.T) {
 		t.Fatalf("Provision failed: %v", err)
 	}
 	server := resolved.Servers[0]
-	if server.Transport != "stdio" || server.Command != "node" || strings.Join(server.Args, "|") != "server.mjs" {
+	if server.Transport != transportStdio || server.Command != nodeCommand || strings.Join(server.Args, "|") != "server.mjs" {
 		t.Fatalf("server = %#v", server)
 	}
 }
@@ -218,13 +220,62 @@ func TestProvisioner_RealServerRequiresNonInteractiveAuth(t *testing.T) {
 	}
 }
 
-func TestProvisioner_MockedModeFailsFast(t *testing.T) {
+func TestProvisioner_MockedFilesystemUsesGeneratedStdioServer(t *testing.T) {
 	t.Parallel()
 
-	_, _, err := (Provisioner{}).Provision(config.MCPConfig{
+	resolved, env, err := (Provisioner{}).Provision(config.MCPConfig{
 		Servers: []config.MCPServer{{Name: "filesystem", Mode: "mocked"}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "mock server provisioning is not implemented") {
-		t.Fatalf("expected mocked mode not implemented error, got %v", err)
+	if err != nil {
+		t.Fatalf("Provision failed: %v", err)
+	}
+	if len(env) != 0 {
+		t.Fatalf("run env = %#v, want empty", env)
+	}
+	server := resolved.Servers[0]
+	if server.Mode != modeMocked || server.Transport != transportStdio || server.Command != nodeCommand {
+		t.Fatalf("server = %#v", server)
+	}
+	if len(server.Args) != 2 || server.Args[0] != "-e" {
+		t.Fatalf("Args = %#v", server.Args)
+	}
+	if !strings.Contains(server.Args[1], "list_directory") || !strings.Contains(server.Args[1], "write_file") {
+		t.Fatalf("mock script does not expose filesystem tools")
+	}
+}
+
+func TestProvisioner_MockedServerFromConfigRefUsesToolResponses(t *testing.T) {
+	t.Parallel()
+
+	skillDir := t.TempDir()
+	configPath := filepath.Join(skillDir, "mcp.yaml")
+	content := `tool_responses:
+  create_publish_plan_simple:
+    default:
+      id: "plan-{{params.name | default: 'demo'}}"
+      status: created
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, env, err := (Provisioner{SkillDir: skillDir}).Provision(config.MCPConfig{
+		Servers: []config.MCPServer{{Name: "project-mgmt", Mode: "mocked", ConfigRef: "mcp.yaml"}},
+	})
+	if err != nil {
+		t.Fatalf("Provision failed: %v", err)
+	}
+	if len(env) != 0 {
+		t.Fatalf("run env = %#v, want empty", env)
+	}
+	server := resolved.Servers[0]
+	if server.ConfigRef != configPath {
+		t.Fatalf("ConfigRef = %q, want %q", server.ConfigRef, configPath)
+	}
+	if server.Transport != transportStdio || server.Command != nodeCommand {
+		t.Fatalf("server = %#v", server)
+	}
+	if len(server.Args) != 2 || !strings.Contains(server.Args[1], "create_publish_plan_simple") {
+		t.Fatalf("mock script missing fixture tool: %#v", server.Args)
 	}
 }

--- a/internal/runtime/README.md
+++ b/internal/runtime/README.md
@@ -148,7 +148,7 @@ The runtime may provide MCP server configuration:
 ```go
 type MCPServerConfig struct {
     Name      string            // MCP Server name
-    Mode      string            // real / mocked (mocked is reserved)
+    Mode      string            // real / mocked
     Transport string            // http / stdio
     Command   string            // stdio MCP launch command
     Args      []string          // stdio MCP launch arguments


### PR DESCRIPTION
## Summary
- Provision `mode: mocked` MCP servers as generated stdio mock servers instead of failing fast.
- Install mocked servers through the existing agent MCP install path, so they behave like any other MCP server.
- A mocked server can use the built-in `filesystem` mock, or define tool responses via a `config_ref` file's `tool_responses` map (with `{{params.*}}` templating).
- Adds `mcp-mocked-marker` e2e fixture + `TestMCP_MockedMarkerAgents`, and updates the writing-evals docs (EN/ZH) and runtime README.

A second commit isolates an unrelated, pre-existing test flake: `TestResolveJudgeInitParams_FallsBackToRunnerBaseURLBeforeCredentialFallback` read `ANTHROPIC_*` from the process environment and failed when a developer had `ANTHROPIC_BASE_URL` set.

## Test plan
- [x] `go build ./...`
- [x] `go vet` + `golangci-lint` (0 issues)
- [x] `go test ./...` (all packages pass)
- [x] `go test -tags=e2e` compiles
- [ ] Full e2e `TestMCP_MockedMarkerAgents` (requires Agent + model credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)