### PR TITLE
feat: add network_policy support for sandbox egress isolation

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -416,6 +416,115 @@ func TestCLI_RunAutoWithClaudeCode(t *testing.T) {
 	}
 }
 
+// network_policy e2e coverage: exercise the validate/run commands on the
+// environment.network_policy field end-to-end so schema parsing, validator
+// rules, and CLI exit codes are all covered.
+
+func writeNetworkPolicyEval(t *testing.T, envType, policy string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	writeFile(t, filepath.Join(tmpDir, "SKILL.md"), "# net-policy\n")
+	casePath := filepath.Join(tmpDir, "evals", "cases", "ok.yaml")
+	writeFile(t, casePath, `id: ok
+input:
+  prompt: hi
+`)
+	evalPath := filepath.Join(tmpDir, "evals", "eval.yaml")
+	envBlock := "  type: " + envType + "\n"
+	if envType == "opensandbox" {
+		envBlock += "  kwargs:\n    base_url: https://sandbox.example.test\n"
+	}
+	if policy != "" {
+		envBlock += "  network_policy: " + policy + "\n"
+	}
+	writeFile(t, evalPath, `schema_version: v1alpha1
+environment:
+`+envBlock+`engine:
+  name: claude_code
+  model:
+    provider: anthropic
+    name: dummy
+cases:
+  files:
+    - evals/cases/ok.yaml
+judge:
+  type: rule_based
+`)
+	return evalPath
+}
+
+func TestCLI_Validate_NetworkPolicy_DenyAllOpenSandbox(t *testing.T) {
+	t.Parallel()
+	Cover(t, "skill-up validate network_policy=deny_all opensandbox")
+
+	evalPath := writeNetworkPolicyEval(t, "opensandbox", "deny_all")
+	result := RunSimple(t, "validate", evalPath)
+
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstdout: %s\nstderr: %s",
+			result.ExitCode, result.Stdout, result.Stderr)
+	}
+}
+
+func TestCLI_Validate_NetworkPolicy_AllowDeclaredOpenSandbox(t *testing.T) {
+	t.Parallel()
+	Cover(t, "skill-up validate network_policy=allow_declared opensandbox")
+
+	evalPath := writeNetworkPolicyEval(t, "opensandbox", "allow_declared")
+	result := RunSimple(t, "validate", evalPath)
+
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstdout: %s\nstderr: %s",
+			result.ExitCode, result.Stdout, result.Stderr)
+	}
+}
+
+func TestCLI_Validate_NetworkPolicy_RejectsInvalidValue(t *testing.T) {
+	t.Parallel()
+	Cover(t, "skill-up validate rejects invalid network_policy")
+
+	evalPath := writeNetworkPolicyEval(t, "opensandbox", "allow_all")
+	result := RunSimple(t, "validate", evalPath)
+
+	if result.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit, stdout=%s stderr=%s", result.Stdout, result.Stderr)
+	}
+	if !strings.Contains(result.Stderr, "network_policy must be one of") {
+		t.Fatalf("expected network_policy enum error, stderr=%s", result.Stderr)
+	}
+}
+
+func TestCLI_Validate_NetworkPolicy_RejectsWithRuntimeNone(t *testing.T) {
+	t.Parallel()
+	Cover(t, "skill-up validate rejects network_policy with type=none")
+
+	evalPath := writeNetworkPolicyEval(t, "none", "deny_all")
+	result := RunSimple(t, "validate", evalPath)
+
+	if result.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit, stdout=%s stderr=%s", result.Stdout, result.Stderr)
+	}
+	if !strings.Contains(result.Stderr, "network_policy requires environment.type opensandbox") {
+		t.Fatalf("expected runtime-type incompatibility error, stderr=%s", result.Stderr)
+	}
+}
+
+func TestCLI_Run_NetworkPolicy_DryRun(t *testing.T) {
+	t.Parallel()
+	Cover(t, "skill-up run --dry-run with network_policy")
+
+	evalPath := writeNetworkPolicyEval(t, "opensandbox", "deny_all")
+	result := RunSimple(t, "run", evalPath, "--dry-run")
+
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstdout: %s\nstderr: %s",
+			result.ExitCode, result.Stdout, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, "Would run") {
+		t.Fatalf("expected dry-run banner, stdout=%s", result.Stdout)
+	}
+}
+
 func TestCLI_RunTestdataSample(t *testing.T) {
 	t.Parallel()
 

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -420,7 +420,7 @@ func TestCLI_RunAutoWithClaudeCode(t *testing.T) {
 // environment.network_policy field end-to-end so schema parsing, validator
 // rules, and CLI exit codes are all covered.
 
-func writeNetworkPolicyEval(t *testing.T, envType, policy string) string {
+func writeNetworkPolicyEval(t *testing.T, envType, policy string, allowedEgress ...string) string {
 	t.Helper()
 	tmpDir := t.TempDir()
 	writeFile(t, filepath.Join(tmpDir, "SKILL.md"), "# net-policy\n")
@@ -436,6 +436,14 @@ input:
 	}
 	if policy != "" {
 		envBlock += "  network_policy: " + policy + "\n"
+	}
+	if len(allowedEgress) > 0 {
+		envBlock += "  allowed_egress:\n"
+		for _, target := range allowedEgress {
+			// Quote entries so a leading '*' (wildcard domain) is not parsed
+			// as a YAML alias.
+			envBlock += "    - \"" + target + "\"\n"
+		}
 	}
 	writeFile(t, evalPath, `schema_version: v1alpha1
 environment:
@@ -470,12 +478,27 @@ func TestCLI_Validate_NetworkPolicy_AllowDeclaredOpenSandbox(t *testing.T) {
 	t.Parallel()
 	Cover(t, "skill-up validate network_policy=allow_declared opensandbox")
 
-	evalPath := writeNetworkPolicyEval(t, "opensandbox", "allow_declared")
+	evalPath := writeNetworkPolicyEval(t, "opensandbox", "allow_declared", "pypi.org", "*.githubusercontent.com")
 	result := RunSimple(t, "validate", evalPath)
 
 	if result.ExitCode != 0 {
 		t.Fatalf("expected exit 0, got %d\nstdout: %s\nstderr: %s",
 			result.ExitCode, result.Stdout, result.Stderr)
+	}
+}
+
+func TestCLI_Validate_NetworkPolicy_AllowDeclaredRequiresAllowlist(t *testing.T) {
+	t.Parallel()
+	Cover(t, "skill-up validate rejects allow_declared without allowed_egress")
+
+	evalPath := writeNetworkPolicyEval(t, "opensandbox", "allow_declared")
+	result := RunSimple(t, "validate", evalPath)
+
+	if result.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit, stdout=%s stderr=%s", result.Stdout, result.Stderr)
+	}
+	if !strings.Contains(result.Stderr, "allow_declared requires a non-empty allowed_egress list") {
+		t.Fatalf("expected allowed_egress requirement error, stderr=%s", result.Stderr)
 	}
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -33,6 +33,7 @@ type Environment struct {
 	Entrypoint            []string          `yaml:"entrypoint,omitempty"`
 	Metadata              map[string]string `yaml:"metadata,omitempty"`
 	Kwargs                map[string]string `yaml:"kwargs,omitempty"`
+	NetworkPolicy         string            `yaml:"network_policy,omitempty"` // deny_all, allow_declared
 }
 
 // ToRuntimeConfig converts Environment to runtime.Config.
@@ -55,6 +56,7 @@ func (e Environment) ToRuntimeConfig() runtime.Config {
 		Entrypoint:      e.Entrypoint,
 		Metadata:        e.Metadata,
 		Kwargs:          e.Kwargs,
+		NetworkPolicy:   e.NetworkPolicy,
 		Delete:          true,
 	}
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -34,6 +34,7 @@ type Environment struct {
 	Metadata              map[string]string `yaml:"metadata,omitempty"`
 	Kwargs                map[string]string `yaml:"kwargs,omitempty"`
 	NetworkPolicy         string            `yaml:"network_policy,omitempty"` // deny_all, allow_declared
+	AllowedEgress         []string          `yaml:"allowed_egress,omitempty"` // FQDN/wildcard egress allowlist for allow_declared
 }
 
 // ToRuntimeConfig converts Environment to runtime.Config.
@@ -57,6 +58,7 @@ func (e Environment) ToRuntimeConfig() runtime.Config {
 		Metadata:        e.Metadata,
 		Kwargs:          e.Kwargs,
 		NetworkPolicy:   e.NetworkPolicy,
+		AllowedEgress:   e.AllowedEgress,
 		Delete:          true,
 	}
 }

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -161,6 +161,22 @@ func TestEnvironmentToRuntimeConfig_NetworkPolicy(t *testing.T) {
 	}
 }
 
+func TestEnvironmentToRuntimeConfig_AllowedEgress(t *testing.T) {
+	t.Parallel()
+
+	rtCfg := Environment{
+		Type:          "opensandbox",
+		NetworkPolicy: "allow_declared",
+		AllowedEgress: []string{"pypi.org", "*.githubusercontent.com"},
+	}.ToRuntimeConfig()
+
+	if len(rtCfg.AllowedEgress) != 2 ||
+		rtCfg.AllowedEgress[0] != "pypi.org" ||
+		rtCfg.AllowedEgress[1] != "*.githubusercontent.com" {
+		t.Errorf("AllowedEgress = %v, want [pypi.org *.githubusercontent.com]", rtCfg.AllowedEgress)
+	}
+}
+
 func TestDefaultEvalConfig_ReturnsNewInstance(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -135,6 +135,32 @@ func TestEnvironmentToRuntimeConfig_OpenSandboxKwargs(t *testing.T) {
 	}
 }
 
+func TestEnvironmentToRuntimeConfig_NetworkPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		policy string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"deny_all", "deny_all", "deny_all"},
+		{"allow_declared", "allow_declared", "allow_declared"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rtCfg := Environment{
+				Type:          "opensandbox",
+				NetworkPolicy: tt.policy,
+			}.ToRuntimeConfig()
+			if rtCfg.NetworkPolicy != tt.want {
+				t.Errorf("NetworkPolicy = %q, want %q", rtCfg.NetworkPolicy, tt.want)
+			}
+		})
+	}
+}
+
 func TestDefaultEvalConfig_ReturnsNewInstance(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -13,6 +13,12 @@ const (
 	maxRetryPolicyRetries = 10
 )
 
+// Runtime type constants.
+const (
+	runtimeTypeNone        = "none"
+	runtimeTypeOpenSandbox = "opensandbox"
+)
+
 // Validator checks eval and case documents against the v1alpha1 schema.
 type Validator struct{}
 
@@ -38,6 +44,8 @@ func (v *Validator) ValidateEvalConfig(cfg *EvalConfig) error {
 	} else if !isValidRuntimeType(cfg.Environment.Type) {
 		errs = append(errs, "environment.type must be one of: none, opensandbox")
 	}
+
+	errs = append(errs, validateNetworkPolicy(cfg.Environment)...)
 
 	// engine.name is required
 	if cfg.Engine.Name == "" {
@@ -153,9 +161,23 @@ func (v *Validator) ValidateAll(result *EvalResult) error {
 }
 
 func isValidRuntimeType(t string) bool {
-	return t == "none" || t == "opensandbox"
+	return t == runtimeTypeNone || t == runtimeTypeOpenSandbox
 }
 
 func isValidJudgeType(t string) bool {
 	return t == judgeTypeRuleBased || t == judgeTypeScript || t == judgeTypeAgentJudge
+}
+
+func validateNetworkPolicy(env Environment) []string {
+	policy := env.NetworkPolicy
+	if policy == "" {
+		return nil
+	}
+	if policy != "deny_all" && policy != "allow_declared" {
+		return []string{"network_policy must be one of: deny_all, allow_declared"}
+	}
+	if env.Type == runtimeTypeNone {
+		return []string{"network_policy requires environment.type opensandbox (none cannot enforce network isolation)"}
+	}
+	return nil
 }

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -171,6 +171,9 @@ func isValidJudgeType(t string) bool {
 func validateNetworkPolicy(env Environment) []string {
 	policy := env.NetworkPolicy
 	if policy == "" {
+		if len(env.AllowedEgress) > 0 {
+			return []string{"allowed_egress requires network_policy: allow_declared"}
+		}
 		return nil
 	}
 	if policy != "deny_all" && policy != "allow_declared" {
@@ -179,5 +182,27 @@ func validateNetworkPolicy(env Environment) []string {
 	if env.Type == runtimeTypeNone {
 		return []string{"network_policy requires environment.type opensandbox (none cannot enforce network isolation)"}
 	}
-	return nil
+
+	var errs []string
+	switch policy {
+	case "allow_declared":
+		if len(env.AllowedEgress) == 0 {
+			errs = append(errs, "network_policy: allow_declared requires a non-empty allowed_egress list")
+		}
+		for i, target := range env.AllowedEgress {
+			t := strings.TrimSpace(target)
+			if t == "" {
+				errs = append(errs, fmt.Sprintf("allowed_egress[%d] must not be empty", i))
+				continue
+			}
+			if strings.ContainsAny(t, "/ ") {
+				errs = append(errs, fmt.Sprintf("allowed_egress[%d] %q must be a bare FQDN or wildcard domain, not a URL", i, target))
+			}
+		}
+	case "deny_all":
+		if len(env.AllowedEgress) > 0 {
+			errs = append(errs, "allowed_egress is only valid with network_policy: allow_declared")
+		}
+	}
+	return errs
 }

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -444,6 +444,76 @@ func TestValidator_ValidateEvalConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "valid network_policy deny_all with opensandbox",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:          "opensandbox",
+					NetworkPolicy: "deny_all",
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid network_policy allow_declared with opensandbox",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:          "opensandbox",
+					NetworkPolicy: "allow_declared",
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid network_policy value",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:          "opensandbox",
+					NetworkPolicy: "allow_all",
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "network_policy must be one of: deny_all, allow_declared",
+		},
+		{
+			name: "network_policy with none runtime is rejected",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:          "none",
+					NetworkPolicy: "deny_all",
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "network_policy requires environment.type opensandbox",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -468,6 +468,7 @@ func TestValidator_ValidateEvalConfig(t *testing.T) {
 				Environment: Environment{
 					Type:          "opensandbox",
 					NetworkPolicy: "allow_declared",
+					AllowedEgress: []string{"pypi.org", "*.githubusercontent.com"},
 				},
 				Engine: EngineConfig{
 					Name: "claude_code",
@@ -477,6 +478,80 @@ func TestValidator_ValidateEvalConfig(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "allow_declared without allowed_egress is rejected",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:          "opensandbox",
+					NetworkPolicy: "allow_declared",
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "network_policy: allow_declared requires a non-empty allowed_egress list",
+		},
+		{
+			name: "allowed_egress with deny_all is rejected",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:          "opensandbox",
+					NetworkPolicy: "deny_all",
+					AllowedEgress: []string{"pypi.org"},
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "allowed_egress is only valid with network_policy: allow_declared",
+		},
+		{
+			name: "allowed_egress without network_policy is rejected",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:          "opensandbox",
+					AllowedEgress: []string{"pypi.org"},
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "allowed_egress requires network_policy: allow_declared",
+		},
+		{
+			name: "allowed_egress entry as URL is rejected",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:          "opensandbox",
+					NetworkPolicy: "allow_declared",
+					AllowedEgress: []string{"https://pypi.org/simple"},
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "must be a bare FQDN or wildcard domain",
 		},
 		{
 			name: "invalid network_policy value",

--- a/internal/runtime/opensandbox.go
+++ b/internal/runtime/opensandbox.go
@@ -172,6 +172,7 @@ func (r *OpenSandboxRuntime) Create(ctx context.Context) error {
 		Metadata:       r.cfg.Metadata,
 		Extensions:     r.extensions,
 		ReadyTimeout:   r.cfg.ReadyTimeout,
+		NetworkPolicy:  r.networkPolicy(),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create opensandbox: %w", err)
@@ -627,6 +628,17 @@ func (r *OpenSandboxRuntime) entrypoint() []string {
 	}
 	// The sandbox joins entrypoint items with " && ", so the default must stay a single shell line.
 	return []string{"tail -F /dev/null"}
+}
+
+func (r *OpenSandboxRuntime) networkPolicy() *opensandbox.NetworkPolicy {
+	switch strings.ToLower(strings.TrimSpace(r.cfg.NetworkPolicy)) {
+	case "deny_all":
+		return &opensandbox.NetworkPolicy{DefaultAction: "deny"}
+	case "allow_declared":
+		return &opensandbox.NetworkPolicy{DefaultAction: "allow"}
+	default:
+		return nil
+	}
 }
 
 func (r *OpenSandboxRuntime) resolveExtensions(ctx context.Context) map[string]string {

--- a/internal/runtime/opensandbox.go
+++ b/internal/runtime/opensandbox.go
@@ -635,7 +635,20 @@ func (r *OpenSandboxRuntime) networkPolicy() *opensandbox.NetworkPolicy {
 	case "deny_all":
 		return &opensandbox.NetworkPolicy{DefaultAction: "deny"}
 	case "allow_declared":
-		return &opensandbox.NetworkPolicy{DefaultAction: "allow"}
+		// Deny by default and permit only the declared egress targets, so an
+		// empty allowlist blocks all outbound traffic rather than allowing it.
+		policy := &opensandbox.NetworkPolicy{DefaultAction: "deny"}
+		for _, target := range r.cfg.AllowedEgress {
+			t := strings.TrimSpace(target)
+			if t == "" {
+				continue
+			}
+			policy.Egress = append(policy.Egress, opensandbox.NetworkRule{
+				Action: "allow",
+				Target: t,
+			})
+		}
+		return policy
 	default:
 		return nil
 	}

--- a/internal/runtime/opensandbox_test.go
+++ b/internal/runtime/opensandbox_test.go
@@ -112,15 +112,28 @@ func TestOpenSandboxCreatePassesNetworkPolicy(t *testing.T) {
 	setOpenSandboxTestAuth(t)
 
 	tests := []struct {
-		name       string
-		policy     string
-		wantNil    bool
-		wantAction string
+		name          string
+		policy        string
+		allowedEgress []string
+		wantNil       bool
+		wantAction    string
+		wantEgress    []string
 	}{
-		{"empty policy", "", true, ""},
-		{"deny_all", "deny_all", false, "deny"},
-		{"allow_declared", "allow_declared", false, "allow"},
-		{"unknown value", "custom", true, ""},
+		{name: "empty policy", policy: "", wantNil: true},
+		{name: "deny_all", policy: "deny_all", wantAction: "deny"},
+		{
+			name:          "allow_declared denies by default with allow rules",
+			policy:        "allow_declared",
+			allowedEgress: []string{"pypi.org", " *.example.com ", ""},
+			wantAction:    "deny",
+			wantEgress:    []string{"pypi.org", "*.example.com"},
+		},
+		{
+			name:       "allow_declared with no targets denies all",
+			policy:     "allow_declared",
+			wantAction: "deny",
+		},
+		{name: "unknown value", policy: "custom", wantNil: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -132,6 +145,7 @@ func TestOpenSandboxCreatePassesNetworkPolicy(t *testing.T) {
 			rt, err := NewOpenSandboxRuntime(Config{
 				Image:         "ubuntu:24.04",
 				NetworkPolicy: tt.policy,
+				AllowedEgress: tt.allowedEgress,
 				Kwargs:        map[string]string{"base_url": "https://sandbox.example.test"},
 				Delete:        true,
 			})
@@ -145,12 +159,23 @@ func TestOpenSandboxCreatePassesNetworkPolicy(t *testing.T) {
 				if gotOpts.NetworkPolicy != nil {
 					t.Fatalf("NetworkPolicy = %+v, want nil", gotOpts.NetworkPolicy)
 				}
-			} else {
-				if gotOpts.NetworkPolicy == nil {
-					t.Fatal("NetworkPolicy = nil, want non-nil")
+				return
+			}
+			if gotOpts.NetworkPolicy == nil {
+				t.Fatal("NetworkPolicy = nil, want non-nil")
+			}
+			if gotOpts.NetworkPolicy.DefaultAction != tt.wantAction {
+				t.Fatalf("DefaultAction = %q, want %q", gotOpts.NetworkPolicy.DefaultAction, tt.wantAction)
+			}
+			if len(gotOpts.NetworkPolicy.Egress) != len(tt.wantEgress) {
+				t.Fatalf("Egress = %+v, want %d rule(s)", gotOpts.NetworkPolicy.Egress, len(tt.wantEgress))
+			}
+			for i, rule := range gotOpts.NetworkPolicy.Egress {
+				if rule.Action != "allow" {
+					t.Errorf("Egress[%d].Action = %q, want allow", i, rule.Action)
 				}
-				if gotOpts.NetworkPolicy.DefaultAction != tt.wantAction {
-					t.Fatalf("DefaultAction = %q, want %q", gotOpts.NetworkPolicy.DefaultAction, tt.wantAction)
+				if rule.Target != tt.wantEgress[i] {
+					t.Errorf("Egress[%d].Target = %q, want %q", i, rule.Target, tt.wantEgress[i])
 				}
 			}
 		})

--- a/internal/runtime/opensandbox_test.go
+++ b/internal/runtime/opensandbox_test.go
@@ -106,6 +106,57 @@ func TestOpenSandboxCreateUsesSDKOptions(t *testing.T) {
 	}
 }
 
+func TestOpenSandboxCreatePassesNetworkPolicy(t *testing.T) {
+	origCreate := createOpenSandbox
+	t.Cleanup(func() { createOpenSandbox = origCreate })
+	setOpenSandboxTestAuth(t)
+
+	tests := []struct {
+		name       string
+		policy     string
+		wantNil    bool
+		wantAction string
+	}{
+		{"empty policy", "", true, ""},
+		{"deny_all", "deny_all", false, "deny"},
+		{"allow_declared", "allow_declared", false, "allow"},
+		{"unknown value", "custom", true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotOpts opensandbox.SandboxCreateOptions
+			createOpenSandbox = func(_ context.Context, _ opensandbox.ConnectionConfig, opts opensandbox.SandboxCreateOptions) (openSandboxClient, error) {
+				gotOpts = opts
+				return &fakeOpenSandbox{}, nil
+			}
+			rt, err := NewOpenSandboxRuntime(Config{
+				Image:         "ubuntu:24.04",
+				NetworkPolicy: tt.policy,
+				Kwargs:        map[string]string{"base_url": "https://sandbox.example.test"},
+				Delete:        true,
+			})
+			if err != nil {
+				t.Fatalf("NewOpenSandboxRuntime error: %v", err)
+			}
+			if err := rt.Create(context.Background()); err != nil {
+				t.Fatalf("Create error: %v", err)
+			}
+			if tt.wantNil {
+				if gotOpts.NetworkPolicy != nil {
+					t.Fatalf("NetworkPolicy = %+v, want nil", gotOpts.NetworkPolicy)
+				}
+			} else {
+				if gotOpts.NetworkPolicy == nil {
+					t.Fatal("NetworkPolicy = nil, want non-nil")
+				}
+				if gotOpts.NetworkPolicy.DefaultAction != tt.wantAction {
+					t.Fatalf("DefaultAction = %q, want %q", gotOpts.NetworkPolicy.DefaultAction, tt.wantAction)
+				}
+			}
+		})
+	}
+}
+
 func TestOpenSandboxCreateSnapshotsKwargs(t *testing.T) {
 	origCreate := createOpenSandbox
 	t.Cleanup(func() { createOpenSandbox = origCreate })

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -141,6 +141,8 @@ type Config struct {
 	Metadata       map[string]string
 	Kwargs         map[string]string
 
+	NetworkPolicy string // deny_all, allow_declared
+
 	SkillPath string
 
 	Delete bool

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -141,7 +141,8 @@ type Config struct {
 	Metadata       map[string]string
 	Kwargs         map[string]string
 
-	NetworkPolicy string // deny_all, allow_declared
+	NetworkPolicy string   // deny_all, allow_declared
+	AllowedEgress []string // FQDN/wildcard egress allowlist for allow_declared
 
 	SkillPath string
 


### PR DESCRIPTION
## Summary

Threads a `network_policy` field (`deny_all` / `allow_declared`) through the config layer, runtime config, and OpenSandbox sandbox creation so each sandbox can enforce a per-sandbox egress network policy. Validation rejects `network_policy` when `environment.type=none`, which cannot enforce network isolation.

Migrated from internal CR [27276276](https://code.alibaba-inc.com/build-service/skill-eval/codereview/27276276) and adapted to the open-source repo (which only supports `none`/`opensandbox` runtimes — `docker` references dropped).

## Changes

- **internal/config/schema.go**: `Environment` gains a `NetworkPolicy` field; `ToRuntimeConfig()` passes it through
- **internal/runtime/runtime.go**: `Config` gains a `NetworkPolicy` field
- **internal/runtime/opensandbox.go**: `Create()` maps the `network_policy` enum to the OpenSandbox SDK `NetworkPolicy` type (`deny_all` → `deny`, `allow_declared` → `allow`)
- **internal/config/validator.go**: new `validateNetworkPolicy()` rejects invalid enum values and `network_policy` on `type=none`; extracts runtime-type constants
- **tests**: config parsing, validation, runtime mapping unit tests + e2e validate/run coverage

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/config/... ./internal/runtime/...` — all pass
- [x] `go test -tags e2e ./e2e/... -run NetworkPolicy` — all pass
- [x] pre-commit lint (revive + golangci-lint) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)