### PR TITLE
chore: Add coverage badge generation and update README links

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "coverage",
+  "message": "pending",
+  "color": "lightgrey"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,12 @@ on:
       - '*.md'
       - '.github/workflows/docs.yml'
 
+# Default the workflow token to read-only. Jobs that execute PR-supplied
+# code (build/test, e2e, lint) must never be able to push to the repo, even
+# on same-repository PRs where GITHUB_TOKEN would otherwise be writable.
+# Only the dedicated badge-commit job below opts back into contents: write.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -65,19 +69,47 @@ jobs:
           echo "color=$color" >> "$GITHUB_OUTPUT"
           echo "::notice::Total coverage: ${pct}% (${color})"
 
-      # Commit the refreshed badge back to main. PRs (including forks) only
-      # compute the number for visibility and never write to the repo.
-      - name: Commit updated coverage badge
+      # Hand the badge to the push-only update-coverage-badge job below via
+      # an artifact. PRs (including forks) still run the compute step above
+      # for visibility, but skip the upload so they can never trigger a push.
+      - name: Upload coverage badge artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-badge
+          path: .github/badges/coverage.json
+          if-no-files-found: error
+          retention-days: 1
+
+  update-coverage-badge:
+    name: Commit coverage badge
+    needs: build
+    # Gate the entire job — not just individual steps — on push-to-main so
+    # the contents: write token below is never issued for pull_request runs.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download coverage badge artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: coverage-badge
+          path: .github/badges/
+
+      - name: Commit updated coverage badge
         run: |
           if git diff --quiet -- .github/badges/coverage.json; then
             echo "coverage badge unchanged, nothing to commit"
             exit 0
           fi
+          pct=$(awk -F'"' '/"message"/ {print $4}' .github/badges/coverage.json)
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .github/badges/coverage.json
-          git commit -m "chore(ci): update coverage badge to ${{ steps.coverage.outputs.pct }}% [skip ci]"
+          git commit -m "chore(ci): update coverage badge to ${pct} [skip ci]"
           git push
 
   e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/docs.yml'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -40,16 +40,45 @@ jobs:
         run: go build ./...
 
       - name: Test (with race detector and coverage)
-        run: go test -race -timeout 120s -covermode=atomic -coverprofile=coverage.out ./...
+        run: go test -race -timeout 120s -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./coverage.out
-          flags: unittests
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      # Self-hosted coverage badge: parse the total from `go tool cover -func`
+      # and rewrite .github/badges/coverage.json. The shields.io endpoint badge
+      # in README.md reads this JSON via raw.githubusercontent.com.
+      - name: Compute coverage and update badge
+        id: coverage
+        run: |
+          pct=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%","",$3); print $3}')
+          if [ -z "$pct" ]; then
+            echo "could not parse total coverage" >&2
+            exit 1
+          fi
+          color=$(awk -v p="$pct" 'BEGIN {
+            if (p+0 >= 80)      print "brightgreen";
+            else if (p+0 >= 60) print "yellow";
+            else                print "red";
+          }')
+          mkdir -p .github/badges
+          printf '{\n  "schemaVersion": 1,\n  "label": "coverage",\n  "message": "%s%%",\n  "color": "%s"\n}\n' \
+            "$pct" "$color" > .github/badges/coverage.json
+          echo "pct=$pct" >> "$GITHUB_OUTPUT"
+          echo "color=$color" >> "$GITHUB_OUTPUT"
+          echo "::notice::Total coverage: ${pct}% (${color})"
+
+      # Commit the refreshed badge back to main. PRs (including forks) only
+      # compute the number for visibility and never write to the repo.
+      - name: Commit updated coverage badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          if git diff --quiet -- .github/badges/coverage.json; then
+            echo "coverage badge unchanged, nothing to commit"
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/coverage.json
+          git commit -m "chore(ci): update coverage badge to ${{ steps.coverage.outputs.pct }}% [skip ci]"
+          git push
 
   e2e:
     name: E2E (none runtime)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
       # Hand the badge to the push-only update-coverage-badge job below via
       # an artifact. PRs (including forks) still run the compute step above
       # for visibility, but skip the upload so they can never trigger a push.
+      #
+      # include-hidden-files: true is required — the badge lives under
+      # .github/, and actions/upload-artifact defaults to excluding files
+      # whose path contains any dot-prefixed segment. Without this the
+      # upload would silently match nothing and, combined with
+      # if-no-files-found: error, fail the build job on every push to main.
       - name: Upload coverage badge artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v5
@@ -79,6 +85,7 @@ jobs:
           name: coverage-badge
           path: .github/badges/coverage.json
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: 1
 
   update-coverage-badge:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test vet fmt fmt-check lint lint-new revive verify tidy clean install hooks e2e lint-tools
+.PHONY: build test vet fmt fmt-check lint lint-new revive verify tidy clean install hooks e2e lint-tools coverage coverage-badge
 
 CMD := ./cmd/skill-up
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -89,6 +89,25 @@ hooks:
 # Run e2e tests
 e2e:
 	go test -tags e2e -v ./e2e
+
+# Generate a coverage profile across all packages (writes coverage.out).
+coverage:
+	go test -race -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
+
+# Compute total coverage from coverage.out and refresh .github/badges/coverage.json
+# so the shields.io endpoint badge in README.md picks up the new percentage.
+# Color thresholds: >=80 green, >=60 yellow, otherwise red.
+coverage-badge: coverage
+	@pct=$$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%","",$$3); print $$3}'); \
+	if [ -z "$$pct" ]; then echo "could not parse total coverage" >&2; exit 1; fi; \
+	color=$$(awk -v p="$$pct" 'BEGIN { \
+	  if (p+0 >= 80) print "brightgreen"; \
+	  else if (p+0 >= 60) print "yellow"; \
+	  else print "red"; \
+	}'); \
+	mkdir -p .github/badges; \
+	printf '{\n  "schemaVersion": 1,\n  "label": "coverage",\n  "message": "%s%%",\n  "color": "%s"\n}\n' "$$pct" "$$color" > .github/badges/coverage.json; \
+	echo "coverage badge updated: $$pct% ($$color)"
 
 # Note: multi-platform builds, checksums and archives for releases are produced
 # by GoReleaser (see .goreleaser.yaml and .github/workflows/release.yml).

--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@
     <a href="https://github.com/alibaba/skill-up/actions">
       <img src="https://github.com/alibaba/skill-up/actions/workflows/ci.yml/badge.svg" alt="CI" />
     </a>
-    <a href="https://codecov.io/gh/alibaba/skill-up">
-      <img src="https://codecov.io/gh/alibaba/skill-up/branch/main/graph/badge.svg" alt="Coverage" />
+    <a href="https://deepwiki.com/alibaba/skill-up">
+      <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" />
+    </a>
+    <a href="./.github/badges/coverage.json">
+      <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/alibaba/skill-up/main/.github/badges/coverage.json" alt="Coverage" />
     </a>
     <a href="https://go.dev/">
       <img src="https://img.shields.io/badge/go-%3E%3D1.25-blue" alt="Go Version" />
@@ -149,12 +152,12 @@ skill-up auto-loads an optional user-level config that supplies default OpenTele
 embed (empty) < user (~/.config/skill-up/config.yaml) < project ($PWD/.skill-up.yaml) < explicit (--config)
 ```
 
-| Source     | Path                                                                                   |
-| ---------- | -------------------------------------------------------------------------------------- |
-| `embed`    | empty `Config{}` — no vendor defaults baked in                                         |
+| Source     | Path                                                                                                      |
+| ---------- | --------------------------------------------------------------------------------------------------------- |
+| `embed`    | empty `Config{}` — no vendor defaults baked in                                                            |
 | `user`     | `$SKILL_EVAL_CONFIG`, else `$XDG_CONFIG_HOME/skill-up/config.yaml`, else `~/.config/skill-up/config.yaml` |
-| `project`  | `$PWD/.skill-up.yaml`                                                                |
-| `explicit` | `--config <path>` (must exist)                                                         |
+| `project`  | `$PWD/.skill-up.yaml`                                                                                     |
+| `explicit` | `--config <path>` (must exist)                                                                            |
 
 Missing files at the `user` and `project` layers are silently skipped; a missing `--config` path is a hard error. A corrupt config at any layer also fails the run.
 
@@ -212,15 +215,15 @@ skill-up import ./evals/evals.json --output ./evals
 
 ## CLI Overview
 
-| Command | Description |
-|---------|-------------|
-| `skill-up run [path]` | Run evaluation cases and produce reports |
-| `skill-up validate [path]` | Validate `eval.yaml` and case files |
-| `skill-up list-cases [path]` | List all cases referenced by the config |
-| `skill-up report <result.json>` | Generate reports from a previous run |
-| `skill-up import <evals.json>` | Import Anthropic `evals.json` to YAML cases |
-| `skill-up debug judge <input.json>` | Debug judge module with a JSON input |
-| `skill-up debug report <input.json>` | Debug report module with a JSON input |
+| Command                              | Description                                 |
+| ------------------------------------ | ------------------------------------------- |
+| `skill-up run [path]`                | Run evaluation cases and produce reports    |
+| `skill-up validate [path]`           | Validate `eval.yaml` and case files         |
+| `skill-up list-cases [path]`         | List all cases referenced by the config     |
+| `skill-up report <result.json>`      | Generate reports from a previous run        |
+| `skill-up import <evals.json>`       | Import Anthropic `evals.json` to YAML cases |
+| `skill-up debug judge <input.json>`  | Debug judge module with a JSON input        |
+| `skill-up debug report <input.json>` | Debug report module with a JSON input       |
 
 ## License
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,8 +9,11 @@
     <a href="https://github.com/alibaba/skill-up/actions">
       <img src="https://github.com/alibaba/skill-up/actions/workflows/ci.yml/badge.svg" alt="CI" />
     </a>
-    <a href="https://codecov.io/gh/alibaba/skill-up">
-      <img src="https://codecov.io/gh/alibaba/skill-up/branch/main/graph/badge.svg" alt="Coverage" />
+    <a href="https://deepwiki.com/alibaba/skill-up">
+      <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" />
+    </a>
+    <a href="./.github/badges/coverage.json">
+      <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/alibaba/skill-up/main/.github/badges/coverage.json" alt="Coverage" />
     </a>
     <a href="https://go.dev/">
       <img src="https://img.shields.io/badge/go-%3E%3D1.25-blue" alt="Go Version" />
@@ -145,15 +148,15 @@ skill-up import ./evals/evals.json --output ./evals
 
 ## CLI 命令概览
 
-| 命令 | 说明 |
-|---------|-------------|
-| `skill-up run [path]` | 运行评测用例并生成报告 |
-| `skill-up validate [path]` | 校验 `eval.yaml` 和用例文件 |
-| `skill-up list-cases [path]` | 列出配置引用的所有用例 |
-| `skill-up report <result.json>` | 从已有结果生成报告 |
-| `skill-up import <evals.json>` | 将 Anthropic `evals.json` 导入为 YAML 用例 |
-| `skill-up debug judge <input.json>` | 使用 JSON 输入调试 judge 模块 |
-| `skill-up debug report <input.json>` | 使用 JSON 输入调试 report 模块 |
+| 命令                                 | 说明                                       |
+| ------------------------------------ | ------------------------------------------ |
+| `skill-up run [path]`                | 运行评测用例并生成报告                     |
+| `skill-up validate [path]`           | 校验 `eval.yaml` 和用例文件                |
+| `skill-up list-cases [path]`         | 列出配置引用的所有用例                     |
+| `skill-up report <result.json>`      | 从已有结果生成报告                         |
+| `skill-up import <evals.json>`       | 将 Anthropic `evals.json` 导入为 YAML 用例 |
+| `skill-up debug judge <input.json>`  | 使用 JSON 输入调试 judge 模块              |
+| `skill-up debug report <input.json>` | 使用 JSON 输入调试 report 模块             |
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

Replace the Codecov badge with a self-hosted shields.io endpoint badge whose
percentage and color are computed by CI from `go test -coverprofile` and
committed back to the repo. The project no longer needs to integrate with
codecov.io, while still surfacing the real total coverage in both READMEs.

## Related issues

Closes [#28](https://github.com/alibaba/skill-up/issues/28)

## Changes

- **README.md / README.zh.md**: swap the `codecov.io` badge for a shields.io
  `endpoint` badge backed by `.github/badges/coverage.json` in this repo.
- **`.github/badges/coverage.json`** (new): shields.io endpoint payload
  (`schemaVersion`, `label`, `message`, `color`); seeded as `pending` /
  `lightgrey` until CI writes the first real value.
- **`Makefile`**: add `coverage` (runs `go test` with `-coverpkg=./...
  -coverprofile=coverage.out`) and `coverage-badge` (parses the total from
  `go tool cover -func` and rewrites `coverage.json`) targets, plus matching
  `.PHONY` entries.
- **`.github/workflows/ci.yml`**:
  - drop the `codecov/codecov-action@v5` upload step;
  - add `-coverpkg=./...` to the test invocation so the total reflects
    cross-package coverage;
  - new step computes the percentage, picks a color via a single-pass `awk`
    (`>=80` green / `>=60` yellow / else red), and rewrites `coverage.json`;
  - on `push` to `main` only, commit the refreshed badge back with
    `[skip ci]` to avoid recursive runs (PRs only compute, never write);
  - bump `permissions.contents` from `read` to `write` to allow that push.
- **Color-threshold fix**: the first iteration used `A && B || C && D`,
  which is *not* if/elif — it kept evaluating `&& color=yellow` after the
  brightgreen branch succeeded, painting 93% as yellow. Replaced with a
  single `awk` block that branches deterministically.

## Test plan

- [x] `make test` passes
- [x] `make verify` passes (fmt + vet + lint)
- [x] Manual testing steps:
  - Ran `go test -covermode=atomic -coverpkg=./internal/credential
    -coverprofile=coverage.out ./internal/credential` → parsed total via the
    new pipeline, produced `{"message":"93.0%","color":"brightgreen"}`.
  - Verified the threshold branches end-to-end with 93.0 / 75.0 / 42.0
    inputs → `brightgreen` / `yellow` / `red` respectively.
  - `make -n coverage-badge` dry-run shows the expected command chain.
  - Confirmed `coverage.out` is already covered by the existing `*.out`
    rule in `.gitignore`; no new ignore entry needed.

## Notes for reviewers

- The auto-commit step requires `contents: write`. It is scoped to
  `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so PRs
  (including from forks) never trigger a write. The commit message carries
  `[skip ci]` to prevent CI loops.
- The badge URL hard-codes `alibaba/skill-up` and the `main` branch; if the
  repository is ever renamed or the default branch changes, update both
  `README.md` and `README.zh.md`.
- `-coverpkg=./...` slightly slows the test step but is required for the
  total to mean "repo-wide coverage" rather than "per-package self-coverage";
  the e2e job is unaffected.
- shields.io caches the endpoint JSON for a few minutes via
  `raw.githubusercontent.com`, so the badge updates lag the merge by ~5
  minutes — this is expected, not a CI problem.