### PR TITLE
fix(claude_code): also write ANTHROPIC_AUTH_TOKEN for Bearer-auth proxies

### DIFF
--- a/internal/agent/claude_code.go
+++ b/internal/agent/claude_code.go
@@ -102,6 +102,15 @@ func (a *ClaudeCodeAgent) Run(ctx context.Context, rt Runtime, opts ExecOptions,
 	logging.DebugContextf(ctx, "Session ID: %s", sessionID)
 
 	envVars := a.credentialEnvVars(credential.EnvAnthropicAPIKey, credential.EnvAnthropicBaseURL)
+	// Some Anthropic-compatible proxies (e.g. internal anthropic-proxy
+	// gateways) only validate `Authorization: Bearer <token>` and do not
+	// recognise the `x-api-key` header. The Anthropic SDK switches to
+	// Bearer when ANTHROPIC_AUTH_TOKEN is set, and the official Anthropic
+	// API also accepts Bearer, so writing both env vars covers both
+	// flavours without forcing operators to maintain two credentials.
+	if a.Cfg.APIKey != "" {
+		envVars[credential.EnvAnthropicAuthToken] = a.Cfg.APIKey
+	}
 	envVars["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
 	envVars["IS_SANDBOX"] = "1"
 	if observability.TracingEnabled() {

--- a/internal/agent/claude_code_test.go
+++ b/internal/agent/claude_code_test.go
@@ -175,6 +175,42 @@ func TestClaudeCodeEffectiveModelName_PassesThroughExplicitModel(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeRun_WritesBothAnthropicAuthEnvVars(t *testing.T) {
+	t.Parallel()
+
+	rt := &claudeCodeTestRuntime{
+		workspace: t.TempDir(),
+		execResult: runtime.ExecResult{
+			Stdout:   "OK\n",
+			ExitCode: 0,
+		},
+	}
+	ag := NewClaudeCodeAgent(Config{
+		APIKey:    "sk-test-token",
+		BaseURL:   "https://anthropic-proxy.example.com",
+		ModelName: "claude-sonnet-4-6",
+	})
+
+	if _, err := ag.Run(context.Background(), rt, ExecOptions{}, []transcript.Message{{
+		Role:    transcript.RoleUser,
+		Content: "Reply OK.",
+		Turn:    1,
+	}}); err != nil {
+		t.Fatalf("run claude-code: %v", err)
+	}
+
+	// Both vars must be present so internal anthropic-proxy gateways that
+	// only validate Authorization: Bearer (e.g. ducky /v1/anthropic-proxy)
+	// authenticate, while keeping x-api-key compatibility for the official
+	// Anthropic endpoint and any proxy that prefers it.
+	if got := rt.lastExecEnv[credential.EnvAnthropicAPIKey]; got != "sk-test-token" {
+		t.Fatalf("%s = %q, want sk-test-token", credential.EnvAnthropicAPIKey, got)
+	}
+	if got := rt.lastExecEnv[credential.EnvAnthropicAuthToken]; got != "sk-test-token" {
+		t.Fatalf("%s = %q, want sk-test-token", credential.EnvAnthropicAuthToken, got)
+	}
+}
+
 func TestClaudeCodeRun_EnablesTelemetryAndPropagatesTraceContext(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://collector:4318/v1/traces")
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "http/protobuf")

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -17,6 +17,7 @@ const (
 	EnvOpenAIAPIKey             = "OPENAI_API_KEY" //nolint:gosec // false positive: constant name, not a credential
 	EnvOpenAIBaseURL            = "OPENAI_BASE_URL"
 	EnvAnthropicAPIKey          = "ANTHROPIC_API_KEY" //nolint:gosec // false positive: constant name, not a credential
+	EnvAnthropicAuthToken       = "ANTHROPIC_AUTH_TOKEN" //nolint:gosec // false positive: constant name, not a credential
 	EnvAnthropicBaseURL         = "ANTHROPIC_BASE_URL"
 	EnvQoderPersonalAccessToken = "QODER_PERSONAL_ACCESS_TOKEN" //nolint:gosec // false positive: constant name, not a credential
 )

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -16,7 +16,7 @@ import (
 const (
 	EnvOpenAIAPIKey             = "OPENAI_API_KEY" //nolint:gosec // false positive: constant name, not a credential
 	EnvOpenAIBaseURL            = "OPENAI_BASE_URL"
-	EnvAnthropicAPIKey          = "ANTHROPIC_API_KEY" //nolint:gosec // false positive: constant name, not a credential
+	EnvAnthropicAPIKey          = "ANTHROPIC_API_KEY"    //nolint:gosec // false positive: constant name, not a credential
 	EnvAnthropicAuthToken       = "ANTHROPIC_AUTH_TOKEN" //nolint:gosec // false positive: constant name, not a credential
 	EnvAnthropicBaseURL         = "ANTHROPIC_BASE_URL"
 	EnvQoderPersonalAccessToken = "QODER_PERSONAL_ACCESS_TOKEN" //nolint:gosec // false positive: constant name, not a credential


### PR DESCRIPTION
## Problem

Some Anthropic-compatible proxies (typically internal `anthropic-proxy` gateways) only validate `Authorization: Bearer <token>` and reject the `x-api-key` header that the Anthropic SDK sends when only `ANTHROPIC_API_KEY` is configured.

Concretely, running `skill-up run --engine claude_code --base-url https://<internal-anthropic-proxy>/v1/anthropic-proxy --api-key <token> ...` against such a proxy fails every case with:

```
Failed to authenticate. API Error: 401 get token from header error
```

even though the token is valid — the SDK is sending `x-api-key`, the proxy only inspects `Authorization`.

## Fix

The Anthropic SDK switches to `Authorization: Bearer` when `ANTHROPIC_AUTH_TOKEN` is set, and the official Anthropic API also accepts Bearer. Writing both env vars in `ClaudeCodeAgent.Run` covers both proxy flavours without forcing operators to maintain two credentials or branch on proxy type.

Concrete changes:

- `internal/credential/credential.go` — add `EnvAnthropicAuthToken = "ANTHROPIC_AUTH_TOKEN"` constant alongside the existing `EnvAnthropicAPIKey` / `EnvAnthropicBaseURL`.
- `internal/agent/claude_code.go` — in `Run`, populate `ANTHROPIC_AUTH_TOKEN` alongside `ANTHROPIC_API_KEY` whenever `Cfg.APIKey` is set.
- `internal/agent/claude_code_test.go` — new test `TestClaudeCodeRun_WritesBothAnthropicAuthEnvVars` asserts both env vars land in the exec env.

## Why both, not "switch to AUTH_TOKEN"

Setting both is safe: `ANTHROPIC_AUTH_TOKEN` takes precedence in the SDK (sends Bearer), and the official Anthropic endpoint accepts both header forms. Switching solely to `AUTH_TOKEN` would risk regressions for any proxy / SDK consumer that only inspects `x-api-key`.

## Verified

- `go test ./internal/agent/... ./internal/credential/...` passes locally.
- End-to-end: applied the same change in our component layer (`skill-up` CI component) and observed the upstream call go from `401 get token from header error` → `200` against the proxy in question, confirming Bearer auth now works.

## Scope

Smallest possible change. No public API change. Only adds an extra env var on the claude_code Run path.