### PR TITLE
chore(deps): upgrade OpenSandbox SDK to v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alibaba/skill-up
 go 1.25.0
 
 require (
-	github.com/alibaba/OpenSandbox/sdks/sandbox/go v1.0.0
+	github.com/alibaba/OpenSandbox/sdks/sandbox/go v1.0.1
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/alibaba/OpenSandbox/sdks/sandbox/go v1.0.0 h1:oqsi+3TwN7qQX1XHgk/io+fIr4KUKC6izLjah+D40q4=
-github.com/alibaba/OpenSandbox/sdks/sandbox/go v1.0.0/go.mod h1:RUNXUZnKDUAN/gIkfWcZZ1HNRJ0G6NIjGca0uMDex6I=
+github.com/alibaba/OpenSandbox/sdks/sandbox/go v1.0.1 h1:iZ/Mi7rZalQSJoGKs5MRuLxeRsbzVwlN41CKOx1R35Y=
+github.com/alibaba/OpenSandbox/sdks/sandbox/go v1.0.1/go.mod h1:+5yiVrwgbbwCD4+REoaqoIauQgjlnfL2mxbBrTy/Jgo=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/runtime/opensandbox.go
+++ b/internal/runtime/opensandbox.go
@@ -43,7 +43,7 @@ const openSandboxDefaultFileTransferParallelism = 8
 
 type openSandboxClient interface {
 	ID() string
-	Close()
+	Close() error
 	Kill(ctx context.Context) error
 	Pause(ctx context.Context) error
 	Ping(ctx context.Context) error
@@ -78,7 +78,7 @@ func createOpenSandboxCompat(ctx context.Context, cfg opensandbox.ConnectionConf
 
 	lifecycle := newOpenSandboxLifecycleClient(cfg)
 	created, err := lifecycle.CreateSandbox(ctx, opensandbox.CreateSandboxRequest{
-		Image:          opensandbox.ImageSpec{URI: opts.Image, Auth: opts.ImageAuth},
+		Image:          &opensandbox.ImageSpec{URI: opts.Image, Auth: opts.ImageAuth},
 		Entrypoint:     entrypoint,
 		ResourceLimits: limits,
 		Timeout:        timeout,
@@ -198,15 +198,21 @@ func (r *OpenSandboxRuntime) closeSandbox(ctx context.Context) error {
 	sandbox := r.sandbox
 	if !r.cfg.Delete {
 		logging.DebugContextf(ctx, "OpenSandboxRuntime.Close: skipping cleanup, sandbox preserved: %s", sandbox.ID())
-		sandbox.Close()
+		err := sandbox.Close()
 		r.sandbox = nil
+		if err != nil {
+			return fmt.Errorf("failed to close opensandbox %s: %w", sandbox.ID(), err)
+		}
 		return nil
 	}
 	if err := sandbox.Kill(ctx); err != nil {
 		return fmt.Errorf("failed to kill opensandbox %s: %w", sandbox.ID(), err)
 	}
-	sandbox.Close()
+	err := sandbox.Close()
 	r.sandbox = nil
+	if err != nil {
+		return fmt.Errorf("failed to close opensandbox %s: %w", sandbox.ID(), err)
+	}
 	return nil
 }
 

--- a/internal/runtime/opensandbox_test.go
+++ b/internal/runtime/opensandbox_test.go
@@ -721,7 +721,7 @@ type fakeOpenSandbox struct {
 }
 
 func (f *fakeOpenSandbox) ID() string { return "sbx-test" }
-func (f *fakeOpenSandbox) Close()     {}
+func (f *fakeOpenSandbox) Close() error { return nil }
 func (f *fakeOpenSandbox) Kill(ctx context.Context) error {
 	f.killed = true
 	f.killCtxErr = ctx.Err()

--- a/internal/runtime/opensandbox_test.go
+++ b/internal/runtime/opensandbox_test.go
@@ -720,7 +720,7 @@ type fakeOpenSandbox struct {
 	killCtxErr             error
 }
 
-func (f *fakeOpenSandbox) ID() string { return "sbx-test" }
+func (f *fakeOpenSandbox) ID() string   { return "sbx-test" }
 func (f *fakeOpenSandbox) Close() error { return nil }
 func (f *fakeOpenSandbox) Kill(ctx context.Context) error {
 	f.killed = true


### PR DESCRIPTION
## Summary

Adapt to breaking changes:
- CreateSandboxRequest.Image now *ImageSpec (pointer)
- Sandbox.Close() now returns error

## Test plan

- [x] `make test` passes
- [x] `make verify` passes (fmt + vet + lint)
- [ ] Manual testing steps (if applicable):

## Notes for reviewers

upgrade OpenSandbox SDK to v1.0.1