### PR TITLE
fix(credential): load default credentials file in run path

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -213,7 +213,7 @@ func loadCredentialsAndAgent(cmd *cobra.Command, evalCfg *config.EvalConfig) (ag
 	cliModel, _ := cmd.Flags().GetString("model")
 	cliAPIKey, _ := cmd.Flags().GetString("api-key")
 
-	resolver := credential.NewResolver("")
+	resolver := credential.NewResolver(credential.DefaultConfPath())
 	if err := resolver.Load(); err != nil {
 		return nil, nil, credential.AgentInitParams{}, fmt.Errorf("failed to load credentials: %w", err)
 	}

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -2,6 +2,7 @@ package credential
 
 import (
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/joho/godotenv"
@@ -21,6 +22,18 @@ const (
 )
 
 const apiKeyMaskLen = 4 // Length for API key masking
+
+// DefaultConfPath returns the default credentials file path,
+// ~/.skill-up/credentials.yaml. It returns "" when the home directory
+// cannot be determined, in which case the file layer is silently skipped.
+func DefaultConfPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+
+	return filepath.Join(home, ".skill-up", "credentials.yaml")
+}
 
 // Resolver resolves credentials for model providers.
 type Resolver struct {

--- a/internal/credential/credential_test.go
+++ b/internal/credential/credential_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -37,6 +38,21 @@ func TestMaskAPIKey(t *testing.T) {
 				t.Errorf("MaskAPIKey(%q) = %q, want %q", tt.key, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestDefaultConfPath(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("cannot determine home directory: %v", err)
+	}
+
+	got := DefaultConfPath()
+	want := filepath.Join(home, ".skill-up", "credentials.yaml")
+	if got != want {
+		t.Errorf("DefaultConfPath() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `skill-up run` constructed the credential resolver with a hard-coded empty `confPath` (`internal/cli/run.go:216`), so `Resolver.Load()` never read a credentials file — it only honored `--api-key`, env vars, and a `.env` in the CWD.
- This contradicted the documented `~/.skill-up/credentials.yaml` fallback in `docs/guide/writing-evals.md`, `CONTRIBUTING.md`, and `AGENTS.md`.
- Added `credential.DefaultConfPath()` returning `~/.skill-up/credentials.yaml` and passed it to `NewResolver` in the run command.

## Why

The docs advertise a persistent credentials file as a fallback, but the code path made it unreachable. Users who put keys in `~/.skill-up/credentials.yaml` saw `skill-up run` fail with missing credentials.

## Notes for reviewers

- A missing credentials file is still handled gracefully — `Resolver.Load()` logs a debug line and falls through to env vars / CLI flags — so behavior is unchanged when the file is absent.
- `DefaultConfPath()` returns `""` when the home directory cannot be determined, which `Resolver` treats as "skip the file layer".
- No doc changes needed: the docs were already correct; the code was the bug.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/credential/` (added `TestDefaultConfPath`)
- [ ] Manual: place a key in `~/.skill-up/credentials.yaml` with no `--api-key`/env var and confirm `skill-up run` resolves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)