### PR TITLE
refactor(runtime): use SDK batch UploadFiles for directory upload

### DIFF
--- a/docs/guide/writing-evals.md
+++ b/docs/guide/writing-evals.md
@@ -188,7 +188,7 @@ Common fields:
 | `kwargs.base_url` | OpenSandbox service URL; can also be set via `OPENSANDBOX_BASE_URL`. |
 | `kwargs.extensions` | OpenSandbox extension config as a JSON string. |
 | `kwargs.request_timeout_seconds` | Request timeout for the OpenSandbox SDK. |
-| `kwargs.file_transfer_parallelism` | Concurrency for directory upload/download. |
+| `kwargs.file_transfer_parallelism` | Concurrency for directory download. |
 
 ---
 

--- a/docs/zh/guide/writing-evals.md
+++ b/docs/zh/guide/writing-evals.md
@@ -188,7 +188,7 @@ environment:
 | `kwargs.base_url` | OpenSandbox 服务地址，也可用 `OPENSANDBOX_BASE_URL` 设置 |
 | `kwargs.extensions` | JSON 字符串形式的 OpenSandbox 扩展配置 |
 | `kwargs.request_timeout_seconds` | OpenSandbox SDK 请求超时时间 |
-| `kwargs.file_transfer_parallelism` | 目录上传/下载并发度 |
+| `kwargs.file_transfer_parallelism` | 目录下载并发度 |
 
 ---
 

--- a/internal/runtime/opensandbox.go
+++ b/internal/runtime/opensandbox.go
@@ -49,6 +49,7 @@ type openSandboxClient interface {
 	Ping(ctx context.Context) error
 	CreateDirectory(ctx context.Context, remotePath string, mode int) error
 	UploadFile(ctx context.Context, reader io.Reader, opts opensandbox.UploadFileOptions) error
+	UploadFiles(ctx context.Context, entries []opensandbox.UploadFileEntry) error
 	DownloadFile(ctx context.Context, remotePath, rangeHeader string) (io.ReadCloser, error)
 	SearchFiles(ctx context.Context, dir, pattern string) ([]opensandbox.FileInfo, error)
 	RunCommandWithOpts(ctx context.Context, req opensandbox.RunCommandRequest, handlers *opensandbox.ExecutionHandlers) (*opensandbox.Execution, error)
@@ -325,55 +326,42 @@ func (r *OpenSandboxRuntime) uploadFiles(ctx context.Context, items []uploadItem
 	if len(items) == 0 {
 		return nil
 	}
-	parallelism := r.fileParallelism
-	if parallelism <= 0 {
-		parallelism = openSandboxDefaultFileTransferParallelism
-	}
-	parallelism = min(parallelism, len(items))
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	entries := make([]opensandbox.UploadFileEntry, 0, len(items))
+	closers := make([]io.Closer, 0, len(items))
+	defer func() {
+		for _, c := range closers {
+			_ = c.Close()
+		}
+	}()
 
-	jobs := make(chan uploadItem)
-	errCh := make(chan error, 1)
-	var wg sync.WaitGroup
-	for range parallelism {
-		wg.Go(func() {
-			for item := range jobs {
-				if err := r.uploadRemoteFile(ctx, item.source, item.target); err != nil {
-					select {
-					case errCh <- err:
-						cancel()
-					default:
-					}
-					return
-				}
-			}
+	for _, item := range items {
+		file, err := os.Open(item.source)
+		if err != nil {
+			return fmt.Errorf("failed to open source file %s: %w", item.source, err)
+		}
+		closers = append(closers, file)
+
+		info, err := file.Stat()
+		if err != nil {
+			return fmt.Errorf("failed to stat source file %s: %w", item.source, err)
+		}
+		entries = append(entries, opensandbox.UploadFileEntry{
+			File: file,
+			Options: opensandbox.UploadFileOptions{
+				FileName: filepath.Base(item.source),
+				Metadata: opensandbox.FileMetadata{
+					Path: item.target,
+					Mode: opensandbox.OctalMode(info.Mode()),
+				},
+			},
 		})
 	}
 
-	for _, item := range items {
-		select {
-		case <-ctx.Done():
-			close(jobs)
-			wg.Wait()
-			select {
-			case err := <-errCh:
-				return err
-			default:
-				return ctx.Err()
-			}
-		case jobs <- item:
-		}
+	if err := r.sandbox.UploadFiles(ctx, entries); err != nil {
+		return fmt.Errorf("failed to upload %d files: %w", len(entries), err)
 	}
-	close(jobs)
-	wg.Wait()
-	select {
-	case err := <-errCh:
-		return err
-	default:
-		return nil
-	}
+	return nil
 }
 
 // DownloadFile downloads a file from the sandbox to the host.

--- a/internal/runtime/opensandbox.go
+++ b/internal/runtime/opensandbox.go
@@ -41,6 +41,11 @@ const (
 
 const openSandboxDefaultFileTransferParallelism = 8
 
+// openSandboxUploadBatchSize caps how many files a single UploadFiles request
+// carries. It bounds the open file descriptors held per batch so uploading a
+// large directory tree stays well under a typical ulimit -n.
+const openSandboxUploadBatchSize = 128
+
 type openSandboxClient interface {
 	ID() string
 	Close() error
@@ -297,6 +302,19 @@ func collectUploadItems(sourceDir, targetRoot string) ([]uploadItem, []string, e
 }
 
 func (r *OpenSandboxRuntime) uploadFiles(ctx context.Context, items []uploadItem) error {
+	for start := 0; start < len(items); start += openSandboxUploadBatchSize {
+		end := min(start+openSandboxUploadBatchSize, len(items))
+		if err := r.uploadFileBatch(ctx, items[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// uploadFileBatch uploads one bounded batch of files in a single SDK request.
+// Batching keeps the number of simultaneously open file descriptors below
+// openSandboxUploadBatchSize so large directory trees do not exhaust ulimit -n.
+func (r *OpenSandboxRuntime) uploadFileBatch(ctx context.Context, items []uploadItem) error {
 	if len(items) == 0 {
 		return nil
 	}

--- a/internal/runtime/opensandbox.go
+++ b/internal/runtime/opensandbox.go
@@ -48,7 +48,6 @@ type openSandboxClient interface {
 	Pause(ctx context.Context) error
 	Ping(ctx context.Context) error
 	CreateDirectory(ctx context.Context, remotePath string, mode int) error
-	UploadFile(ctx context.Context, reader io.Reader, opts opensandbox.UploadFileOptions) error
 	UploadFiles(ctx context.Context, entries []opensandbox.UploadFileEntry) error
 	DownloadFile(ctx context.Context, remotePath, rangeHeader string) (io.ReadCloser, error)
 	SearchFiles(ctx context.Context, dir, pattern string) ([]opensandbox.FileInfo, error)
@@ -248,32 +247,7 @@ func (r *OpenSandboxRuntime) UploadFile(ctx context.Context, sourcePath, targetP
 	if err := r.ensureDirectory(ctx, path.Dir(target), 755); err != nil {
 		return fmt.Errorf("failed to create target directory %s: %w", path.Dir(target), err)
 	}
-	return r.uploadRemoteFile(ctx, sourcePath, target)
-}
-
-func (r *OpenSandboxRuntime) uploadRemoteFile(ctx context.Context, sourcePath, target string) error {
-	file, err := os.Open(sourcePath)
-	if err != nil {
-		return fmt.Errorf("failed to open source file %s: %w", sourcePath, err)
-	}
-	defer func() {
-		_ = file.Close()
-	}()
-
-	info, err := file.Stat()
-	if err != nil {
-		return fmt.Errorf("failed to stat source file %s: %w", sourcePath, err)
-	}
-	if err := r.sandbox.UploadFile(ctx, file, opensandbox.UploadFileOptions{
-		FileName: filepath.Base(sourcePath),
-		Metadata: opensandbox.FileMetadata{
-			Path: target,
-			Mode: opensandbox.OctalMode(info.Mode()),
-		},
-	}); err != nil {
-		return fmt.Errorf("failed to upload file %s to %s: %w", sourcePath, target, err)
-	}
-	return nil
+	return r.uploadFiles(ctx, []uploadItem{{source: sourcePath, target: target}})
 }
 
 // UploadDir recursively uploads a directory tree from the host into the sandbox.

--- a/internal/runtime/opensandbox_test.go
+++ b/internal/runtime/opensandbox_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -577,6 +579,30 @@ func TestOpenSandboxUploadDirUploadsFilesInSingleBatch(t *testing.T) {
 	}
 	if strings.Contains(fake.execs[0].Command, "tar") {
 		t.Fatalf("UploadDir exec command = %q, want no tar command", fake.execs[0].Command)
+	}
+}
+
+func TestOpenSandboxUploadDirChunksLargeTreeIntoBoundedBatches(t *testing.T) {
+	dir := t.TempDir()
+	const total = openSandboxUploadBatchSize + 2
+	for i := range total {
+		name := fmt.Sprintf("file-%03d.txt", i)
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(name), noneFileMode); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	fake := &fakeOpenSandbox{execResult: &opensandbox.Execution{ExitCode: intPtr(0)}}
+	rt := &OpenSandboxRuntime{workspace: "/workspace", sandbox: fake}
+
+	if err := rt.UploadDir(context.Background(), dir, "dest"); err != nil {
+		t.Fatalf("UploadDir returned error: %v", err)
+	}
+	if len(fake.uploads) != total {
+		t.Fatalf("uploaded files = %d, want %d", len(fake.uploads), total)
+	}
+	wantBatches := []int{openSandboxUploadBatchSize, 2}
+	if !slices.Equal(fake.uploadFilesBatchSizes, wantBatches) {
+		t.Fatalf("UploadFiles batch sizes = %#v, want %#v", fake.uploadFilesBatchSizes, wantBatches)
 	}
 }
 

--- a/internal/runtime/opensandbox_test.go
+++ b/internal/runtime/opensandbox_test.go
@@ -523,25 +523,31 @@ func TestOpenSandboxUploadDownloadFile(t *testing.T) {
 	}
 }
 
-func TestOpenSandboxUploadDirUploadsFilesConcurrently(t *testing.T) {
+func writeUploadDirFixture(t *testing.T, dir string) {
+	t.Helper()
+	for _, sub := range []string{"nested", "empty"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), noneDirMode); err != nil {
+			t.Fatalf("create %s dir: %v", sub, err)
+		}
+	}
+	files := map[string]string{
+		"file.txt":         "content",
+		"nested/other.txt": "other",
+	}
+	for rel, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(rel)), []byte(content), noneFileMode); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+}
+
+func TestOpenSandboxUploadDirUploadsFilesInSingleBatch(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, "nested"), noneDirMode); err != nil {
-		t.Fatalf("create nested dir: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(dir, "empty"), noneDirMode); err != nil {
-		t.Fatalf("create empty dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), noneFileMode); err != nil {
-		t.Fatalf("write source: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "nested", "other.txt"), []byte("other"), noneFileMode); err != nil {
-		t.Fatalf("write nested source: %v", err)
-	}
+	writeUploadDirFixture(t, dir)
 	fake := &fakeOpenSandbox{
-		execResult:  &opensandbox.Execution{ExitCode: intPtr(0)},
-		uploadDelay: 20 * time.Millisecond,
+		execResult: &opensandbox.Execution{ExitCode: intPtr(0)},
 	}
-	rt := &OpenSandboxRuntime{workspace: "/workspace", sandbox: fake, fileParallelism: 2}
+	rt := &OpenSandboxRuntime{workspace: "/workspace", sandbox: fake}
 
 	if err := rt.UploadDir(context.Background(), dir, "dest"); err != nil {
 		t.Fatalf("UploadDir returned error: %v", err)
@@ -563,11 +569,11 @@ func TestOpenSandboxUploadDirUploadsFilesConcurrently(t *testing.T) {
 			t.Fatalf("UploadDir mkdir command = %q, want %s", fake.execs[0].Command, want)
 		}
 	}
-	if fake.maxConcurrentUploads < 2 {
-		t.Fatalf("max concurrent uploads = %d, want at least 2", fake.maxConcurrentUploads)
+	if fake.uploadFilesCalls != 1 {
+		t.Fatalf("UploadFiles calls = %d, want a single batched call", fake.uploadFilesCalls)
 	}
-	if fake.maxConcurrentUploads > 2 {
-		t.Fatalf("max concurrent uploads = %d, want no more than 2", fake.maxConcurrentUploads)
+	if len(fake.uploadFilesBatchSizes) != 1 || fake.uploadFilesBatchSizes[0] != 2 {
+		t.Fatalf("UploadFiles batch sizes = %#v, want one batch of 2 files", fake.uploadFilesBatchSizes)
 	}
 	if strings.Contains(fake.execs[0].Command, "tar") {
 		t.Fatalf("UploadDir exec command = %q, want no tar command", fake.execs[0].Command)
@@ -712,6 +718,8 @@ type fakeOpenSandbox struct {
 	uploadMu               sync.Mutex
 	activeUploads          int
 	maxConcurrentUploads   int
+	uploadFilesCalls       int
+	uploadFilesBatchSizes  []int
 	downloadDelay          time.Duration
 	downloadMu             sync.Mutex
 	activeDownloads        int
@@ -765,6 +773,19 @@ func (f *fakeOpenSandbox) UploadFile(_ context.Context, reader io.Reader, opts o
 	}
 	f.uploads[opts.Metadata.Path] = data
 	f.uploadMu.Unlock()
+	return nil
+}
+
+func (f *fakeOpenSandbox) UploadFiles(ctx context.Context, entries []opensandbox.UploadFileEntry) error {
+	f.uploadMu.Lock()
+	f.uploadFilesCalls++
+	f.uploadFilesBatchSizes = append(f.uploadFilesBatchSizes, len(entries))
+	f.uploadMu.Unlock()
+	for _, entry := range entries {
+		if err := f.UploadFile(ctx, entry.File, entry.Options); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- The OpenSandbox SDK v1.0.1 (adopted in #18) exposes `UploadFiles`, which sends multiple files in a single multipart request.
- `OpenSandboxRuntime.uploadFiles` previously fanned a directory upload out across a worker pool of single-file `UploadFile` calls. It now builds `[]UploadFileEntry` and calls the SDK's batch interface directly — no goroutine concurrency.
- Uploads are chunked into batches of 128 files (`openSandboxUploadBatchSize`) so a large tree keeps open file descriptors bounded instead of exhausting `ulimit -n`.
- Single-file `UploadFile` delegates to the same batch path; `UploadFile` is dropped from the `openSandboxClient` interface (keeps it within the `interfacebloat` 10-method cap).
- `kwargs.file_transfer_parallelism` now only governs directory **download**; docs updated in both EN and ZH.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/runtime/` passes (incl. new chunking regression test)
- [x] pre-commit + full `golangci-lint` clean
- [ ] verify directory upload against a live OpenSandbox endpoint