### PR TITLE
fix(cli): make `init --config` read a source file, not a write target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- `skill-up init`: `--config <path>` now names a **source** file to read
+  rather than a write target. `init` validates the source as a skill-up
+  config and writes its raw bytes (comments preserved) to the target
+  selected by `--local` (or the default XDG path). `--local` and
+  `--config` are no longer mutually exclusive. Without `--config`, `init`
+  still writes the commented template as before. This aligns `--config`
+  with the `run`/`validate` discovery chain semantics
+  (`embed < user < project < --config`).
+
+### Added
+- `userconfig.LoadFile(path)` helper for callers that need to read and
+  validate a single config file without consulting discovery layers.
+
 ## [0.1.1] - 2026-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.2] - 2026-05-20
 
 ### Changed
 - `skill-up init`: `--config <path>` now names a **source** file to read
@@ -41,5 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project and delivers the end-to-end capability to declare eval environments,
   run cases and emit structured reports as described in [README.md](README.md).
 
+[0.1.2]: https://github.com/alibaba/skill-up/releases/tag/v0.1.2
 [0.1.1]: https://github.com/alibaba/skill-up/releases/tag/v0.1.1
 [0.1.0]: https://github.com/alibaba/skill-up/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -222,11 +222,17 @@ Missing files at the `user` and `project` layers are silently skipped; a missing
 ### Quickstart
 
 ```bash
-skill-up init              # writes ~/.config/skill-up/config.yaml (XDG-aware)
-skill-up init --local      # writes $PWD/.skill-up.yaml
-skill-up init --print      # writes the template to stdout
-skill-up init --force      # overwrite an existing file
+skill-up init                            # writes a template to ~/.config/skill-up/config.yaml (XDG-aware)
+skill-up init --local                    # writes a template to $PWD/.skill-up.yaml
+skill-up init --print                    # prints the template to stdout
+skill-up init --force                    # overwrite an existing file
+skill-up init --config foo.yaml          # reads foo.yaml, writes it to ~/.config/skill-up/config.yaml
+skill-up init --config foo.yaml --local  # reads foo.yaml, writes it to $PWD/.skill-up.yaml
 ```
+
+With `--config <path>`, `init` reads that file (validating it as a skill-up
+config) and writes its raw bytes to the target — comments and formatting are
+preserved. Without `--config`, `init` writes a commented YAML template.
 
 ### Schema
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
             text: 'Reference',
             items: [
               { text: 'CLI Reference', link: '/guide/cli-reference' },
+              { text: 'User Configuration', link: '/guide/user-config' },
               { text: 'Writing Evals', link: '/guide/writing-evals' },
               { text: 'Migrating from Anthropic', link: '/guide/migration' },
             ],
@@ -62,6 +63,7 @@ export default defineConfig({
               text: 'Reference',
               items: [
                 { text: 'CLI Reference', link: '/guide/cli-reference' },
+                { text: 'User Configuration', link: '/guide/user-config' },
                 { text: 'Migrating from Anthropic', link: '/guide/migration' },
               ],
             },
@@ -91,6 +93,7 @@ export default defineConfig({
             text: '参考',
             items: [
               { text: 'CLI 命令参考', link: '/zh/guide/cli-reference' },
+              { text: '用户配置', link: '/zh/guide/user-config' },
               { text: '编写评测配置与用例', link: '/zh/guide/writing-evals' },
               { text: '从 Anthropic 格式迁移', link: '/zh/guide/migration' },
             ],
@@ -115,6 +118,7 @@ export default defineConfig({
               text: '参考',
               items: [
                 { text: 'CLI 命令参考', link: '/zh/guide/cli-reference' },
+                { text: '用户配置', link: '/zh/guide/user-config' },
                 { text: '从 Anthropic 格式迁移', link: '/zh/guide/migration' },
               ],
             },

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -184,6 +184,44 @@ skill-up report result.json --format html --output-dir ./reports
 
 ---
 
+## skill-up init
+
+Write a skill-up user-config file. See [User Configuration](./user-config) for the discovery chain and schema.
+
+```bash
+skill-up init [flags]
+```
+
+### Flags
+
+| Flag       | Default                                            | Description                                                                                  |
+| :--------: | :-------------------------------------------------: | :-------------------------------------------------------------------------------------------: |
+| `--local`  | `false`                                            | Write target is `$PWD/.skill-up.yaml` instead of the XDG path                                |
+| `--config` | —                                                  | **Source** file to read (validated, copied verbatim with comments). Without this, a commented template is written. |
+| `--print`  | `false`                                            | Print to stdout instead of writing to disk                                                   |
+| `--force`  | `false`                                            | Overwrite an existing target                                                                 |
+
+> Note: for `init`, `--config` names the *source* to read. For every other subcommand (`run`, `validate`, …) it is the *load-path override* sitting at the top of the discovery chain.
+
+### Examples
+
+```bash
+# Write a commented template
+skill-up init                                  # -> ~/.config/skill-up/config.yaml
+skill-up init --local                          # -> ./.skill-up.yaml
+skill-up init --print                          # -> stdout
+
+# Seed from an existing config (validates, preserves comments)
+skill-up init --config ./team-config.yaml          # -> ~/.config/skill-up/config.yaml
+skill-up init --config ./team-config.yaml --local  # -> ./.skill-up.yaml
+skill-up init --config ./team-config.yaml --print  # validate & dump to stdout
+
+# Overwrite
+skill-up init --local --force
+```
+
+---
+
 ## skill-up import
 
 One-shot conversion of an Anthropic `evals.json` into skill-up's native YAML format.

--- a/docs/guide/user-config.md
+++ b/docs/guide/user-config.md
@@ -1,0 +1,165 @@
+# User Configuration
+
+skill-up auto-loads a user-config file on every invocation. It is the
+recommended place for OpenTelemetry defaults, ambient env vars, and
+per-environment `run` kwargs that you don't want to repeat on the command
+line or bake into each `eval.yaml`.
+
+This page covers what is loaded, in what order, and how to bootstrap a
+config file with `skill-up init`.
+
+---
+
+## Discovery chain
+
+Layers are merged in order of increasing precedence:
+
+```text
+embed (empty)
+  < user      (~/.config/skill-up/config.yaml, XDG-aware)
+  < project   ($PWD/.skill-up.yaml)
+  < explicit  (--config <path>)
+```
+
+| Layer      | Path                                                                                                       | Missing |
+| :--------- | :--------------------------------------------------------------------------------------------------------- | :------ |
+| `embed`    | empty `Config{}` — no vendor defaults baked in                                                              | always  |
+| `user`     | `$SKILL_EVAL_CONFIG`, else `$XDG_CONFIG_HOME/skill-up/config.yaml`, else `~/.config/skill-up/config.yaml`   | skipped |
+| `project`  | `$PWD/.skill-up.yaml`                                                                                       | skipped |
+| `explicit` | `--config <path>` passed to any command                                                                     | error   |
+
+A missing or corrupt `user`/`project` file is downgraded to a `warning:` on
+stderr — the command keeps running with whatever layers loaded. A missing or
+invalid `--config` path is a hard error.
+
+Higher-precedence layers overlay non-zero fields onto lower layers; map fields
+(`telemetry.resource_attributes`, `env`, `runtime_kwargs`) are merged key-wise
+rather than replaced wholesale.
+
+---
+
+## Schema
+
+```yaml
+schema_version: v1alpha1
+kind: SkillEvalConfig
+
+telemetry:
+  service_name: skill-up                              # OTEL_SERVICE_NAME
+  traces_exporter: otlp                               # OTEL_TRACES_EXPORTER
+  traces:
+    endpoint: http://localhost:4317                   # OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    protocol: grpc                                    # OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+  resource_attributes:                                # serialized to OTEL_RESOURCE_ATTRIBUTES
+    deployment.environment: local
+  verbose: false                                      # if true, enables OTEL_LOG_* payload capture
+
+env:                                                  # arbitrary defaults, only-if-unset
+  OTEL_EXPORTER_OTLP_HEADERS: authorization=${OTLP_TOKEN}
+
+runtime_kwargs:                                       # per-environment.type defaults for `run`
+  opensandbox:
+    base_url: http://localhost:8080
+```
+
+Semantics:
+
+- **`telemetry` and `env`** — each key maps to an `OTEL_*` (or arbitrary)
+  environment variable. Values are only applied **if the corresponding env var
+  is not already set**, so a value on the command line or in your shell
+  always wins.
+- **`${VAR}` placeholders** in `env` values are expanded from the process
+  environment at load time, so secrets stay out of the file.
+- **`runtime_kwargs`** — defaults for `run` keyed by `environment.type` (e.g.
+  `opensandbox`). `eval.yaml` values take precedence; missing keys fall back
+  here. Keys mirror the environment provider's kwargs schema.
+
+---
+
+## Bootstrapping with `skill-up init`
+
+`skill-up init` writes a config file to one of two well-known locations:
+
+```bash
+skill-up init                            # template -> ~/.config/skill-up/config.yaml
+skill-up init --local                    # template -> ./.skill-up.yaml
+skill-up init --print                    # template -> stdout
+skill-up init --force                    # overwrite an existing target
+```
+
+The default template is fully commented-out, so writing it does not change
+behavior — it just documents every supported key in one place.
+
+### Seeding from an existing config
+
+Pass `--config <source>` to use an existing YAML file as the **source**.
+`init` validates it, then writes its raw bytes (comments and formatting
+preserved) to the target chosen by `--local`:
+
+```bash
+# Copy a team-shared config to the XDG location
+skill-up init --config ./team-config.yaml
+
+# Same content, but as the project-layer file
+skill-up init --config ./team-config.yaml --local
+```
+
+`--config` and `--local` are not mutually exclusive. The `--config` flag for
+`init` is a *source* (read from); for every other subcommand (`run`,
+`validate`, ...) it is a *load-path override* and sits at the top of the
+discovery chain.
+
+### Inspecting the effective config
+
+The simplest way to see what `run` will pick up is `--print`:
+
+```bash
+# Validate and dump the file `run` will see at the explicit layer
+skill-up init --config ./team-config.yaml --print
+```
+
+---
+
+## Examples
+
+### Always export traces to a local collector
+
+`~/.config/skill-up/config.yaml`:
+
+```yaml
+schema_version: v1alpha1
+kind: SkillEvalConfig
+telemetry:
+  service_name: skill-up
+  traces_exporter: otlp
+  traces:
+    endpoint: http://localhost:4317
+    protocol: grpc
+  resource_attributes:
+    deployment.environment: local
+```
+
+Now every `skill-up run` exports traces without touching env vars.
+
+### Per-project override
+
+`./.skill-up.yaml` next to your eval suite:
+
+```yaml
+schema_version: v1alpha1
+kind: SkillEvalConfig
+runtime_kwargs:
+  opensandbox:
+    base_url: http://sandbox.internal:9090
+```
+
+This adds an `opensandbox.base_url` default for this project only — your
+`~/.config/skill-up/config.yaml` still applies elsewhere.
+
+### One-off override on the command line
+
+```bash
+skill-up run ./evals/eval.yaml --config /tmp/debug-config.yaml
+```
+
+`--config` overrides both user and project layers for this invocation.

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -184,6 +184,44 @@ skill-up report result.json --format html --output-dir ./reports
 
 ---
 
+## skill-up init
+
+写出一份 skill-up 用户配置文件。完整的加载顺序与字段说明见 [用户配置](./user-config)。
+
+```bash
+skill-up init [flags]
+```
+
+### Flags
+
+| Flag       | 默认值       | 说明                                                                                            |
+| :--------: | :----------: | :---------------------------------------------------------------------------------------------: |
+| `--local`  | `false`      | 写到 `$PWD/.skill-up.yaml` 而不是 XDG 路径                                                       |
+| `--config` | —            | **读取源**文件（先校验，再原样拷贝，注释保留）。未提供时写出带注释的模板                          |
+| `--print`  | `false`      | 输出到 stdout，而不是写盘                                                                        |
+| `--force`  | `false`      | 覆盖已存在的目标文件                                                                             |
+
+> 注意：对 `init` 子命令，`--config` 是**读取源**；对其他子命令（`run`、`validate` …），`--config` 是加载链最顶层的覆盖路径。
+
+### 示例
+
+```bash
+# 写出带注释的模板
+skill-up init                                  # -> ~/.config/skill-up/config.yaml
+skill-up init --local                          # -> ./.skill-up.yaml
+skill-up init --print                          # -> stdout
+
+# 从已有配置初始化（先校验，注释完整保留）
+skill-up init --config ./team-config.yaml          # -> ~/.config/skill-up/config.yaml
+skill-up init --config ./team-config.yaml --local  # -> ./.skill-up.yaml
+skill-up init --config ./team-config.yaml --print  # 校验后输出到 stdout
+
+# 覆盖
+skill-up init --local --force
+```
+
+---
+
 ## skill-up import
 
 将 Anthropic `evals.json` 格式的用例一次性转换为 skill-up 的原生 YAML 格式。

--- a/docs/zh/guide/user-config.md
+++ b/docs/zh/guide/user-config.md
@@ -1,0 +1,156 @@
+# 用户配置
+
+每次执行 `skill-up`，框架都会自动加载一份用户配置（user-config）。它适合存放
+OpenTelemetry 默认值、共享的环境变量、以及不想在命令行或每个 `eval.yaml` 里
+重复声明的 `run` 默认参数。
+
+本页说明加载顺序、Schema，以及如何用 `skill-up init` 落地这个文件。
+
+---
+
+## 加载顺序
+
+按优先级从低到高依次合并：
+
+```text
+embed (空)
+  < user      (~/.config/skill-up/config.yaml，遵循 XDG)
+  < project   ($PWD/.skill-up.yaml)
+  < explicit  (--config <path>)
+```
+
+| Layer      | 路径                                                                                                         | 文件缺失 |
+| :--------- | :----------------------------------------------------------------------------------------------------------- | :------- |
+| `embed`    | 空的 `Config{}`，不内嵌任何厂商默认值                                                                          | 永远存在 |
+| `user`     | `$SKILL_EVAL_CONFIG` → `$XDG_CONFIG_HOME/skill-up/config.yaml` → `~/.config/skill-up/config.yaml`            | 跳过     |
+| `project`  | `$PWD/.skill-up.yaml`                                                                                         | 跳过     |
+| `explicit` | 任意子命令的 `--config <path>`                                                                                | 报错     |
+
+`user` / `project` 层文件不存在或解析失败会降级为 stderr 上的 `warning:`，命令
+继续执行。`--config` 显式路径如果缺失或不合法则直接报错。
+
+高优先级层只**覆盖非零字段**；map 类字段（`telemetry.resource_attributes`、
+`env`、`runtime_kwargs`）按 key 逐项合并，而不是整体替换。
+
+---
+
+## Schema
+
+```yaml
+schema_version: v1alpha1
+kind: SkillEvalConfig
+
+telemetry:
+  service_name: skill-up                              # OTEL_SERVICE_NAME
+  traces_exporter: otlp                               # OTEL_TRACES_EXPORTER
+  traces:
+    endpoint: http://localhost:4317                   # OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    protocol: grpc                                    # OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+  resource_attributes:                                # 序列化为 OTEL_RESOURCE_ATTRIBUTES
+    deployment.environment: local
+  verbose: false                                      # 为 true 时开启 OTEL_LOG_* 详细载荷
+
+env:                                                  # 任意环境变量，only-if-unset
+  OTEL_EXPORTER_OTLP_HEADERS: authorization=${OTLP_TOKEN}
+
+runtime_kwargs:                                       # 按 environment.type 提供 run 的默认 kwargs
+  opensandbox:
+    base_url: http://localhost:8080
+```
+
+语义：
+
+- **`telemetry` 与 `env`**：每个 key 对应一个 `OTEL_*` 或自定义环境变量，**仅在
+  对应环境变量未被设置时才会注入**——命令行或 shell 中已有的值优先。
+- **`env` 中的 `${VAR}`** 在加载时从当前进程环境展开，密钥不会被写进文件本身。
+- **`runtime_kwargs`**：`run` 命令按 `environment.type`（如 `opensandbox`）查找
+  默认值。`eval.yaml` 中显式给的值优先；未提供的字段在这里兜底。Key 的形态与
+  对应 environment provider 的 kwargs 一致。
+
+---
+
+## 用 `skill-up init` 初始化
+
+`skill-up init` 会把配置文件写到两个标准位置之一：
+
+```bash
+skill-up init                            # 模板 -> ~/.config/skill-up/config.yaml
+skill-up init --local                    # 模板 -> ./.skill-up.yaml
+skill-up init --print                    # 模板 -> stdout
+skill-up init --force                    # 覆盖已存在的目标
+```
+
+默认模板里所有可选字段都是注释掉的——直接写入不会改变任何行为，它的价值是把
+所有支持的字段集中在一份带注释的文件里。
+
+### 从已有配置初始化
+
+`--config <source>` 指定一个已存在的 YAML 作为**源文件**：`init` 会先把它当作
+skill-up 配置进行校验，然后将原始字节（注释、格式都保留）写到由 `--local`
+决定的目标位置：
+
+```bash
+# 把团队共享的配置拷到 XDG 路径
+skill-up init --config ./team-config.yaml
+
+# 同样的内容，作为项目级配置
+skill-up init --config ./team-config.yaml --local
+```
+
+`--config` 和 `--local` 可以同时使用。对 `init` 子命令，`--config` 是**读取
+源**；而对其他子命令（`run` / `validate` 等），`--config` 是加载链最顶层的
+**覆盖路径**。
+
+### 查看会被加载的内容
+
+最简单的方式是 `--print`：
+
+```bash
+# 校验并把 run 实际看到的 explicit 层内容输出到 stdout
+skill-up init --config ./team-config.yaml --print
+```
+
+---
+
+## 示例
+
+### 默认导出 trace 到本地 collector
+
+`~/.config/skill-up/config.yaml`：
+
+```yaml
+schema_version: v1alpha1
+kind: SkillEvalConfig
+telemetry:
+  service_name: skill-up
+  traces_exporter: otlp
+  traces:
+    endpoint: http://localhost:4317
+    protocol: grpc
+  resource_attributes:
+    deployment.environment: local
+```
+
+之后每次 `skill-up run` 都会自动导出 trace，不用再手动设置环境变量。
+
+### 项目级覆盖
+
+在评测目录旁放一份 `./.skill-up.yaml`：
+
+```yaml
+schema_version: v1alpha1
+kind: SkillEvalConfig
+runtime_kwargs:
+  opensandbox:
+    base_url: http://sandbox.internal:9090
+```
+
+这样只对当前项目生效，`~/.config/skill-up/config.yaml` 在其他地方依然有效。
+
+### 命令行一次性覆盖
+
+```bash
+skill-up run ./evals/eval.yaml --config /tmp/debug-config.yaml
+```
+
+`--config` 在本次执行中覆盖 user 和 project 两层。

--- a/e2e/userconfig_test.go
+++ b/e2e/userconfig_test.go
@@ -31,12 +31,12 @@ func TestCLI_InitPrint(t *testing.T) {
 
 func TestCLI_InitWriteAndForce(t *testing.T) {
 	t.Parallel()
-	Cover(t, "skill-up init writes XDG file")
+	Cover(t, "skill-up init --local write + --force overwrite")
 
 	tmp := t.TempDir()
-	target := filepath.Join(tmp, "config.yaml")
+	target := filepath.Join(tmp, ".skill-up.yaml")
 
-	r1 := RunSimple(t, "init", "--config", target)
+	r1 := Run(t, RunConfig{WorkDir: tmp}, "init", "--local")
 	if r1.ExitCode != 0 {
 		t.Fatalf("first write failed: %s", r1.Stderr)
 	}
@@ -44,14 +44,40 @@ func TestCLI_InitWriteAndForce(t *testing.T) {
 		t.Fatalf("target not created: %v", err)
 	}
 
-	r2 := RunSimple(t, "init", "--config", target)
+	r2 := Run(t, RunConfig{WorkDir: tmp}, "init", "--local")
 	if r2.ExitCode == 0 {
 		t.Fatalf("second write without --force should fail; stdout: %s", r2.Stdout)
 	}
 
-	r3 := RunSimple(t, "init", "--config", target, "--force")
+	r3 := Run(t, RunConfig{WorkDir: tmp}, "init", "--local", "--force")
 	if r3.ExitCode != 0 {
 		t.Fatalf("force write failed: %s", r3.Stderr)
+	}
+}
+
+func TestCLI_InitConfigSourceCopied(t *testing.T) {
+	t.Parallel()
+	Cover(t, "skill-up init --config <source> --local")
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "source.yaml")
+	sourceContent := "# my custom header\nschema_version: v1alpha1\nkind: SkillEvalConfig\ntelemetry:\n  service_name: from-source\n"
+	if err := os.WriteFile(source, []byte(sourceContent), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	r := Run(t, RunConfig{WorkDir: tmp}, "init", "--config", source, "--local")
+	if r.ExitCode != 0 {
+		t.Fatalf("init --config <source> --local failed: %s", r.Stderr)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tmp, ".skill-up.yaml"))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	// The source bytes must round-trip verbatim — comments and all.
+	if string(got) != sourceContent {
+		t.Errorf("target content mismatch\nwant:\n%s\ngot:\n%s", sourceContent, got)
 	}
 }
 
@@ -89,12 +115,17 @@ func TestCLI_UserConfigRoundTrip(t *testing.T) {
 	Cover(t, "skill-up --config round-trip")
 
 	tmp := t.TempDir()
-	cfgPath := filepath.Join(tmp, "config.yaml")
 
-	// Generate then re-load via --config against a real eval.yaml.
-	if r := RunSimple(t, "init", "--config", cfgPath); r.ExitCode != 0 {
-		t.Fatalf("init: %s", r.Stderr)
+	// Write a template into a temp workdir via --local, then re-load that
+	// file via --config when running validate against a real eval.yaml.
+	if r := Run(t, RunConfig{WorkDir: tmp}, "init", "--local"); r.ExitCode != 0 {
+		t.Fatalf("init --local: %s", r.Stderr)
 	}
+	cfgPath := filepath.Join(tmp, ".skill-up.yaml")
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("expected %s to exist: %v", cfgPath, err)
+	}
+
 	examplesDir := getExamplesDir()
 	evalPath := filepath.Join(examplesDir, "eval.yaml")
 	r := RunSimple(t, "--config", cfgPath, "validate", evalPath)

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,18 +17,22 @@ const (
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Write a skill-up user-config template",
-	Long: `Write a commented YAML template for the skill-up user-config file.
+	Short: "Write a skill-up user-config file",
+	Long: `Write a skill-up user-config file.
 
-Default target is the XDG path ($XDG_CONFIG_HOME/skill-up/config.yaml or
-~/.config/skill-up/config.yaml). Use --local to write $PWD/.skill-up.yaml,
-or --config <path> to choose an explicit target. --print writes to stdout
-instead.`,
+Without --config, writes a commented YAML template. With --config <path>,
+reads that file (validating it as a skill-up config) and writes its raw
+contents to the target, preserving comments and formatting.
+
+Target selection:
+  default        $XDG_CONFIG_HOME/skill-up/config.yaml (or ~/.config/...)
+  --local        $PWD/.skill-up.yaml
+  --print        stdout (no file written)`,
 	RunE: runInit,
 }
 
 func init() {
-	initCmd.Flags().Bool("local", false, "Write to $PWD/.skill-up.yaml")
+	initCmd.Flags().Bool("local", false, "Write target is $PWD/.skill-up.yaml instead of the XDG path")
 	initCmd.Flags().Bool("print", false, "Print to stdout instead of writing to disk")
 	initCmd.Flags().Bool("force", false, "Overwrite an existing file")
 	rootCmd.AddCommand(initCmd)
@@ -39,20 +42,19 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	local, _ := cmd.Flags().GetBool("local")
 	printOnly, _ := cmd.Flags().GetBool("print")
 	force, _ := cmd.Flags().GetBool("force")
-	configPath, _ := cmd.Flags().GetString(configFlagName)
+	sourcePath, _ := cmd.Flags().GetString(configFlagName)
 
-	if local && configPath != "" {
-		return errors.New("--local and --config are mutually exclusive")
+	content, err := resolveInitContent(sourcePath)
+	if err != nil {
+		return err
 	}
-
-	content := renderInitTemplate(userconfig.Redact(userconfig.Config{}))
 
 	if printOnly {
 		_, err := fmt.Fprint(cmd.OutOrStdout(), content)
 		return err
 	}
 
-	target, err := resolveInitTarget(configPath, local)
+	target, err := resolveInitTarget(local)
 	if err != nil {
 		return err
 	}
@@ -71,35 +73,45 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func resolveInitTarget(configPath string, local bool) (string, error) {
-	switch {
-	case configPath != "":
-		return configPath, nil
-	case local:
+// resolveInitContent returns the bytes to write. If sourcePath is empty the
+// embedded template is used. Otherwise the source is loaded and validated as
+// a skill-up config, and its raw bytes are returned so comments/formatting
+// survive.
+func resolveInitContent(sourcePath string) (string, error) {
+	if sourcePath == "" {
+		return initTemplateContent, nil
+	}
+	if _, err := userconfig.LoadFile(sourcePath); err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(sourcePath) //nolint:gosec // path is user-supplied by design
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func resolveInitTarget(local bool) (string, error) {
+	if local {
 		wd, err := os.Getwd()
 		if err != nil {
 			return "", err
 		}
 		return filepath.Join(wd, userconfig.ProjectConfigFile), nil
-	default:
-		if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-			return filepath.Join(xdg, userconfig.UserConfigDir, userconfig.UserConfigFile), nil
-		}
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".config", userconfig.UserConfigDir, userconfig.UserConfigFile), nil
 	}
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, userconfig.UserConfigDir, userconfig.UserConfigFile), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", userconfig.UserConfigDir, userconfig.UserConfigFile), nil
 }
 
-// renderInitTemplate produces a commented YAML template covering every
-// top-level section. All optional knobs are commented out so the default
-// behavior is a no-op.
-func renderInitTemplate(_ userconfig.Config) string {
-	return initTemplateContent
-}
-
+// initTemplateContent is the commented YAML template used by `init` when no
+// --config source is given. All optional knobs are commented out so the
+// default behavior is a no-op.
 const initTemplateContent = `# skill-up user config -- auto-loaded by every command.
 # Discovery order (lowest to highest precedence):
 #   embedded defaults < ~/.config/skill-up/config.yaml < $PWD/.skill-up.yaml < --config

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -54,7 +54,11 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	target, err := resolveInitTarget(local)
+	resolveTarget := resolveUserConfigTarget
+	if local {
+		resolveTarget = resolveProjectConfigTarget
+	}
+	target, err := resolveTarget()
 	if err != nil {
 		return err
 	}
@@ -91,14 +95,20 @@ func resolveInitContent(sourcePath string) (string, error) {
 	return string(data), nil
 }
 
-func resolveInitTarget(local bool) (string, error) {
-	if local {
-		wd, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(wd, userconfig.ProjectConfigFile), nil
+// resolveProjectConfigTarget returns $PWD/.skill-up.yaml — the per-project
+// config layer.
+func resolveProjectConfigTarget() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
 	}
+	return filepath.Join(wd, userconfig.ProjectConfigFile), nil
+}
+
+// resolveUserConfigTarget returns the XDG-aware user config path
+// ($XDG_CONFIG_HOME/skill-up/config.yaml, falling back to
+// ~/.config/skill-up/config.yaml).
+func resolveUserConfigTarget() (string, error) {
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		return filepath.Join(xdg, userconfig.UserConfigDir, userconfig.UserConfigFile), nil
 	}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -51,49 +51,121 @@ func TestInit_Print(t *testing.T) {
 	}
 }
 
-func TestInit_WriteAndForce(t *testing.T) {
-	t.Parallel()
+func TestInit_LocalWritesTemplate(t *testing.T) {
 	tmp := t.TempDir()
-	target := filepath.Join(tmp, "config.yaml")
+	t.Chdir(tmp)
 
 	cmd := newInitCmdForTest()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"--config", target})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--local"})
 	if err := cmd.Execute(); err != nil {
-		t.Fatalf("first write: %v", err)
+		t.Fatalf("init --local: %v", err)
 	}
-	if _, err := os.Stat(target); err != nil {
-		t.Fatalf("target not created: %v", err)
+	target := filepath.Join(tmp, ".skill-up.yaml")
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != initTemplateContent {
+		t.Errorf("expected template content, got:\n%s", got)
 	}
 
+	// Second write without --force must fail.
 	cmd2 := newInitCmdForTest()
-	cmd2.SetArgs([]string{"--config", target})
 	cmd2.SetOut(&bytes.Buffer{})
 	cmd2.SetErr(&bytes.Buffer{})
 	cmd2.SilenceUsage = true
 	cmd2.SilenceErrors = true
+	cmd2.SetArgs([]string{"--local"})
 	if err := cmd2.Execute(); err == nil {
 		t.Fatal("expected error on second write without --force")
 	}
 
+	// With --force, succeeds.
 	cmd3 := newInitCmdForTest()
-	cmd3.SetArgs([]string{"--config", target, "--force"})
 	cmd3.SetOut(&bytes.Buffer{})
+	cmd3.SetArgs([]string{"--local", "--force"})
 	if err := cmd3.Execute(); err != nil {
 		t.Fatalf("force write: %v", err)
 	}
 }
 
-func TestInit_LocalConflictsWithConfig(t *testing.T) {
+func TestInit_ConfigSourceCopiedToLocal(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	source := filepath.Join(tmp, "source.yaml")
+	sourceContent := "# my custom comment\nschema_version: v1alpha1\nkind: SkillEvalConfig\ntelemetry:\n  service_name: custom\n"
+	if err := os.WriteFile(source, []byte(sourceContent), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	cmd := newInitCmdForTest()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", source, "--local"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	target := filepath.Join(tmp, ".skill-up.yaml")
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	// Source bytes must be preserved verbatim (comments and all).
+	if string(got) != sourceContent {
+		t.Errorf("target content mismatch\nwant:\n%s\ngot:\n%s", sourceContent, got)
+	}
+}
+
+func TestInit_ConfigSourcePrint(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "source.yaml")
+	sourceContent := "schema_version: v1alpha1\nkind: SkillEvalConfig\n# kept comment\n"
+	if err := os.WriteFile(source, []byte(sourceContent), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	cmd := newInitCmdForTest()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--config", source, "--print"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init --print: %v", err)
+	}
+	if out.String() != sourceContent {
+		t.Errorf("print output mismatch\nwant:\n%s\ngot:\n%s", sourceContent, out.String())
+	}
+}
+
+func TestInit_ConfigSourceMissing(t *testing.T) {
 	t.Parallel()
 	cmd := newInitCmdForTest()
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
-	cmd.SetArgs([]string{"--local", "--config", "/tmp/x.yaml"})
+	cmd.SetArgs([]string{"--config", "/definitely/does/not/exist.yaml", "--print"})
 	if err := cmd.Execute(); err == nil {
-		t.Fatal("expected mutual exclusion error")
+		t.Fatal("expected error for missing source")
+	}
+}
+
+func TestInit_ConfigSourceInvalid(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "bad.yaml")
+	if err := os.WriteFile(source, []byte("not: [valid yaml"), 0o600); err != nil {
+		t.Fatalf("write bad source: %v", err)
+	}
+	cmd := newInitCmdForTest()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"--config", source, "--print"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for invalid source")
 	}
 }

--- a/internal/userconfig/loader.go
+++ b/internal/userconfig/loader.go
@@ -154,6 +154,24 @@ func resolveProjectConfigPath(opts LoadOptions) string {
 	return filepath.Join(dir, ProjectConfigFile)
 }
 
+// LoadFile reads and validates a single config file. Returns an error if the
+// file is missing, unparseable, or fails Validate. Unlike LoadEffective it
+// does not consult any discovery layers — it is meant for callers (e.g. the
+// `init` subcommand) that want to vet a specific file in isolation.
+func LoadFile(path string) (Config, error) {
+	cfg, ok, err := loadConfigFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	if !ok {
+		return Config{}, fmt.Errorf("config file not found: %s", path)
+	}
+	if err := cfg.Validate(); err != nil {
+		return Config{}, fmt.Errorf("validate %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
 func loadConfigFile(path string) (Config, bool, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // path is user-supplied by design
 	if err != nil {


### PR DESCRIPTION
## Summary

- `skill-up init --config <path>` previously meant "write the template to this path", which conflicted with the same flag's load-source meaning on `run`/`validate`/etc. Now it consistently names a **source**: `init` validates that file as a skill-up config and writes its raw bytes (comments preserved) to the target selected by `--local` (default: XDG `~/.config/skill-up/config.yaml`).
- `--local` and `--config` are no longer mutually exclusive.
- The `run`/`validate` discovery chain (`embed < user < project < --config`) is unchanged.
- Adds `userconfig.LoadFile(path)` to validate a single config file without consulting discovery layers.

### Behavior matrix

| Command | Effect |
|---|---|
| `skill-up init` | template -> `~/.config/skill-up/config.yaml` *(unchanged)* |
| `skill-up init --local` | template -> `./.skill-up.yaml` *(unchanged)* |
| `skill-up init --config foo.yaml` | reads `foo.yaml`, writes to `~/.config/skill-up/config.yaml` |
| `skill-up init --config foo.yaml --local` | reads `foo.yaml`, writes to `./.skill-up.yaml` |
| `skill-up init --config foo.yaml --print` | validates and prints `foo.yaml` to stdout |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] New tests in `internal/cli/init_test.go` cover: template write via `--local`, `--config` source copied verbatim (comments preserved), `--config` + `--print`, missing-source error, invalid-YAML-source error
- [x] Removed obsolete `TestInit_WriteAndForce` / `TestInit_LocalConflictsWithConfig` (asserted the old `--config = write target` semantics)
- [ ] Manual sanity: `skill-up init --config foo.yaml --local` produces a `.skill-up.yaml` that `skill-up run` then picks up via the project layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)