### PR TITLE
fix(runtime/agent): stop misleading exit-code -1 noise on timeout

### DIFF
--- a/internal/agent/claude_code.go
+++ b/internal/agent/claude_code.go
@@ -319,8 +319,11 @@ func (a *ClaudeCodeAgent) buildSessionResult(ctx context.Context, rt Runtime, op
 	var finalMsg string
 	var inputTokens, outputTokens int
 
+	cleanupCtx, cleanupCancel := sessionCleanupContext(ctx)
+	defer cleanupCancel()
+
 	generatedFiles := []string{}
-	if artifactPath, err := persistSessionArtifact(ctx, rt, opts.ArtifactDir, "stdout.json", result.Stdout); err == nil {
+	if artifactPath, err := persistSessionArtifact(cleanupCtx, rt, opts.ArtifactDir, "stdout.json", result.Stdout); err == nil {
 		if opts.ArtifactDir == "" {
 			generatedFiles = append(generatedFiles, artifactPath)
 		}
@@ -328,7 +331,7 @@ func (a *ClaudeCodeAgent) buildSessionResult(ctx context.Context, rt Runtime, op
 
 	var cleanupSession func()
 	generatedFiles, cleanupSession = withDownloadedSession(
-		ctx, rt, opts.ArtifactDir, findClaudeSessionFile(ctx, rt), generatedFiles,
+		cleanupCtx, rt, opts.ArtifactDir, findClaudeSessionFile(cleanupCtx, rt), generatedFiles,
 		func(artifactPath string) {
 			t, f, inTok, outTok := parseSessionFile(artifactPath)
 			if len(t) > 0 {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -332,9 +332,12 @@ func (a *CodexAgent) buildSessionResult(
 	result ExecResult,
 	lastMessagePath string,
 ) *SessionResult {
+	cleanupCtx, cleanupCancel := sessionCleanupContext(ctx)
+	defer cleanupCancel()
+
 	generatedFiles := []string{}
 	if result.Stdout != "" {
-		if artifactPath, err := persistSessionArtifact(ctx, rt, opts.ArtifactDir, "stdout.json", result.Stdout); err == nil {
+		if artifactPath, err := persistSessionArtifact(cleanupCtx, rt, opts.ArtifactDir, "stdout.json", result.Stdout); err == nil {
 			if opts.ArtifactDir == "" {
 				generatedFiles = append(generatedFiles, artifactPath)
 			}
@@ -346,7 +349,7 @@ func (a *CodexAgent) buildSessionResult(
 
 	var cleanupSession func()
 	generatedFiles, cleanupSession = withDownloadedSession(
-		ctx, rt, opts.ArtifactDir, findCodexSessionPath(ctx, rt, streamParsed.threadID), generatedFiles,
+		cleanupCtx, rt, opts.ArtifactDir, findCodexSessionPath(cleanupCtx, rt, streamParsed.threadID), generatedFiles,
 		func(artifactPath string) {
 			sessionParsed := parseCodexSessionFile(artifactPath)
 			if len(sessionParsed.transcript) > len(streamParsed.transcript) &&
@@ -368,7 +371,7 @@ func (a *CodexAgent) buildSessionResult(
 		finalMsg = trans.FinalAssistantMessage()
 	}
 	var lastMsgCleanup func()
-	finalMsg, trans, generatedFiles, lastMsgCleanup = resolveCodexLastMessage(ctx, rt, opts.ArtifactDir, lastMessagePath, finalMsg, trans, generatedFiles)
+	finalMsg, trans, generatedFiles, lastMsgCleanup = resolveCodexLastMessage(cleanupCtx, rt, opts.ArtifactDir, lastMessagePath, finalMsg, trans, generatedFiles)
 	defer lastMsgCleanup()
 
 	return &SessionResult{

--- a/internal/agent/qodercli.go
+++ b/internal/agent/qodercli.go
@@ -126,8 +126,11 @@ func (a *QoderCLIAgent) buildSessionResult(ctx context.Context, rt Runtime, opts
 	var finalMsg string
 	var inputTokens, outputTokens int
 
+	cleanupCtx, cleanupCancel := sessionCleanupContext(ctx)
+	defer cleanupCancel()
+
 	generatedFiles := []string{}
-	if artifactPath, err := persistSessionArtifact(ctx, rt, opts.ArtifactDir, "stdout.txt", result.Stdout); err == nil {
+	if artifactPath, err := persistSessionArtifact(cleanupCtx, rt, opts.ArtifactDir, "stdout.txt", result.Stdout); err == nil {
 		if opts.ArtifactDir == "" {
 			generatedFiles = append(generatedFiles, artifactPath)
 		}
@@ -135,7 +138,7 @@ func (a *QoderCLIAgent) buildSessionResult(ctx context.Context, rt Runtime, opts
 
 	var cleanupSession func()
 	generatedFiles, cleanupSession = withDownloadedSession(
-		ctx, rt, opts.ArtifactDir, findQoderSessionFile(ctx, rt), generatedFiles,
+		cleanupCtx, rt, opts.ArtifactDir, findQoderSessionFile(cleanupCtx, rt), generatedFiles,
 		func(artifactPath string) {
 			t, f, inTok, outTok := parseSessionFile(artifactPath)
 			if len(t) > 0 {

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -5,7 +5,25 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+// sessionCleanupTimeout caps how long the post-run session-file lookup,
+// download and stdout persistence steps may run. It is independent of the
+// agent run's own timeout because those steps execute after the agent
+// process has already returned (or been killed) and must not inherit a
+// canceled run context — otherwise every Exec / DownloadFile call fires
+// against a dead ctx and logs misleading "command exited with code -1"
+// noise that hides the real timeout.
+const sessionCleanupTimeout = 30 * time.Second
+
+// sessionCleanupContext derives a context for post-run session-file
+// persistence, lookup and download. It detaches from cancellation of the
+// run context (so a timed-out agent run does not poison the cleanup) but
+// preserves context values such as the OTel trace ID.
+func sessionCleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), sessionCleanupTimeout)
+}
 
 // withDownloadedSession encapsulates the "download → register → parse" pipeline
 // shared by claude_code / qodercli / codex. It calls `apply` with the local

--- a/internal/runtime/none.go
+++ b/internal/runtime/none.go
@@ -195,12 +195,22 @@ func (r *NoneRuntime) Exec(ctx context.Context, command string, opts ExecOptions
 	span.SetAttributes(attribute.Int("process.exit_code", result.ExitCode))
 	observability.RecordRuntimeExec(ctx, result.ExitCode, time.Since(startTime).Milliseconds())
 
-	if result.ExitCode != 0 {
+	switch {
+	case result.ExitCode == -1 && ctx.Err() != nil:
+		// Process was killed because the parent context was canceled or
+		// hit its deadline. -1 is a sentinel, not a real exit code, and
+		// attaching the full command source ("exited with code -1: set
+		// -e ...") misleads readers into chasing a script-level failure.
+		logging.ErrorContextf(ctx, "command killed by context (%v); command: %s", ctx.Err(), maskCommand(command))
+		if result.Stderr != "" {
+			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
+		}
+	case result.ExitCode != 0:
 		logNonZeroExit(ctx, result.ExitCode, command)
 		if result.Stderr != "" {
 			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
 		}
-	} else if result.Stderr != "" {
+	case result.Stderr != "":
 		logging.WarnContextf(ctx, "stderr: %s", result.Stderr)
 	}
 

--- a/internal/runtime/opensandbox.go
+++ b/internal/runtime/opensandbox.go
@@ -500,18 +500,33 @@ func (r *OpenSandboxRuntime) Exec(ctx context.Context, command string, opts Exec
 
 	exec, err := r.sandbox.RunCommandWithOpts(ctx, req, nil)
 	result := executionToResult(exec)
-	if err != nil && result.ExitCode == 0 {
+	// Distinguish two failure modes that previously both surfaced as exit
+	// code -1:
+	//   (a) sandbox SDK call itself errored, or returned nil — the remote
+	//       command may never have run, and there is no real exit code to
+	//       report. Avoid the misleading "command exited with code -1: <full
+	//       script>" log; record this as a sandbox-side failure instead.
+	//   (b) remote command ran and returned a non-zero exit code — log as
+	//       before.
+	sandboxCallFailed := err != nil || exec == nil
+	if sandboxCallFailed && result.ExitCode == 0 {
 		result.ExitCode = -1
 	}
 	span.SetAttributes(attribute.Int("process.exit_code", result.ExitCode))
 	observability.RecordRuntimeExec(ctx, result.ExitCode, time.Since(startTime).Milliseconds())
 
-	if result.ExitCode != 0 {
+	switch {
+	case sandboxCallFailed:
+		logging.ErrorContextf(ctx, "opensandbox SDK call failed before a remote exit code was reported (err=%v); command: %s", err, maskCommand(command))
+		if result.Stderr != "" {
+			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
+		}
+	case result.ExitCode != 0:
 		logNonZeroExit(ctx, result.ExitCode, command)
 		if result.Stderr != "" {
 			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
 		}
-	} else if result.Stderr != "" {
+	case result.Stderr != "":
 		logging.WarnContextf(ctx, "stderr: %s", result.Stderr)
 	}
 	if err != nil {


### PR DESCRIPTION
## Summary

When an eval case timed out (e.g. claude-code waiting on a slow provider), CI logs filled up with bursts like:

```
level=ERROR msg=\"command exited with code -1: set -e\nif ! command -v 'claude' >/dev/null 2>&1; then\n  export NVM_DIR=...\"
level=ERROR msg=\"command exited with code -1: home=\$(printenv HOME); [ -n \\\"\$home\\\" ] || exit 0\nroot=\\\"\$home/.claude/projects/\$SKILL_UP_CLAUDE_WSKEY\\\"; [ -d \\\"\$root\\\" ] || exit 0\ntmp=\$(mktemp)...\"
```

which actively misled readers into thinking \`claude\` was missing or the nvm bootstrap had failed. The real cause — \`claude-code run failed: context deadline exceeded\` — was hidden at the bottom of the run.

Two compounding issues:

1. The \`ExitCode=-1\` sentinel is shared between \"process killed by ctx / signal\", \"sandbox SDK call itself failed\", and a normal non-zero exit, and the log line treated all of them identically.
2. Post-run session-file lookup / stdout persistence / download in [internal/agent/claude_code.go](internal/agent/claude_code.go), [codex.go](internal/agent/codex.go) and [qodercli.go](internal/agent/qodercli.go) reused the *same* (already canceled) run context, so they were guaranteed to be killed instantly and emit another -1 log every time.

## Fix

- **[internal/runtime/none.go](internal/runtime/none.go)** — when \`ExitCode == -1\` because \`ctx\` was canceled / hit deadline, log \`\"command killed by context (<reason>); command: <masked>\"\` instead of pretending it was a script-level non-zero exit.
- **[internal/runtime/opensandbox.go](internal/runtime/opensandbox.go)** — when the SDK call itself errored or returned a nil execution, log \`\"opensandbox SDK call failed before a remote exit code was reported (err=...); command: ...\"\` and skip the misleading full-script dump.
- **[internal/agent/session_lookup.go](internal/agent/session_lookup.go)** — add \`sessionCleanupContext(ctx)\` which derives a context via \`context.WithoutCancel\` + a fresh 30 s timeout. Used by claude_code / codex / qodercli for all post-run persistence, session-file lookup, and download steps, so a canceled run context can no longer poison cleanup.

\`ExitCode=-1\` sentinel is preserved everywhere for callers that depend on the non-zero signal — only the log lines and the cleanup context change. Trace context values are preserved via \`WithoutCancel\`.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/runtime/... ./internal/agent/...\`
- [ ] Re-run devix-acp pipeline (188855/41753939) and confirm the timeout shows up as a single \"killed by context (context deadline exceeded)\" line, with no repeating nvm-bootstrap dumps for the session-file lookup