### PR TITLE
feat: add --runtime flag to override environment.type

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -512,8 +512,9 @@ func applyRuntimeKwargOverrides(evalCfg *config.EvalConfig, cmd *cobra.Command) 
 }
 
 // applyRuntimeTypeOverride applies the --runtime flag onto environment.type.
-// The value is validated here because config validation runs before CLI
-// overrides are applied, so an overridden value would otherwise bypass it.
+// The value and its compatibility with network_policy are validated here
+// because config validation runs before CLI overrides are applied, so an
+// overridden value would otherwise bypass validation.
 func applyRuntimeTypeOverride(evalCfg *config.EvalConfig, cmd *cobra.Command) error {
 	flag := cmd.Flags().Lookup(runtimeFlagName)
 	if flag == nil || !flag.Changed {
@@ -522,6 +523,9 @@ func applyRuntimeTypeOverride(evalCfg *config.EvalConfig, cmd *cobra.Command) er
 	value := strings.TrimSpace(flag.Value.String())
 	if !slices.Contains(validRuntimeTypes, value) {
 		return fmt.Errorf("invalid --runtime %q (supported: %s)", value, strings.Join(validRuntimeTypes, ", "))
+	}
+	if value == "none" && evalCfg.Environment.NetworkPolicy != "" {
+		return fmt.Errorf("--runtime none is incompatible with network_policy %q (none cannot enforce network isolation)", evalCfg.Environment.NetworkPolicy)
 	}
 	evalCfg.Environment.Type = value
 	return nil

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -34,7 +35,11 @@ const (
 	maxParallelismOverride = 256
 	runtimeKwargFlagName   = "runtime-kwarg"
 	runtimeKwargAlias      = "rk"
+	runtimeFlagName        = "runtime"
 )
+
+// validRuntimeTypes lists the environment.type values accepted by --runtime.
+var validRuntimeTypes = []string{"none", "opensandbox"}
 
 type verbosityValue int
 
@@ -94,6 +99,7 @@ func init() {
 	runCmd.Flags().StringArray("format", nil, "Report format (json, junit, html). Can be specified multiple times. Default: json")
 	runCmd.Flags().String("output-dir", "", "Directory for report/artifact outputs. Default: <skill-dir>/<skill-name>-workspace")
 	runCmd.Flags().String("engine", "", "Override engine name")
+	runCmd.Flags().String(runtimeFlagName, "", "Override environment.type (none, opensandbox)")
 	runCmd.Flags().String("model", "", "Override model (accepts either a bare model name or provider/name)")
 	runCmd.Flags().String("api-key", "", "API key for the model provider")
 	runCmd.Flags().Int("parallelism", 0, "Override cases.parallelism. Must be between 1 and 256 when specified")
@@ -438,6 +444,9 @@ func applyRunConfigOverrides(evalCfg *config.EvalConfig, cmd *cobra.Command) err
 	if err := applyRuntimeKwargOverrides(evalCfg, cmd); err != nil {
 		return err
 	}
+	if err := applyRuntimeTypeOverride(evalCfg, cmd); err != nil {
+		return err
+	}
 	applyUserConfigKwargs(cmd.Context(), evalCfg)
 
 	parallelismFlag := cmd.Flags().Lookup("parallelism")
@@ -499,6 +508,22 @@ func applyRuntimeKwargOverrides(evalCfg *config.EvalConfig, cmd *cobra.Command) 
 		}
 		evalCfg.Environment.Kwargs[key] = val
 	}
+	return nil
+}
+
+// applyRuntimeTypeOverride applies the --runtime flag onto environment.type.
+// The value is validated here because config validation runs before CLI
+// overrides are applied, so an overridden value would otherwise bypass it.
+func applyRuntimeTypeOverride(evalCfg *config.EvalConfig, cmd *cobra.Command) error {
+	flag := cmd.Flags().Lookup(runtimeFlagName)
+	if flag == nil || !flag.Changed {
+		return nil
+	}
+	value := strings.TrimSpace(flag.Value.String())
+	if !slices.Contains(validRuntimeTypes, value) {
+		return fmt.Errorf("invalid --runtime %q (supported: %s)", value, strings.Join(validRuntimeTypes, ", "))
+	}
+	evalCfg.Environment.Type = value
 	return nil
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -20,6 +20,8 @@ import (
 
 const agentJudgeType = "agent_judge"
 
+const testRuntimeOpenSandbox = "opensandbox"
+
 func TestRunCommand_UsesUsageAwareArgs(t *testing.T) {
 	t.Parallel()
 
@@ -955,6 +957,56 @@ func TestApplyRunConfigOverrides_RuntimeKwargs(t *testing.T) {
 	}
 	if got := cfg.Environment.Kwargs["extensions"]; got != `{"profile":"ci"}` {
 		t.Fatalf("extensions kwarg = %q, want CLI value", got)
+	}
+}
+
+func TestApplyRunConfigOverrides_RuntimeType(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String(runtimeFlagName, "", "")
+	if err := cmd.Flags().Set(runtimeFlagName, testRuntimeOpenSandbox); err != nil {
+		t.Fatalf("set runtime: %v", err)
+	}
+
+	cfg := config.DefaultEvalConfig()
+	cfg.Environment.Type = "none"
+	if err := applyRunConfigOverrides(cfg, cmd); err != nil {
+		t.Fatalf("applyRunConfigOverrides: %v", err)
+	}
+	if got := cfg.Environment.Type; got != testRuntimeOpenSandbox {
+		t.Fatalf("Environment.Type = %q, want opensandbox", got)
+	}
+}
+
+func TestApplyRunConfigOverrides_RuntimeTypeUnsetPreservesConfig(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String(runtimeFlagName, "", "")
+
+	cfg := config.DefaultEvalConfig()
+	cfg.Environment.Type = testRuntimeOpenSandbox
+	if err := applyRunConfigOverrides(cfg, cmd); err != nil {
+		t.Fatalf("applyRunConfigOverrides: %v", err)
+	}
+	if got := cfg.Environment.Type; got != testRuntimeOpenSandbox {
+		t.Fatalf("Environment.Type = %q, want opensandbox", got)
+	}
+}
+
+func TestApplyRunConfigOverrides_RuntimeTypeRejectsInvalid(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String(runtimeFlagName, "", "")
+	if err := cmd.Flags().Set(runtimeFlagName, "docker"); err != nil {
+		t.Fatalf("set runtime: %v", err)
+	}
+
+	cfg := config.DefaultEvalConfig()
+	if err := applyRunConfigOverrides(cfg, cmd); err == nil {
+		t.Fatal("applyRunConfigOverrides: want error for invalid --runtime, got nil")
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1010,6 +1010,26 @@ func TestApplyRunConfigOverrides_RuntimeTypeRejectsInvalid(t *testing.T) {
 	}
 }
 
+func TestApplyRunConfigOverrides_RuntimeTypeNoneRejectsNetworkPolicy(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String(runtimeFlagName, "", "")
+	if err := cmd.Flags().Set(runtimeFlagName, "none"); err != nil {
+		t.Fatalf("set runtime: %v", err)
+	}
+
+	cfg := config.DefaultEvalConfig()
+	cfg.Environment.Type = testRuntimeOpenSandbox
+	cfg.Environment.NetworkPolicy = "deny_all"
+	if err := applyRunConfigOverrides(cfg, cmd); err == nil {
+		t.Fatal("applyRunConfigOverrides: want error for --runtime none with network_policy, got nil")
+	}
+	if got := cfg.Environment.Type; got != testRuntimeOpenSandbox {
+		t.Fatalf("Environment.Type = %q, want unchanged after rejected override", got)
+	}
+}
+
 func TestApplyRunConfigOverrides_UserConfigKwargs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The `run` command can override engine, model, and runtime kwargs from the CLI, but the runtime type itself was only settable via `eval.yaml`'s `environment.type`. This adds a `--runtime` flag so users can switch between `none` and `opensandbox` without editing config.

## Related issues

<!-- none -->

## Changes

- Add `--runtime` flag to `skill-up run` that overrides `environment.type`
- `applyRuntimeTypeOverride` applies the flag in `applyRunConfigOverrides`, alongside the existing engine/model/kwarg overrides
- The flag value is validated against the `none`/`opensandbox` whitelist in the CLI, because config validation runs before CLI overrides are applied — an overridden value would otherwise bypass validation
- Override-only: it does not fill an empty `environment.type` (config validation would already fail before the override runs)

## Test plan

- [x] `make test` passes (`internal/cli` suite green)
- [x] `make verify` passes (fmt + vet + lint — pre-commit hook ran clean)
- [ ] Manual testing steps (if applicable):
  - `skill-up run --runtime opensandbox` overrides a config with `environment.type: none`
  - `skill-up run --runtime docker` fails with an invalid-value error

## Notes for reviewers

`--runtime` only overrides an already-valid config. If `eval.yaml` leaves `environment.type` empty, config validation fails before the override is applied. Supporting empty-config completion would require reordering the load→validate→override flow; left out per scope.