### PR TITLE
docs(changelog): add 0.1.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.2] - 2026-05-20
+## [0.1.2] - 2026-05-21
+
+### Added
+- `skill-upper`: a bundled meta-skill under `skills/skill-upper/` that
+  drives `skill-up` to scaffold and run evals for a target skill end-to-end.
+- `--runtime` CLI flag on `skill-up run` overrides `environment.type`
+  (`none` / `opensandbox`) without editing `eval.yaml`. The override path
+  also rejects `--runtime none` when `network_policy` is configured, so
+  network isolation cannot be silently dropped.
+- `network_policy` for sandbox egress isolation: `deny_all` blocks all
+  egress; `allow_declared` plus `environment.allowed_egress` permits only
+  the listed FQDN / wildcard domains. Validated against the runtime type
+  (rejected on `environment.type: none`) and against URL-shaped entries.
+- Mocked MCP servers (`mode: mocked`): provisioned as generated stdio
+  servers via the existing agent MCP install path. Supports the built-in
+  `filesystem` mock and arbitrary `tool_responses` via `config_ref`.
+- `userconfig.LoadFile(path)` helper for callers that need to read and
+  validate a single config file without consulting discovery layers.
+- Coverage badge generation in CI and README badge links.
 
 ### Changed
 - `skill-up init`: `--config <path>` now names a **source** file to read
@@ -16,10 +34,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still writes the commented template as before. This aligns `--config`
   with the `run`/`validate` discovery chain semantics
   (`embed < user < project < --config`).
+- OpenSandbox directory uploads now use the SDK's batch `UploadFiles` in
+  chunks of 128 files (one multipart request per chunk) instead of N
+  concurrent single-file uploads. `file_transfer_parallelism` now only
+  governs directory **download**.
+- OpenSandbox SDK upgraded to v1.0.1.
+- Default eval workspace is now placed **alongside** the skill directory
+  (`<skill>-workspace/` as a sibling of `<skill>/`) instead of inside it,
+  matching the Anthropic eval layout convention. Docs and `--output-dir`
+  default updated accordingly.
 
-### Added
-- `userconfig.LoadFile(path)` helper for callers that need to read and
-  validate a single config file without consulting discovery layers.
+### Fixed
+- `context.git.checkout` is now actually honored by the fixture loader.
+  Previously the field parsed but was never read, so cases ran on the
+  fixture's current branch. The loader now runs `git switch` (or creates
+  the branch on an unborn HEAD) before inline `context.files` and
+  `apply_diff`; a missing branch in a committed fixture fails loudly,
+  and branch names are validated against shell injection.
+- `skill-up run` credential resolver now reads the documented
+  `~/.skill-up/credentials.yaml`. Previously the run path passed an
+  empty config path, so only `--api-key`, env vars, and a CWD `.env`
+  were consulted.
+- Post-run session lookup, stdout download, and last-message resolution
+  (claude_code / codex / qodercli) no longer inherit the canceled run
+  context, so a timed-out eval case no longer produces two bursts of
+  misleading "command exited with code -1: ..." log lines for the
+  cleanup steps. A fresh 30s `sessionCleanupTimeout` is used instead.
+- `runtime/none`: when a command is killed because its context was
+  canceled or timed out, the log now reads "command killed by context"
+  instead of pretending to be a real `-1` exit with the full bootstrap
+  script attached.
+- `runtime/opensandbox`: when the OpenSandbox SDK call itself fails
+  (network error, nil execution, timeout before a remote exit code is
+  reported), the log now identifies it as an SDK-level failure and
+  skips the misleading script dump. Genuine remote non-zero exits keep
+  the existing log.
 
 ## [0.1.1] - 2026-05-15
 


### PR DESCRIPTION
## Summary

Round out the `[0.1.2]` entry in `CHANGELOG.md` so it covers all 14 user-visible commits landed since v0.1.1, not just `#37` (which added its own line when it merged).

New entries added under 0.1.2:

**Added** — skill-upper meta-skill (#17), `--runtime` override flag (#25), `network_policy` egress isolation (#16), mocked MCP servers (#15), coverage badge (#26).

**Changed** — batch `UploadFiles` for directory uploads (#23), OpenSandbox SDK v1.0.1 (#18), default eval workspace as sibling of skill dir (#27).

**Fixed** — `context.git.checkout` actually applied (#30), `run` credential resolver loads `~/.skill-up/credentials.yaml` (#29), post-run cleanup uses fresh ctx so timeouts stop emitting misleading `-1` exits, `runtime/none` distinguishes ctx-kill from real non-zero exit, `runtime/opensandbox` distinguishes SDK failure from remote non-zero exit.

Date bumped from `2026-05-20` to `2026-05-21`, matching the planned tag day. No code changes — `CHANGELOG.md` only.

## Test plan

- [x] `git diff` shows only `CHANGELOG.md` changes
- [x] Pre-commit hook (`go vet` + `revive` + `golangci-lint`) passes
- [x] Each bullet traces to a merged PR / commit in the v0.1.1..HEAD range
- [ ] Tag `v0.1.2` on the merged commit once this PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)