### PR TITLE
chore: replace instances of 'SkillEvalConfig' with 'SkillUpConfig' and update related environment variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-05-21
+
+### Changed
+- `kind: SkillEvalConfig` renamed to `kind: SkillUpConfig` in all user config files.
+  Existing configs using the old kind value must be updated.
+- `$SKILL_EVAL_CONFIG` environment variable renamed to `$SKILL_UP_CONFIG`.
+  Scripts and CI pipelines that set `SKILL_EVAL_CONFIG` must switch to `SKILL_UP_CONFIG`.
+
 ## [0.1.2] - 2026-05-21
 
 ### Added
@@ -90,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project and delivers the end-to-end capability to declare eval environments,
   run cases and emit structured reports as described in [README.md](README.md).
 
+[0.2.0]: https://github.com/alibaba/skill-up/releases/tag/v0.2.0
 [0.1.2]: https://github.com/alibaba/skill-up/releases/tag/v0.1.2
 [0.1.1]: https://github.com/alibaba/skill-up/releases/tag/v0.1.1
 [0.1.0]: https://github.com/alibaba/skill-up/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -213,12 +213,12 @@ skill-up auto-loads an optional user-level config that supplies default OpenTele
 embed (empty) < user (~/.config/skill-up/config.yaml) < project ($PWD/.skill-up.yaml) < explicit (--config)
 ```
 
-| Source     | Path                                                                                                      |
-| ---------- | --------------------------------------------------------------------------------------------------------- |
-| `embed`    | empty `Config{}` — no vendor defaults baked in                                                            |
-| `user`     | `$SKILL_EVAL_CONFIG`, else `$XDG_CONFIG_HOME/skill-up/config.yaml`, else `~/.config/skill-up/config.yaml` |
-| `project`  | `$PWD/.skill-up.yaml`                                                                                     |
-| `explicit` | `--config <path>` (must exist)                                                                            |
+| Source     | Path                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------- |
+| `embed`    | empty `Config{}` — no vendor defaults baked in                                                          |
+| `user`     | `$SKILL_UP_CONFIG`, else `$XDG_CONFIG_HOME/skill-up/config.yaml`, else `~/.config/skill-up/config.yaml` |
+| `project`  | `$PWD/.skill-up.yaml`                                                                                   |
+| `explicit` | `--config <path>` (must exist)                                                                          |
 
 Missing files at the `user` and `project` layers are silently skipped; a missing `--config` path is a hard error. A corrupt config at any layer also fails the run.
 
@@ -241,7 +241,7 @@ preserved. Without `--config`, `init` writes a commented YAML template.
 
 ```yaml
 schema_version: v1alpha1
-kind: SkillEvalConfig
+kind: SkillUpConfig
 
 telemetry:
   service_name: skill-up                              # OTEL_SERVICE_NAME

--- a/docs/guide/user-config.md
+++ b/docs/guide/user-config.md
@@ -21,12 +21,12 @@ embed (empty)
   < explicit  (--config <path>)
 ```
 
-| Layer      | Path                                                                                                       | Missing |
-| :--------- | :--------------------------------------------------------------------------------------------------------- | :------ |
-| `embed`    | empty `Config{}` — no vendor defaults baked in                                                              | always  |
-| `user`     | `$SKILL_EVAL_CONFIG`, else `$XDG_CONFIG_HOME/skill-up/config.yaml`, else `~/.config/skill-up/config.yaml`   | skipped |
-| `project`  | `$PWD/.skill-up.yaml`                                                                                       | skipped |
-| `explicit` | `--config <path>` passed to any command                                                                     | error   |
+| Layer      | Path                                                                                                    | Missing |
+| :--------- | :------------------------------------------------------------------------------------------------------ | :------ |
+| `embed`    | empty `Config{}` — no vendor defaults baked in                                                          | always  |
+| `user`     | `$SKILL_UP_CONFIG`, else `$XDG_CONFIG_HOME/skill-up/config.yaml`, else `~/.config/skill-up/config.yaml` | skipped |
+| `project`  | `$PWD/.skill-up.yaml`                                                                                   | skipped |
+| `explicit` | `--config <path>` passed to any command                                                                 | error   |
 
 A missing or corrupt `user`/`project` file is downgraded to a `warning:` on
 stderr — the command keeps running with whatever layers loaded. A missing or
@@ -42,7 +42,7 @@ rather than replaced wholesale.
 
 ```yaml
 schema_version: v1alpha1
-kind: SkillEvalConfig
+kind: SkillUpConfig
 
 telemetry:
   service_name: skill-up                              # OTEL_SERVICE_NAME
@@ -128,7 +128,7 @@ skill-up init --config ./team-config.yaml --print
 
 ```yaml
 schema_version: v1alpha1
-kind: SkillEvalConfig
+kind: SkillUpConfig
 telemetry:
   service_name: skill-up
   traces_exporter: otlp
@@ -147,7 +147,7 @@ Now every `skill-up run` exports traces without touching env vars.
 
 ```yaml
 schema_version: v1alpha1
-kind: SkillEvalConfig
+kind: SkillUpConfig
 runtime_kwargs:
   opensandbox:
     base_url: http://sandbox.internal:9090

--- a/docs/zh/guide/user-config.md
+++ b/docs/zh/guide/user-config.md
@@ -19,12 +19,12 @@ embed (空)
   < explicit  (--config <path>)
 ```
 
-| Layer      | 路径                                                                                                         | 文件缺失 |
-| :--------- | :----------------------------------------------------------------------------------------------------------- | :------- |
-| `embed`    | 空的 `Config{}`，不内嵌任何厂商默认值                                                                          | 永远存在 |
-| `user`     | `$SKILL_EVAL_CONFIG` → `$XDG_CONFIG_HOME/skill-up/config.yaml` → `~/.config/skill-up/config.yaml`            | 跳过     |
-| `project`  | `$PWD/.skill-up.yaml`                                                                                         | 跳过     |
-| `explicit` | 任意子命令的 `--config <path>`                                                                                | 报错     |
+| Layer      | 路径                                                                                            | 文件缺失 |
+| :--------- | :---------------------------------------------------------------------------------------------- | :------- |
+| `embed`    | 空的 `Config{}`，不内嵌任何厂商默认值                                                           | 永远存在 |
+| `user`     | `$SKILL_UP_CONFIG` → `$XDG_CONFIG_HOME/skill-up/config.yaml` → `~/.config/skill-up/config.yaml` | 跳过     |
+| `project`  | `$PWD/.skill-up.yaml`                                                                           | 跳过     |
+| `explicit` | 任意子命令的 `--config <path>`                                                                  | 报错     |
 
 `user` / `project` 层文件不存在或解析失败会降级为 stderr 上的 `warning:`，命令
 继续执行。`--config` 显式路径如果缺失或不合法则直接报错。
@@ -38,7 +38,7 @@ embed (空)
 
 ```yaml
 schema_version: v1alpha1
-kind: SkillEvalConfig
+kind: SkillUpConfig
 
 telemetry:
   service_name: skill-up                              # OTEL_SERVICE_NAME
@@ -120,7 +120,7 @@ skill-up init --config ./team-config.yaml --print
 
 ```yaml
 schema_version: v1alpha1
-kind: SkillEvalConfig
+kind: SkillUpConfig
 telemetry:
   service_name: skill-up
   traces_exporter: otlp
@@ -139,7 +139,7 @@ telemetry:
 
 ```yaml
 schema_version: v1alpha1
-kind: SkillEvalConfig
+kind: SkillUpConfig
 runtime_kwargs:
   opensandbox:
     base_url: http://sandbox.internal:9090

--- a/e2e/userconfig_test.go
+++ b/e2e/userconfig_test.go
@@ -19,7 +19,7 @@ func TestCLI_InitPrint(t *testing.T) {
 	}
 	for _, want := range []string{
 		"schema_version: v1alpha1",
-		"kind: SkillEvalConfig",
+		"kind: SkillUpConfig",
 		"telemetry:",
 		"# runtime_kwargs:",
 	} {
@@ -61,7 +61,7 @@ func TestCLI_InitConfigSourceCopied(t *testing.T) {
 
 	tmp := t.TempDir()
 	source := filepath.Join(tmp, "source.yaml")
-	sourceContent := "# my custom header\nschema_version: v1alpha1\nkind: SkillEvalConfig\ntelemetry:\n  service_name: from-source\n"
+	sourceContent := "# my custom header\nschema_version: v1alpha1\nkind: SkillUpConfig\ntelemetry:\n  service_name: from-source\n"
 	if err := os.WriteFile(source, []byte(sourceContent), 0o600); err != nil {
 		t.Fatalf("write source: %v", err)
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -128,7 +128,7 @@ const initTemplateContent = `# skill-up user config -- auto-loaded by every comm
 # Use ` + "`skill-up init --print`" + ` to regenerate this template.
 
 schema_version: v1alpha1
-kind: SkillEvalConfig
+kind: SkillUpConfig
 
 # OpenTelemetry defaults. Each key maps to a well-known OTEL_* env var.
 # Values are only applied if the corresponding env var is not already set.

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -23,7 +23,7 @@ func TestInit_TemplateContainsAllSections(t *testing.T) {
 	t.Parallel()
 	want := []string{
 		"schema_version: v1alpha1",
-		"kind: SkillEvalConfig",
+		"kind: SkillUpConfig",
 		"telemetry:",
 		"traces:",
 		"# resource_attributes:",
@@ -95,7 +95,7 @@ func TestInit_ConfigSourceCopiedToLocal(t *testing.T) {
 	t.Chdir(tmp)
 
 	source := filepath.Join(tmp, "source.yaml")
-	sourceContent := "# my custom comment\nschema_version: v1alpha1\nkind: SkillEvalConfig\ntelemetry:\n  service_name: custom\n"
+	sourceContent := "# my custom comment\nschema_version: v1alpha1\nkind: SkillUpConfig\ntelemetry:\n  service_name: custom\n"
 	if err := os.WriteFile(source, []byte(sourceContent), 0o600); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestInit_ConfigSourcePrint(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	source := filepath.Join(tmp, "source.yaml")
-	sourceContent := "schema_version: v1alpha1\nkind: SkillEvalConfig\n# kept comment\n"
+	sourceContent := "schema_version: v1alpha1\nkind: SkillUpConfig\n# kept comment\n"
 	if err := os.WriteFile(source, []byte(sourceContent), 0o600); err != nil {
 		t.Fatalf("write source: %v", err)
 	}

--- a/internal/runtime/opensandbox_test.go
+++ b/internal/runtime/opensandbox_test.go
@@ -73,7 +73,7 @@ func TestOpenSandboxCreateUsesSDKOptions(t *testing.T) {
 		SandboxTimeout: 2 * time.Minute,
 		Env:            map[string]string{"RUNTIME_ENV": "1"},
 		Entrypoint:     []string{"tail", "-f", "/dev/null"},
-		Metadata:       map[string]string{"skill_eval": "true"},
+		Metadata:       map[string]string{"skill_up": "true"},
 		Kwargs: map[string]string{
 			"base_url":                "https://sandbox.example.test",
 			"extensions":              `{"template":"basic"}`,

--- a/internal/userconfig/apply_test.go
+++ b/internal/userconfig/apply_test.go
@@ -98,10 +98,10 @@ func TestMergeKwargs_NilEval(t *testing.T) {
 	}
 }
 
-func TestApplyEnv_PassesThroughSkillEvalEnvFromUserEnvMap(t *testing.T) {
+func TestApplyEnv_PassesThroughSkillUpEnvFromUserEnvMap(t *testing.T) {
 	// Project-routing attribute envs are not in the schema -- downstream
 	// vendor bundles set them through the generic env: map. Verify pass-through.
-	const key = "SKILL_EVAL_OTEL_RESOURCE_ATTRIBUTES"
+	const key = "SKILL_UP_OTEL_RESOURCE_ATTRIBUTES"
 	t.Setenv(key, "")
 	_ = os.Unsetenv(key)
 

--- a/internal/userconfig/loader.go
+++ b/internal/userconfig/loader.go
@@ -1,7 +1,7 @@
 // Discovery layers for user config (lowest to highest precedence):
 //
 //  1. embed     — the empty Config{} (no vendor defaults baked in).
-//  2. user      — $SKILL_EVAL_CONFIG, else $XDG_CONFIG_HOME/skill-up/config.yaml,
+//  2. user      — $SKILL_UP_CONFIG, else $XDG_CONFIG_HOME/skill-up/config.yaml,
 //                 else ~/.config/skill-up/config.yaml. Missing = silent skip.
 //  3. project   — $WorkingDir/.skill-up.yaml. Missing = silent skip.
 //  4. explicit  — opts.ExplicitPath. Missing = ERROR.
@@ -22,7 +22,7 @@ import (
 )
 
 // ConfigEnvVar overrides the user-layer config path.
-const ConfigEnvVar = "SKILL_EVAL_CONFIG"
+const ConfigEnvVar = "SKILL_UP_CONFIG"
 
 // ProjectConfigFile is the per-project config file name (in WorkingDir).
 const ProjectConfigFile = ".skill-up.yaml"

--- a/skills/skill-upper/SKILL.md
+++ b/skills/skill-upper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-upper
-description: 'Set up, run, and interpret Agent Skill evaluations (evals) with the skill-up CLI / 使用 skill-up CLI 给 Agent Skill 搭建和运行评测. Use when the user asks to evaluate, test, regress, or verify a Skill; add evals or cases; write eval.yaml/case.yaml; run skill-up run/validate/list-cases/report/import/init; or migrate from Anthropic evals.json. Handles Skill discovery, evals scaffolding, judge authoring, credentials, user config, validation, runs, and reports.'
+description: "Set up, run, and interpret Agent Skill evaluations (evals) with the skill-up CLI / 使用 skill-up CLI 给 Agent Skill 搭建和运行评测. Use when the user asks to evaluate, test, regress, or verify a Skill; add evals or cases; write eval.yaml/case.yaml; run skill-up run/validate/list-cases/report/import/init; or migrate from Anthropic evals.json. Handles Skill discovery, evals scaffolding, judge authoring, credentials, user config, validation, runs, and reports."
 ---
 
 # use-skill-up-cli
@@ -99,7 +99,7 @@ skill-up init --print
 skill-up init --force
 ```
 
-Precedence (low → high): embedded empty defaults < user config < project `.skill-up.yaml` < `--config`. `SKILL_EVAL_CONFIG` can point at the user config file (env var name is historical). See the upstream README "User config".
+Precedence (low → high): embedded empty defaults < user config < project `.skill-up.yaml` < `--config`. `SKILL_UP_CONFIG` can point at the user config file (env var name is historical). See the upstream README "User config".
 
 ### Step 1: Locate the target Skill
 
@@ -158,17 +158,17 @@ For `opensandbox`, also ensure `OPENSANDBOX_API_KEY` (and related env) as needed
 skill-up run <skill-root>/evals/eval.yaml
 ```
 
-| Scenario | Command |
-|---|---|
-| Subset | `--include-case-name "basic-*"` |
-| Exclude | `--exclude-case-name "*-flaky"` |
-| HTML report | `--format html` |
-| Engine override | `--engine codex --model openai/gpt-4` |
-| Parallelism | `--parallelism 4` (1–256) |
-| Anthropic JSON | `--auto` |
-| N rounds | `--iteration 3` |
-| Auto-append after last iteration | `--iteration 0` (default behavior) |
-| Verbose | `-v`, `-vv` |
+| Scenario                         | Command                               |
+| -------------------------------- | ------------------------------------- |
+| Subset                           | `--include-case-name "basic-*"`       |
+| Exclude                          | `--exclude-case-name "*-flaky"`       |
+| HTML report                      | `--format html`                       |
+| Engine override                  | `--engine codex --model openai/gpt-4` |
+| Parallelism                      | `--parallelism 4` (1–256)             |
+| Anthropic JSON                   | `--auto`                              |
+| N rounds                         | `--iteration 3`                       |
+| Auto-append after last iteration | `--iteration 0` (default behavior)    |
+| Verbose                          | `-v`, `-vv`                           |
 
 Exit `0` = all passed; `1` = failure or error — suitable for CI.
 
@@ -183,17 +183,17 @@ Summarize: pass rate and timing; for failures, case id, assertion `text`, and `e
 
 ## Command quick reference
 
-| Command | Purpose |
-|---|---|
-| `skill-up validate <eval.yaml>` | Validate before `run`. |
-| `skill-up list-cases <eval.yaml>` | List cases. |
-| `skill-up run [eval.yaml]` | Run evals. |
-| `skill-up run --auto` | Run from `evals/evals.json`. |
-| `skill-up report <result.json> --format html` | Re-render reports. |
-| `skill-up import <evals.json>` | Convert Anthropic format to YAML. |
-| `skill-up init` | Write user-config template. |
-| `skill-up debug judge <input.json>` | Debug judge. |
-| `skill-up debug report <input.json>` | Debug report. |
+| Command                                       | Purpose                           |
+| --------------------------------------------- | --------------------------------- |
+| `skill-up validate <eval.yaml>`               | Validate before `run`.            |
+| `skill-up list-cases <eval.yaml>`             | List cases.                       |
+| `skill-up run [eval.yaml]`                    | Run evals.                        |
+| `skill-up run --auto`                         | Run from `evals/evals.json`.      |
+| `skill-up report <result.json> --format html` | Re-render reports.                |
+| `skill-up import <evals.json>`                | Convert Anthropic format to YAML. |
+| `skill-up init`                               | Write user-config template.       |
+| `skill-up debug judge <input.json>`           | Debug judge.                      |
+| `skill-up debug report <input.json>`          | Debug report.                     |
 
 Full flags: `references/cli.md`.
 

--- a/skills/skill-upper/references/cli.md
+++ b/skills/skill-upper/references/cli.md
@@ -14,25 +14,25 @@ skill-up run [path] [flags]
 
 ### 参数
 
-| 参数 | 说明 |
-| --- | --- |
+| 参数   | 说明                                                             |
+| ------ | ---------------------------------------------------------------- |
 | `path` | `eval.yaml` 的路径。省略时默认在当前目录下查找 `evals/eval.yaml` |
 
 ### Flags
 
-| Flag | 默认 | 说明 |
-| --- | --- | --- |
-| `--auto` | `false` | 自动检测 `evals/` 目录，支持直接消费 Anthropic `evals.json` |
-| `--include-case-name` | — | 只运行匹配的用例（glob，可多次） |
-| `--exclude-case-name` | — | 排除匹配的用例（glob，可多次） |
-| `--format` | — | 附加报告格式：`junit` / `html`（可多次）。`result.json` 始终写入；`--format junit` 生成 `report.xml`；`--format html` 生成 `report.html`；`--format json` 对 `result.json` 为冗余 |
-| `--output-dir` | eval.yaml 同级目录 | 报告和产物的输出目录 |
-| `--iteration` | `0`（auto） | 总运行次数。`0` = 自动：在最后一个已有 `iteration-N/` 之后追加一轮；正整数 = 显式运行 N 轮，产物写入 `iteration-1/` … `iteration-N/` |
-| `--engine` | 配置中的值 | 覆盖 Engine 名称 |
-| `--model` | 配置中的值 | 覆盖模型（格式：`provider/name`） |
-| `--parallelism` | 配置中的值 | 覆盖 `cases.parallelism`，临时调整用例并行数，取值 1–256 |
-| `--api-key` | — | 传入 API Key（优先级高于环境变量） |
-| `-v, --verbose` | `0` | 日志详细程度：`info` 默认；`-v` 为 `debug`；`-vv` / `--verbose=2` 为 `trace` |
+| Flag                  | 默认               | 说明                                                                                                                                                                              |
+| --------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--auto`              | `false`            | 自动检测 `evals/` 目录，支持直接消费 Anthropic `evals.json`                                                                                                                       |
+| `--include-case-name` | —                  | 只运行匹配的用例（glob，可多次）                                                                                                                                                  |
+| `--exclude-case-name` | —                  | 排除匹配的用例（glob，可多次）                                                                                                                                                    |
+| `--format`            | —                  | 附加报告格式：`junit` / `html`（可多次）。`result.json` 始终写入；`--format junit` 生成 `report.xml`；`--format html` 生成 `report.html`；`--format json` 对 `result.json` 为冗余 |
+| `--output-dir`        | eval.yaml 同级目录 | 报告和产物的输出目录                                                                                                                                                              |
+| `--iteration`         | `0`（auto）        | 总运行次数。`0` = 自动：在最后一个已有 `iteration-N/` 之后追加一轮；正整数 = 显式运行 N 轮，产物写入 `iteration-1/` … `iteration-N/`                                              |
+| `--engine`            | 配置中的值         | 覆盖 Engine 名称                                                                                                                                                                  |
+| `--model`             | 配置中的值         | 覆盖模型（格式：`provider/name`）                                                                                                                                                 |
+| `--parallelism`       | 配置中的值         | 覆盖 `cases.parallelism`，临时调整用例并行数，取值 1–256                                                                                                                          |
+| `--api-key`           | —                  | 传入 API Key（优先级高于环境变量）                                                                                                                                                |
+| `-v, --verbose`       | `0`                | 日志详细程度：`info` 默认；`-v` 为 `debug`；`-vv` / `--verbose=2` 为 `trace`                                                                                                      |
 
 ### 退出码
 
@@ -96,10 +96,10 @@ skill-up list-cases [path to eval.yaml]
 skill-up report <path to result.json> [flags]
 ```
 
-| Flag | 默认 | 说明 |
-| --- | --- | --- |
-| `--format` | `json` | `json` / `junit` / `html`（可多次） |
-| `--output-dir` | result.json 同级 | 输出目录 |
+| Flag           | 默认             | 说明                                |
+| -------------- | ---------------- | ----------------------------------- |
+| `--format`     | `json`           | `json` / `junit` / `html`（可多次） |
+| `--output-dir` | result.json 同级 | 输出目录                            |
 
 ```bash
 skill-up report result.json --format html
@@ -116,8 +116,8 @@ skill-up report result.json --format json --format junit --format html --output-
 skill-up import <evals.json> [flags]
 ```
 
-| Flag | 默认 | 说明 |
-| --- | --- | --- |
+| Flag       | 默认            | 说明     |
+| ---------- | --------------- | -------- |
 | `--output` | evals.json 同级 | 输出目录 |
 
 `import` 与 `run --auto` 的区别：`import` 是一次性格式转换；`run --auto` 运行时直接读 `evals.json`，不落 YAML。
@@ -132,14 +132,14 @@ skill-up import <evals.json> [flags]
 skill-up init [flags]
 ```
 
-| Flag | 说明 |
-| --- | --- |
-| `--local` | 写入 `$PWD/.skill-up.yaml`（与 `--config` 互斥） |
-| `--print` | 打印模板到 stdout，不写文件 |
-| `--force` | 覆盖已存在文件 |
-| `--config <path>` | 显式目标路径（需与 `--local` 二选一） |
+| Flag              | 说明                                             |
+| ----------------- | ------------------------------------------------ |
+| `--local`         | 写入 `$PWD/.skill-up.yaml`（与 `--config` 互斥） |
+| `--print`         | 打印模板到 stdout，不写文件                      |
+| `--force`         | 覆盖已存在文件                                   |
+| `--config <path>` | 显式目标路径（需与 `--local` 二选一）            |
 
-默认路径：`$XDG_CONFIG_HOME/skill-up/config.yaml` 或 `~/.config/skill-up/config.yaml`。发现链中还支持环境变量 `SKILL_EVAL_CONFIG` 指向用户配置文件。
+默认路径：`$XDG_CONFIG_HOME/skill-up/config.yaml` 或 `~/.config/skill-up/config.yaml`。发现链中还支持环境变量 `SKILL_UP_CONFIG` 指向用户配置文件。
 
 ---
 


### PR DESCRIPTION
## Summary

Replace all occurrences of the old product name `SkillEvalConfig` with `SkillUpConfig`, and rename the related environment variable `SKILL_EVAL_CONFIG` to `SKILL_UP_CONFIG` for consistency with the `skill-up` project name.

## Related issues

<!-- Closes #<issue-number> -->

## Changes

- Replace `SkillEvalConfig` → `SkillUpConfig` in config kind field across YAML templates, docs, and tests
- Rename env var `SKILL_EVAL_CONFIG` → `SKILL_UP_CONFIG` in loader, docs, and CLI references
- Rename metadata key `skill_eval` → `skill_up` in opensandbox test
- Rename test function `TestApplyEnv_PassesThroughSkillEvalEnvFromUserEnvMap` → `TestApplyEnv_PassesThroughSkillUpEnvFromUserEnvMap`
- Update README, docs (en + zh), and SKILL.md references

## Test plan

- [x] `make test` passes
- [x] `make verify` passes (fmt + vet + lint)

## Notes for reviewers

Pure rename / find-and-replace — no logic changes.