### PR TITLE
feat(runtime): add docker runtime for local container-isolated evals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,6 +350,43 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  e2e-docker:
+    name: E2E (docker runtime)
+    runs-on: ubuntu-latest
+    # Container lifecycle + image pull on a clean runner; comfortably under
+    # 15 min in practice but leave headroom for Docker Hub rate-limit retries.
+    timeout-minutes: 20
+    # No API keys / LLM credentials needed: these tests drive the docker
+    # runtime against a real daemon directly, no agent or model in the loop.
+    # That also means they run on fork PRs, unlike the other two e2e jobs.
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Verify docker is available
+        # ubuntu-latest runners ship docker pre-installed and running; this
+        # makes the dependency explicit so the failure mode is obvious if
+        # GitHub ever changes the image.
+        run: |
+          docker version
+          docker info
+
+      - name: Pre-pull base image
+        # Pre-pulling outside the test binary keeps the per-test timeouts
+        # tight and surfaces registry / rate-limit issues as their own step
+        # rather than a misleading test failure.
+        run: docker pull alpine:3.20
+
+      - name: Run docker integration tests
+        # `docker_integration` is the build tag added in internal/runtime/
+        # docker_integration_test.go. Tests skip cleanly if the daemon is
+        # missing, so this command is also safe to run locally.
+        run: go test -tags docker_integration -timeout 600s -count=1 -v ./internal/runtime/
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,54 @@ jobs:
         # missing, so this command is also safe to run locally.
         run: go test -tags docker_integration -timeout 600s -count=1 -v ./internal/runtime/
 
+  e2e-docker-full:
+    name: E2E (docker runtime, full LLM)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check secret availability
+        id: secrets
+        env:
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+        run: |
+          if [ -z "$DASHSCOPE_API_KEY" ]; then
+            echo "::notice::Skipping docker full e2e: DASHSCOPE_API_KEY not provisioned (likely a fork PR)."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-go@v6
+        if: steps.secrets.outputs.available == 'true'
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Pre-pull Docker image
+        if: steps.secrets.outputs.available == 'true'
+        run: docker pull node:22
+
+      - name: Run docker full e2e
+        if: steps.secrets.outputs.available == 'true'
+        run: go test -tags e2e -timeout 1800s -count=1 -v -run TestAgent_ClaudeCode_DockerRuntime ./e2e
+        env:
+          SKILL_UP_FULL_E2E: "1"
+          SKILL_UP_E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-docker-full-artifacts
+          ANTHROPIC_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          ANTHROPIC_BASE_URL: https://dashscope.aliyuncs.com/apps/anthropic
+          ANTHROPIC_MODEL: qwen3.6-plus
+
+      - name: Upload docker full e2e artifacts
+        if: always() && steps.secrets.outputs.available == 'true' && hashFiles('e2e-docker-full-artifacts/**') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-docker-full-workspaces
+          path: e2e-docker-full-artifacts/
+          if-no-files-found: ignore
+          retention-days: 14
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/docs/guide/writing-evals.md
+++ b/docs/guide/writing-evals.md
@@ -63,7 +63,7 @@ schema_version: v1alpha1          # Fixed value, required
 
 # ========== 2. Runtime environment ==========
 environment:
-  type: none                      # none / opensandbox
+  type: none                      # none / opensandbox / docker
 
 # ========== 3. MCP servers ==========
 mcp:
@@ -185,6 +185,7 @@ Environment-variable references support both `${VAR}` and full-value `$VAR` form
 | :-----------: | :-----------------------------------------------: | :-----------------------------------------: |
 | `none`        | Plain-text I/O, no filesystem dependencies        | Command routing, Q&A, text generation       |
 | `opensandbox` | Requires a remote sandbox service                  | Code review, project scaffolding, scripting |
+| `docker`      | Local container isolation, no remote dependency    | Custom toolchains, reproducible CI, offline |
 
 > **Tip:** if your Skill does not touch the filesystem, `none` avoids sandbox provisioning and is significantly faster.
 
@@ -217,6 +218,37 @@ Common fields:
 | `kwargs.extensions` | OpenSandbox extension config as a JSON string. |
 | `kwargs.request_timeout_seconds` | Request timeout for the OpenSandbox SDK. |
 | `kwargs.file_transfer_parallelism` | Concurrency for directory download. |
+
+#### Docker configuration
+
+When `environment.type: docker` is used, the agent runs inside a local Docker container. This provides container-level isolation (filesystem, process, network) without any remote service dependency.
+
+**Prerequisites:** a working `docker` CLI on PATH and a running Docker daemon. The runtime does not pull images automatically — run `docker pull <image>` beforehand.
+
+```yaml
+environment:
+  type: docker
+  image: node:22                    # Required — must be pre-pulled locally
+  workspace_mount: /workspace       # Default: /workspace
+  env:
+    NPM_CONFIG_REGISTRY: https://registry.npmmirror.com
+  setup_steps:
+    - run: npm install -g typescript
+  entrypoint: ["sleep", "infinity"] # Override container entrypoint (default: sleep infinity)
+```
+
+Common fields:
+
+| Field | Description |
+| --- | --- |
+| `image` | **Required.** Docker image name. Must be available locally (pre-pull with `docker pull`). |
+| `workspace_mount` | Workspace path inside the container; defaults to `/workspace`. Must be absolute. |
+| `env` | Environment variables injected into container commands. |
+| `setup_steps` | Init commands executed inside the container after it starts. |
+| `entrypoint` | Override the container's ENTRYPOINT. Defaults to `["sleep", "infinity"]`. |
+| `network_policy` | `deny_all` creates the container with `--network=none` (no network access). `allow_declared` is not yet supported — use `opensandbox` if you need FQDN-level egress filtering. |
+
+> **Tip:** Docker runtime is a good fit for evaluations that need custom system packages, specific language runtimes, or offline/air-gapped environments. For remote sandboxing with managed infrastructure, use `opensandbox` instead.
 
 ---
 

--- a/docs/zh/guide/writing-evals.md
+++ b/docs/zh/guide/writing-evals.md
@@ -63,7 +63,7 @@ schema_version: v1alpha1          # 固定值，不可省略
 
 # ========== 2. 运行环境 ==========
 environment:
-  type: none                      # 支持 none / opensandbox
+  type: none                      # 支持 none / opensandbox / docker
 
 # ========== 3. MCP 工具 ==========
 mcp:
@@ -185,6 +185,7 @@ tool_responses:
 | :-----------: | :----------------------------: | :------------------------------: |
 | `none`        | 纯文本 I/O，无文件系统依赖      | 命令路由、知识问答、文本生成     |
 | `opensandbox` | 需要远程沙箱服务                | 代码审查、项目生成、脚本执行     |
+| `docker`      | 本地容器隔离，无需远程服务       | 自定义工具链、可复现 CI、离线环境 |
 
 > **建议**：如果你的 Skill 不涉及文件操作，使用 `none` 可以省去沙箱准备时间。
 
@@ -217,6 +218,37 @@ environment:
 | `kwargs.extensions` | JSON 字符串形式的 OpenSandbox 扩展配置 |
 | `kwargs.request_timeout_seconds` | OpenSandbox SDK 请求超时时间 |
 | `kwargs.file_transfer_parallelism` | 目录下载并发度 |
+
+#### Docker 配置
+
+使用 `environment.type: docker` 时，Agent 在本地 Docker 容器中运行，提供容器级别的隔离（文件系统、进程、网络），无需任何远程服务。
+
+**前置条件：** 需要 `docker` CLI 在 PATH 中，且 Docker daemon 正在运行。runtime 不会自动拉取镜像，请提前执行 `docker pull <image>`。
+
+```yaml
+environment:
+  type: docker
+  image: node:22                    # 必填 — 需提前拉取到本地
+  workspace_mount: /workspace       # 默认：/workspace
+  env:
+    NPM_CONFIG_REGISTRY: https://registry.npmmirror.com
+  setup_steps:
+    - run: npm install -g typescript
+  entrypoint: ["sleep", "infinity"] # 覆盖容器 entrypoint（默认：sleep infinity）
+```
+
+常用配置项：
+
+| 字段 | 说明 |
+| --- | --- |
+| `image` | **必填。** Docker 镜像名称，需在本地可用（使用 `docker pull` 预拉取） |
+| `workspace_mount` | 容器内工作区路径，默认 `/workspace`，必须为绝对路径 |
+| `env` | 注入容器命令执行环境的变量 |
+| `setup_steps` | 容器启动后执行的初始化命令 |
+| `entrypoint` | 覆盖容器的 ENTRYPOINT，默认 `["sleep", "infinity"]` |
+| `network_policy` | `deny_all` 以 `--network=none` 创建容器（无网络访问）；`allow_declared` 暂不支持，需要 FQDN 级别出口过滤请使用 `opensandbox` |
+
+> **建议：** Docker runtime 适合需要自定义系统包、特定语言运行时、或离线/隔离环境的评测。如需远程托管沙箱，请使用 `opensandbox`。
 
 ---
 

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -876,6 +876,117 @@ report:
 	}
 }
 
+// TestAgent_ClaudeCode_DockerRuntime exercises the claude_code engine inside a
+// local Docker container. This is the full-pipeline e2e for the docker runtime:
+// evaluator → docker create/start → npm install claude-code → agent.Run inside
+// container → docker cp results → judge → result.json.
+func TestAgent_ClaudeCode_DockerRuntime(t *testing.T) {
+	skipIfNotFullE2E(t)
+
+	if out, err := exec.Command("docker", "info").CombinedOutput(); err != nil {
+		t.Skipf("docker daemon not available: %v\n%s", err, out)
+	}
+
+	modelAPIKey := os.Getenv("ANTHROPIC_API_KEY")
+	if modelAPIKey == "" {
+		t.Skip("ANTHROPIC_API_KEY not set, skipping claude_code docker test")
+	}
+	modelBaseURL := os.Getenv("ANTHROPIC_BASE_URL")
+	if modelBaseURL == "" {
+		t.Skip("ANTHROPIC_BASE_URL not set, skipping claude_code docker test")
+	}
+	modelName := os.Getenv("ANTHROPIC_MODEL")
+	if modelName == "" {
+		t.Skip("ANTHROPIC_MODEL not set, skipping claude_code docker test")
+	}
+
+	evalDir := t.TempDir()
+	writeFile(t, filepath.Join(evalDir, "SKILL.md"), "# ClaudeCode Docker E2E\n")
+	writeFile(t, filepath.Join(evalDir, "evals", "cases", "ok.yaml"), `id: ok
+title: ClaudeCode Docker smoke
+input:
+  prompt: Reply with exactly "hello world" and nothing else.
+constraints:
+  timeout_seconds: 600
+  max_turns: 1
+expect:
+  must_not_contain:
+    - __skill_up_forbidden__
+`)
+
+	evalPath := filepath.Join(evalDir, "evals", "eval.yaml")
+	writeFile(t, evalPath, `schema_version: v1alpha1
+environment:
+  type: docker
+  image: node:22
+  workspace_mount: /workspace
+mcp:
+  servers: []
+skills: []
+engine:
+  name: claude_code
+  model:
+    provider: anthropic
+    name: `+modelName+`
+cases:
+  files:
+    - evals/cases/ok.yaml
+  defaults:
+    timeout_seconds: 600
+    max_turns: 1
+  parallelism: 1
+  retry_policy:
+    max_retries: 0
+benchmark:
+  enabled: false
+judge:
+  type: rule_based
+  rule_based:
+    must_contain:
+      - "hello"
+report:
+  formats: [json]
+  artifacts: [transcript]
+`)
+
+	outputDir := t.TempDir()
+	preserveWorkspaceArtifacts(t, outputDir)
+	result := Run(t, RunConfig{
+		Timeout: 10 * 60e9,
+		Env: []string{
+			"ANTHROPIC_API_KEY=" + modelAPIKey,
+			"ANTHROPIC_BASE_URL=" + modelBaseURL,
+		},
+	}, "run", evalPath, "--output-dir", outputDir)
+
+	if result.ExitCode == ExitCodeTimeout {
+		t.Skip("claude_code docker run timed out")
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("claude_code docker run failed: exit=%d\nstdout=%s\nstderr=%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	resultPath := filepath.Join(outputDir, "iteration-1", "result.json")
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("failed to read result.json: %v", err)
+	}
+	if !strings.Contains(string(data), `"engine_name": "claude_code"`) {
+		t.Fatalf("result.json missing engine_name claude_code:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), `"status": "PASS"`) {
+		t.Logf("result.json (LLM may not match expect checks):\n%s", string(data))
+	}
+	responsePath := filepath.Join(outputDir, "iteration-1", "ok", "with_skill", "outputs", "response.md")
+	response, err := os.ReadFile(responsePath)
+	if err != nil {
+		t.Fatalf("failed to read response.md: %v", err)
+	}
+	if strings.TrimSpace(string(response)) == "" {
+		t.Fatalf("response.md is empty")
+	}
+}
+
 // TestAgent_ClaudeCode_WithAPIKey tests claude-code with real API key.
 func TestAgent_ClaudeCode_WithAPIKey(t *testing.T) {
 	t.Parallel()

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -920,6 +920,8 @@ environment:
   type: docker
   image: node:22
   workspace_mount: /workspace
+  setup_steps:
+    - run: npm install -g --include=optional @anthropic-ai/claude-code
 mcp:
   servers: []
 skills: []

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -920,8 +920,6 @@ environment:
   type: docker
   image: node:22
   workspace_mount: /workspace
-  setup_steps:
-    - run: npm install -g --include=optional @anthropic-ai/claude-code
 mcp:
   servers: []
 skills: []

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -578,8 +578,16 @@ func applyRuntimeTypeOverride(evalCfg *config.EvalConfig, cmd *cobra.Command) er
 	if value == "none" && evalCfg.Environment.NetworkPolicy != "" {
 		return fmt.Errorf("--runtime none is incompatible with network_policy %q (none cannot enforce network isolation)", evalCfg.Environment.NetworkPolicy)
 	}
-	if value == "docker" && strings.TrimSpace(evalCfg.Environment.Image) == "" {
-		return errors.New("--runtime docker requires environment.image to be set in the eval config")
+	if value == "docker" {
+		if strings.TrimSpace(evalCfg.Environment.Image) == "" {
+			return errors.New("--runtime docker requires environment.image to be set in the eval config")
+		}
+		if mount := strings.TrimSpace(evalCfg.Environment.WorkspaceMount); mount != "" && !path.IsAbs(mount) {
+			return fmt.Errorf("--runtime docker requires environment.workspace_mount to be absolute, got %q", mount)
+		}
+		if policy := strings.TrimSpace(strings.ToLower(evalCfg.Environment.NetworkPolicy)); policy == "allow_declared" {
+			return errors.New("--runtime docker does not support network_policy=allow_declared (use deny_all or run on opensandbox)")
+		}
 	}
 	evalCfg.Environment.Type = value
 	return nil

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -578,6 +578,9 @@ func applyRuntimeTypeOverride(evalCfg *config.EvalConfig, cmd *cobra.Command) er
 	if value == "none" && evalCfg.Environment.NetworkPolicy != "" {
 		return fmt.Errorf("--runtime none is incompatible with network_policy %q (none cannot enforce network isolation)", evalCfg.Environment.NetworkPolicy)
 	}
+	if value == "docker" && strings.TrimSpace(evalCfg.Environment.Image) == "" {
+		return fmt.Errorf("--runtime docker requires environment.image to be set in the eval config")
+	}
 	evalCfg.Environment.Type = value
 	return nil
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -579,7 +579,7 @@ func applyRuntimeTypeOverride(evalCfg *config.EvalConfig, cmd *cobra.Command) er
 		return fmt.Errorf("--runtime none is incompatible with network_policy %q (none cannot enforce network isolation)", evalCfg.Environment.NetworkPolicy)
 	}
 	if value == "docker" && strings.TrimSpace(evalCfg.Environment.Image) == "" {
-		return fmt.Errorf("--runtime docker requires environment.image to be set in the eval config")
+		return errors.New("--runtime docker requires environment.image to be set in the eval config")
 	}
 	evalCfg.Environment.Type = value
 	return nil

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -39,7 +39,7 @@ const (
 )
 
 // validRuntimeTypes lists the environment.type values accepted by --runtime.
-var validRuntimeTypes = []string{"none", "opensandbox"}
+var validRuntimeTypes = []string{"none", "opensandbox", "docker"}
 
 type verbosityValue int
 
@@ -99,7 +99,7 @@ func init() {
 	runCmd.Flags().StringArray("format", nil, "Report format (json, junit, html). Can be specified multiple times. Default: json")
 	runCmd.Flags().String("output-dir", "", "Directory for report/artifact outputs. Default: <skill-name>-workspace alongside the skill directory")
 	runCmd.Flags().String("engine", "", "Override engine name")
-	runCmd.Flags().String(runtimeFlagName, "", "Override environment.type (none, opensandbox)")
+	runCmd.Flags().String(runtimeFlagName, "", "Override environment.type (none, opensandbox, docker)")
 	runCmd.Flags().String("model", "", "Override model (accepts either a bare model name or provider/name)")
 	runCmd.Flags().String("api-key", "", "API key for the model provider")
 	runCmd.Flags().Int("parallelism", 0, "Override cases.parallelism. Must be between 1 and 256 when specified")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1008,7 +1008,7 @@ func TestApplyRunConfigOverrides_RuntimeTypeRejectsInvalid(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.Flags().String(runtimeFlagName, "", "")
-	if err := cmd.Flags().Set(runtimeFlagName, "docker"); err != nil {
+	if err := cmd.Flags().Set(runtimeFlagName, "podman"); err != nil {
 		t.Fatalf("set runtime: %v", err)
 	}
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -21,7 +21,7 @@ type EvalConfig struct {
 
 // Environment defines the runtime environment for evaluation.
 type Environment struct {
-	Type                  string            `yaml:"type"` // none, opensandbox
+	Type                  string            `yaml:"type"` // none, opensandbox, docker
 	Image                 string            `yaml:"image,omitempty"`
 	SandboxTemplate       string            `yaml:"sandbox_template,omitempty"`
 	WorkspaceMount        string            `yaml:"workspace_mount,omitempty"`

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -46,6 +46,15 @@ func (v *Validator) ValidateEvalConfig(cfg *EvalConfig) error {
 		errs = append(errs, "environment.type must be one of: none, opensandbox, docker")
 	}
 
+	// environment.image is required for the docker runtime — without it,
+	// `skill-up validate` would pass and only fail later at run time when
+	// NewDockerRuntime constructs the container. Catch it at the preflight
+	// gate instead. opensandbox has its own image-or-sandbox-template
+	// fallback so it stays permissive here.
+	if cfg.Environment.Type == runtimeTypeDocker && strings.TrimSpace(cfg.Environment.Image) == "" {
+		errs = append(errs, "environment.image is required when environment.type is docker")
+	}
+
 	errs = append(errs, validateNetworkPolicy(cfg.Environment)...)
 
 	// engine.name is required

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path"
 	"strings"
 )
 
@@ -46,13 +47,11 @@ func (v *Validator) ValidateEvalConfig(cfg *EvalConfig) error {
 		errs = append(errs, "environment.type must be one of: none, opensandbox, docker")
 	}
 
-	// environment.image is required for the docker runtime — without it,
-	// `skill-up validate` would pass and only fail later at run time when
-	// NewDockerRuntime constructs the container. Catch it at the preflight
-	// gate instead. opensandbox has its own image-or-sandbox-template
-	// fallback so it stays permissive here.
-	if cfg.Environment.Type == runtimeTypeDocker && strings.TrimSpace(cfg.Environment.Image) == "" {
-		errs = append(errs, "environment.image is required when environment.type is docker")
+	// Docker-runtime fields that would otherwise silently pass `skill-up
+	// validate` and only fail later when NewDockerRuntime constructs the
+	// container — catch them at the preflight gate.
+	if cfg.Environment.Type == runtimeTypeDocker {
+		errs = append(errs, validateDockerEnvironment(cfg.Environment)...)
 	}
 
 	errs = append(errs, validateNetworkPolicy(cfg.Environment)...)
@@ -172,6 +171,32 @@ func (v *Validator) ValidateAll(result *EvalResult) error {
 
 func isValidRuntimeType(t string) bool {
 	return t == runtimeTypeNone || t == runtimeTypeOpenSandbox || t == runtimeTypeDocker
+}
+
+// validateDockerEnvironment collects preflight errors for fields the docker
+// runtime would otherwise reject only at NewDockerRuntime construction time.
+// Keep this in sync with the parallel checks in internal/runtime/docker.go
+// — both layers enforce, but catching it here turns a runtime-error CI
+// failure into a clean validate-step failure.
+func validateDockerEnvironment(env Environment) []string {
+	var errs []string
+
+	// environment.image: required (opensandbox has its own image-or-
+	// sandbox-template fallback, docker does not).
+	if strings.TrimSpace(env.Image) == "" {
+		errs = append(errs, "environment.image is required when environment.type is docker")
+	}
+
+	// environment.workspace_mount: optional, but when set must be
+	// absolute — `docker create --workdir <relative>` is rejected, and
+	// our Upload/Download paths treat relative values as joined under
+	// the workspace which makes no sense if the workspace itself isn't
+	// absolute.
+	if mount := strings.TrimSpace(env.WorkspaceMount); mount != "" && !path.IsAbs(mount) {
+		errs = append(errs, fmt.Sprintf("environment.workspace_mount must be absolute when environment.type is docker, got %q", mount))
+	}
+
+	return errs
 }
 
 func isValidJudgeType(t string) bool {

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -17,6 +17,7 @@ const (
 const (
 	runtimeTypeNone        = "none"
 	runtimeTypeOpenSandbox = "opensandbox"
+	runtimeTypeDocker      = "docker"
 )
 
 // Validator checks eval and case documents against the v1alpha1 schema.
@@ -40,9 +41,9 @@ func (v *Validator) ValidateEvalConfig(cfg *EvalConfig) error {
 
 	// environment.type is required
 	if cfg.Environment.Type == "" {
-		errs = append(errs, "environment.type is required (none, opensandbox)")
+		errs = append(errs, "environment.type is required (none, opensandbox, docker)")
 	} else if !isValidRuntimeType(cfg.Environment.Type) {
-		errs = append(errs, "environment.type must be one of: none, opensandbox")
+		errs = append(errs, "environment.type must be one of: none, opensandbox, docker")
 	}
 
 	errs = append(errs, validateNetworkPolicy(cfg.Environment)...)
@@ -161,7 +162,7 @@ func (v *Validator) ValidateAll(result *EvalResult) error {
 }
 
 func isValidRuntimeType(t string) bool {
-	return t == runtimeTypeNone || t == runtimeTypeOpenSandbox
+	return t == runtimeTypeNone || t == runtimeTypeOpenSandbox || t == runtimeTypeDocker
 }
 
 func isValidJudgeType(t string) bool {
@@ -180,7 +181,14 @@ func validateNetworkPolicy(env Environment) []string {
 		return []string{"network_policy must be one of: deny_all, allow_declared"}
 	}
 	if env.Type == runtimeTypeNone {
-		return []string{"network_policy requires environment.type opensandbox (none cannot enforce network isolation)"}
+		return []string{"network_policy requires environment.type opensandbox or docker (none cannot enforce network isolation)"}
+	}
+	// docker runtime currently implements only deny_all (via --network=none).
+	// allow_declared needs an egress proxy / iptables sidecar that is not
+	// yet in place. Reject early so users do not get a silent "all egress
+	// allowed" container at run time.
+	if env.Type == runtimeTypeDocker && policy == "allow_declared" {
+		return []string{"network_policy: allow_declared is not supported for environment.type docker (use deny_all or opensandbox)"}
 	}
 
 	var errs []string

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -624,6 +624,43 @@ func TestValidator_ValidateEvalConfig(t *testing.T) {
 			errMsg:  "environment.image is required when environment.type is docker",
 		},
 		{
+			name: "docker with relative workspace_mount is rejected at validation",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:           "docker",
+					Image:          "alpine:3.20",
+					WorkspaceMount: "rel/path",
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "environment.workspace_mount must be absolute when environment.type is docker",
+		},
+		{
+			name: "docker with absolute workspace_mount is valid",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:           "docker",
+					Image:          "alpine:3.20",
+					WorkspaceMount: "/work",
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "valid docker with deny_all network policy",
 			cfg: &EvalConfig{
 				SchemaVersion: "v1alpha1",

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -589,6 +589,61 @@ func TestValidator_ValidateEvalConfig(t *testing.T) {
 			wantErr: true,
 			errMsg:  "network_policy requires environment.type opensandbox",
 		},
+		{
+			name: "valid docker runtime type",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:  "docker",
+					Image: "alpine:3.20",
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid docker with deny_all network policy",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:          "docker",
+					Image:         "alpine:3.20",
+					NetworkPolicy: "deny_all",
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "docker with allow_declared is rejected",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type:          "docker",
+					Image:         "alpine:3.20",
+					NetworkPolicy: "allow_declared",
+					AllowedEgress: []string{"pypi.org"},
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "allow_declared is not supported for environment.type docker",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -607,6 +607,23 @@ func TestValidator_ValidateEvalConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "docker without image is rejected at validation",
+			cfg: &EvalConfig{
+				SchemaVersion: "v1alpha1",
+				Environment: Environment{
+					Type: "docker",
+				},
+				Engine: EngineConfig{
+					Name: "claude_code",
+				},
+				Cases: CasesConfig{
+					Files: []string{"evals/cases/test.yaml"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "environment.image is required when environment.type is docker",
+		},
+		{
 			name: "valid docker with deny_all network policy",
 			cfg: &EvalConfig{
 				SchemaVersion: "v1alpha1",

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -809,6 +809,7 @@ func (e *defaultEvaluator) prepareRuntimeForCase(ctx context.Context, caseCfg *c
 		return nil, fmt.Errorf("failed to create runtime: %w", err)
 	}
 	if err := rt.Create(ctx); err != nil {
+		_ = rt.Close()
 		return nil, fmt.Errorf("failed to create runtime workspace: %w", err)
 	}
 	if err := e.setupCaseEnvironment(ctx, rt, caseCfg, configName, ag, mcpCfg); err != nil {

--- a/internal/runtime/README.md
+++ b/internal/runtime/README.md
@@ -115,11 +115,35 @@ Connects to a remote sandbox environment:
 
 Configuration includes `UseServerProxy`, `ReadyTimeout`, `SandboxTimeout`, `Kwargs`, etc. OpenSandbox authentication is handled inside the runtime implementation, which reads `OPENSANDBOX_API_KEY`; non-sensitive runtime parameters are passed through `Kwargs`, e.g. `base_url` and a JSON-string-encoded `extensions`.
 
+### DockerRuntime (Local Container Mode)
+
+Runs the eval inside a local Docker container — container-level isolation (filesystem, process, network) without any remote service dependency.
+
+- `Create`: `docker create --name skill-up-<rand> --workdir <workspace> [--network none] [--env K=V]... <image> sleep infinity`. The `sleep infinity` entrypoint keeps the container alive so subsequent `exec` calls can attach; override via `environment.entrypoint`.
+- `Start` / `Stop`: `docker start` / `docker stop --time 5`; both idempotent.
+- `Close`: `docker rm -f` when `Config.Delete=true`; otherwise just `docker stop` so the user can inspect the container.
+- `UploadFile` / `UploadDir` / `DownloadFile` / `DownloadDir`: implemented via `docker cp`. `UploadDir` and `DownloadDir` use the `src/.` trailing-dot form so the *contents* of `src` are copied into the destination (matching the existing `UploadDir`/`DownloadDir` contracts).
+- `Exec`: `docker exec --workdir <cwd> [--env K=V]... <container> bash -c <command>`. `Cwd` may be relative (joined under `Workspace()`) or absolute. Caller-supplied env layers on top of `cfg.Env`, then on top of the container's own env (so `PATH`, `HOME`, etc. in the image remain intact).
+- `RequiresProcessSandbox()`: returns `false` — the container already isolates the agent's processes.
+- Workspace defaults to `/workspace` and must be an absolute path.
+
+**Requirements**: a working `docker` CLI on PATH and a usable Docker daemon. The runtime does not pull images on its own — pre-pull or use an image already available locally.
+
+**Network policy**:
+
+| Policy | Behavior |
+|-------|----------|
+| (unset) | Default bridge network (full egress). |
+| `deny_all` | `docker create --network=none`; no network access at all. |
+| `allow_declared` | **Not supported yet** — rejected at validation and at `NewDockerRuntime`. FQDN-level egress filtering requires an egress proxy or in-container iptables sidecar that is out of scope for the initial implementation. Use `opensandbox` if you need this. |
+
+**Security note**: `Workspace()` returns the in-container path. Unlike `NoneRuntime`, the host cannot access it directly — all data movement must go through Upload/Download. Absolute `targetPath` values in Upload* refer to absolute *container* paths, not host paths.
+
 ## Configuration
 
 ```go
 type Config struct {
-    Type           string            // "none" | "opensandbox"
+    Type           string            // "none" | "opensandbox" | "docker"
     Image          string            // Sandbox image (for opensandbox mode)
     WorkspaceMount string            // Workspace mount path
     Env            map[string]string // Environment variables

--- a/internal/runtime/README.md
+++ b/internal/runtime/README.md
@@ -119,11 +119,11 @@ Configuration includes `UseServerProxy`, `ReadyTimeout`, `SandboxTimeout`, `Kwar
 
 Runs the eval inside a local Docker container — container-level isolation (filesystem, process, network) without any remote service dependency.
 
-- `Create`: `docker create --name skill-up-<rand> --workdir <workspace> [--network none] [--env K=V]... <image> sleep infinity`. The `sleep infinity` entrypoint keeps the container alive so subsequent `exec` calls can attach; override via `environment.entrypoint`.
-- `Start` / `Stop`: `docker start` / `docker stop --time 5`; both idempotent.
-- `Close`: `docker rm -f` when `Config.Delete=true`; otherwise just `docker stop` so the user can inspect the container.
+- `Create`: `docker create --name skill-up-<rand> --workdir <workspace> [--network none] [--env K=V]... --entrypoint sleep <image> infinity`, followed by `docker start` and a `mkdir -p <workspace>` exec so the runtime is fully ready when Create returns. The `--entrypoint sleep ... infinity` shape keeps the container alive even on images that ship their own ENTRYPOINT (passing `sleep infinity` as positional args would otherwise be appended to that entrypoint and the container would exit immediately). Override the keep-alive command via `environment.entrypoint` — its first element becomes `--entrypoint`, remaining elements become CMD args after the image. Half-created containers are rolled back with `docker rm -f` if start or the workspace mkdir fails.
+- `Stop`: `docker stop --time 5`.
+- `Close`: `docker rm -f` when `Config.Delete=true`; otherwise just `docker stop` so the user can inspect the container. On rm failure the container handle is **retained** so the caller can retry `Close()` after a transient daemon hiccup instead of silently leaking the container.
 - `UploadFile` / `UploadDir` / `DownloadFile` / `DownloadDir`: implemented via `docker cp`. `UploadDir` and `DownloadDir` use the `src/.` trailing-dot form so the *contents* of `src` are copied into the destination (matching the existing `UploadDir`/`DownloadDir` contracts).
-- `Exec`: `docker exec --workdir <cwd> [--env K=V]... <container> bash -c <command>`. `Cwd` may be relative (joined under `Workspace()`) or absolute. Caller-supplied env layers on top of `cfg.Env`, then on top of the container's own env (so `PATH`, `HOME`, etc. in the image remain intact).
+- `Exec`: `docker exec --workdir <cwd> [--env K=V]... <container> sh -c <command>`. `sh` (not `bash`) is used so the runtime works on minimal base images (alpine, distroless, busybox). `Cwd` may be relative (joined under `Workspace()`) or absolute. Caller-supplied env layers on top of `cfg.Env`; values are passed **literally** — there's intentionally no host-env `$VAR` expansion, because expanding container-relative variables like `PATH` against the host would clobber the image's own value.
 - `RequiresProcessSandbox()`: returns `false` — the container already isolates the agent's processes.
 - Workspace defaults to `/workspace` and must be an absolute path.
 

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -118,6 +118,40 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 		return fmt.Errorf("docker runtime: generate container name: %w", err)
 	}
 
+	args := r.buildCreateArgs(name)
+	stdout, stderr, exitCode, err := r.run(ctx, r.cli, args...)
+	if err != nil || exitCode != 0 {
+		return dockerCLIErr(stderr, exitCode, err, "docker create failed")
+	}
+	id := strings.TrimSpace(stdout)
+	if id == "" {
+		id = name
+	}
+	r.containerID = id
+
+	_, startStderr, startExit, startErr := r.run(ctx, r.cli, "start", id)
+	if startErr != nil || startExit != 0 {
+		if r.rollbackRemove(ctx, id) == nil {
+			r.containerID = ""
+		}
+		return dockerCLIErr(startStderr, startExit, startErr, "docker start %s failed", id)
+	}
+	r.started = true
+
+	if _, mkStderr, mkExit, mkErr := r.run(ctx, r.cli, "exec", id, "mkdir", "-p", r.workspace); mkErr != nil || mkExit != 0 {
+		if r.rollbackRemove(ctx, id) == nil {
+			r.containerID = ""
+			r.started = false
+		}
+		return dockerCLIErr(mkStderr, mkExit, mkErr, "docker exec mkdir -p %s failed", r.workspace)
+	}
+	return nil
+}
+
+// buildCreateArgs assembles the `docker create` argument list from the
+// runtime's configuration. Extracted from Create to keep cyclomatic
+// complexity manageable.
+func (r *DockerRuntime) buildCreateArgs(name string) []string {
 	args := []string{
 		"create",
 		"--name", name,
@@ -129,18 +163,6 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 	for k, v := range r.cfg.Env {
 		args = append(args, "--env", k+"="+v)
 	}
-	// Persistent entrypoint so exec calls can attach. `sleep infinity` is
-	// supported in busybox 1.30+, Alpine 3.10+, Debian/Ubuntu coreutils,
-	// and most distroless bases; users with stricter base images can
-	// override via environment.entrypoint.
-	//
-	// Docker treats positional args after the image as CMD, NOT as an
-	// ENTRYPOINT override. If the image already declares an ENTRYPOINT
-	// (e.g. `python`, `java -jar app.jar`), our `sleep infinity` would
-	// arrive as arguments to that entrypoint and the container would
-	// exit immediately. Using `--entrypoint` explicitly replaces the
-	// image's entrypoint with the user's chosen binary, and any
-	// remaining args go into the CMD slot.
 	entry := r.cfg.Entrypoint
 	if len(entry) == 0 {
 		entry = []string{"sleep", "infinity"}
@@ -150,48 +172,7 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 	if len(entry) > 1 {
 		args = append(args, entry[1:]...)
 	}
-
-	stdout, stderr, exitCode, err := r.run(ctx, r.cli, args...)
-	if err != nil || exitCode != 0 {
-		return dockerCLIErr(stderr, exitCode, err, "docker create failed")
-	}
-	id := strings.TrimSpace(stdout)
-	if id == "" {
-		// `docker create --name X` echoes the long ID on success; if it
-		// doesn't, fall back to the name we chose so Close can still
-		// reach the container.
-		id = name
-	}
-	r.containerID = id
-
-	// Start the container so Exec / docker cp work immediately. If start
-	// fails, tear down the half-created container to avoid leaking it on
-	// the host; otherwise the error returned to the caller would leave a
-	// "Created"-state container hanging around forever.
-	_, startStderr, startExit, startErr := r.run(ctx, r.cli, "start", id)
-	if startErr != nil || startExit != 0 {
-		if r.rollbackRemove(ctx, id) == nil {
-			r.containerID = ""
-		}
-		return dockerCLIErr(startStderr, startExit, startErr, "docker start %s failed", id)
-	}
-	r.started = true
-
-	// Defensively create the workspace dir. `--workdir` creates the dir
-	// for `docker run`, but in the `create + start` two-step the
-	// directory is only guaranteed to exist when the first exec runs
-	// with `--workdir` — and if it doesn't, that first exec errors out
-	// with an opaque "no such file or directory" message. mkdir -p
-	// here surfaces any real failure (read-only fs, permissions) right
-	// at Create() time instead.
-	if _, mkStderr, mkExit, mkErr := r.run(ctx, r.cli, "exec", id, "mkdir", "-p", r.workspace); mkErr != nil || mkExit != 0 {
-		if r.rollbackRemove(ctx, id) == nil {
-			r.containerID = ""
-			r.started = false
-		}
-		return dockerCLIErr(mkStderr, mkExit, mkErr, "docker exec mkdir -p %s failed", r.workspace)
-	}
-	return nil
+	return args
 }
 
 // rollbackRemove tears down a half-created container after a failure in
@@ -202,11 +183,12 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 // error if cleanup failed (in which case the caller should retain
 // containerID so a subsequent Close can retry).
 func (r *DockerRuntime) rollbackRemove(_ context.Context, id string) error {
+	//nolint:contextcheck // Intentionally detached: parent cancellation must not skip cleanup.
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), dockerCleanupTimeout)
 	defer cancel()
 	_, stderr, exitCode, err := r.run(cleanupCtx, r.cli, "rm", "-f", id)
 	if err != nil || exitCode != 0 {
-		logging.Debugf("DockerRuntime.rollbackRemove: rm -f %s failed (exit=%d): %s", id, exitCode, strings.TrimSpace(stderr))
+		logging.DebugContextf(cleanupCtx, "DockerRuntime.rollbackRemove: rm -f %s failed (exit=%d): %s", id, exitCode, strings.TrimSpace(stderr))
 		return dockerCLIErr(stderr, exitCode, err, "docker rm -f %s failed during rollback", id)
 	}
 	return nil
@@ -432,13 +414,20 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 	span.SetAttributes(attribute.Int("process.exit_code", result.ExitCode))
 	observability.RecordRuntimeExec(ctx, result.ExitCode, time.Since(startTime).Milliseconds())
 
+	return result, classifyExecResult(ctx, result, err, command)
+}
+
+// classifyExecResult determines whether a docker exec invocation should
+// surface as an error (infra fault, context timeout) or as a normal non-zero
+// exit that the evaluator scores via ExitCode alone.
+func classifyExecResult(ctx context.Context, result ExecResult, err error, command string) error {
 	switch {
 	case result.ExitCode == -1 && ctx.Err() != nil:
 		logging.ErrorContextf(ctx, "docker exec killed by context (%v); command: %s", ctx.Err(), maskCommand(command))
 		if result.Stderr != "" {
 			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
 		}
-		return result, ctx.Err()
+		return ctx.Err()
 	case result.ExitCode != 0:
 		logNonZeroExit(ctx, result.ExitCode, command)
 		if result.Stderr != "" {
@@ -448,24 +437,13 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 		logging.WarnContextf(ctx, "stderr: %s", result.Stderr)
 	}
 
-	// Two distinct failure modes need to surface as errors so the
-	// evaluator routes them through its infra-retry path instead of the
-	// ordinary FAIL path:
-	//
-	//   1. r.run itself returned err — docker CLI couldn't run, or the
-	//      parent context was cancelled / timed out.
-	//   2. docker exec returned a non-zero exit AND stderr looks like a
-	//      daemon / OCI runtime fault (missing container, runtime exec
-	//      failed, etc) — see dockerExecLayerError. A user command that
-	//      legitimately exits non-zero must NOT be wrapped; the
-	//      evaluator inspects ExitCode for those.
 	if err != nil {
-		return result, dockerCLIErr(result.Stderr, result.ExitCode, err, "docker exec failed")
+		return dockerCLIErr(result.Stderr, result.ExitCode, err, "docker exec failed")
 	}
 	if result.ExitCode != 0 && dockerExecLayerError(result.Stderr, result.ExitCode) {
-		return result, dockerCLIErr(result.Stderr, result.ExitCode, nil, "docker exec layer failure")
+		return dockerCLIErr(result.Stderr, result.ExitCode, nil, "docker exec layer failure")
 	}
-	return result, nil
+	return nil
 }
 
 // Workspace returns the in-container workspace path. Unlike NoneRuntime, this

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -392,14 +392,24 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 	// container's own env (PATH, HOME, ...) intact and just layer the
 	// caller-supplied vars on top — so pass only the merged overlay to
 	// docker, not the full host env.
+	//
+	// PATH requires special handling: docker --env sets values literally
+	// (no variable expansion), so "$HOME/.local/bin:$PATH" would become
+	// the literal string. Instead, prepend an `export PATH=...` line to
+	// the command so expansion happens inside the container's shell.
+	var pathPrefix string
 	for _, kv := range overlayEnvList(r.cfg.Env, opts.Env) {
+		if k, v, _ := strings.Cut(kv, "="); k == "PATH" && strings.Contains(v, "$") {
+			pathPrefix = "export PATH=\"" + v + "\"\n"
+			continue
+		}
 		args = append(args, "--env", kv)
 	}
 	// Use `sh -c` rather than `bash -c` so the docker runtime works on
 	// minimal base images (alpine, distroless, busybox, plain debian
 	// without bash). All shell snippets the rest of the codebase ships
 	// (setup_steps, judge scripts, agent commands) are POSIX-compatible.
-	args = append(args, id, "sh", "-c", command)
+	args = append(args, id, "sh", "-c", pathPrefix+command)
 	span.SetAttributes(
 		attribute.String("process.command", command),
 		attribute.String("process.cwd", cwd),

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -161,6 +161,9 @@ func (r *DockerRuntime) buildCreateArgs(name string) []string {
 		args = append(args, "--network", "none")
 	}
 	for k, v := range r.cfg.Env {
+		if k == "PATH" && strings.Contains(v, "$") {
+			continue
+		}
 		args = append(args, "--env", k+"="+v)
 	}
 	entry := r.cfg.Entrypoint
@@ -574,12 +577,10 @@ func dockerCLIErr(stderr string, exitCode int, err error, format string, args ..
 //	                                            failure (TCP/TLS-backed
 //	                                            daemons in particular).
 //
-// 125 alone is unambiguous; the prefixes catch cases where the daemon
-// mapped its failure to a different exit code.
+// Exit code 125 combined with daemon/OCI stderr is a definitive layer
+// fault. Without confirming stderr, a user command that exits 125 would
+// be misclassified.
 func dockerExecLayerError(stderr string, exitCode int) bool {
-	if exitCode == 125 {
-		return true
-	}
 	s := strings.TrimSpace(stderr)
 	switch {
 	case strings.HasPrefix(s, "Error response from daemon:"),
@@ -587,6 +588,8 @@ func dockerExecLayerError(stderr string, exitCode int) bool {
 		strings.HasPrefix(s, "OCI runtime exec failed:"),
 		strings.HasPrefix(s, "Cannot connect to the Docker daemon"),
 		strings.HasPrefix(s, "error during connect:"):
+		return true
+	case exitCode == 125 && s == "":
 		return true
 	}
 	return false

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -182,8 +182,9 @@ func (r *DockerRuntime) buildCreateArgs(name string) []string {
 // window. Returns nil when the container was successfully removed, or an
 // error if cleanup failed (in which case the caller should retain
 // containerID so a subsequent Close can retry).
+//
+//nolint:contextcheck // Intentionally detached: parent cancellation must not skip cleanup.
 func (r *DockerRuntime) rollbackRemove(_ context.Context, id string) error {
-	//nolint:contextcheck // Intentionally detached: parent cancellation must not skip cleanup.
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), dockerCleanupTimeout)
 	defer cancel()
 	_, stderr, exitCode, err := r.run(cleanupCtx, r.cli, "rm", "-f", id)

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -383,9 +383,9 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 	}
 	if !path.IsAbs(cwd) {
 		cwd = path.Join(r.workspace, cwd)
-	}
-	if !isSubPath(r.workspace, cwd) {
-		return ExecResult{}, fmt.Errorf("docker runtime: cwd %q escapes workspace %q", opts.Cwd, r.workspace)
+		if !isSubPath(r.workspace, cwd) {
+			return ExecResult{}, fmt.Errorf("docker runtime: cwd %q escapes workspace %q", opts.Cwd, r.workspace)
+		}
 	}
 	args = append(args, "--workdir", cwd)
 	// mergeEnv covers cfg.Env + opts.Env, but here we want to keep the

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -422,6 +422,16 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 	var pathPrefix string
 	for _, kv := range overlayEnvList(r.cfg.Env, opts.Env) {
 		if k, v, _ := strings.Cut(kv, "="); k == "PATH" && strings.Contains(v, "$") {
+			// shellDoubleQuote escapes \ " `, but not $ — so $VAR
+			// expansion still works (intended), but $(...) command
+			// substitution would also still fire and silently
+			// execute arbitrary commands. Reject the substitution
+			// form rather than try to escape it (escaping $ would
+			// also kill the legitimate $VAR / ${VAR} expansion this
+			// branch exists for).
+			if strings.Contains(v, "$(") {
+				return ExecResult{}, fmt.Errorf("docker runtime: PATH %q contains command substitution $(...), which is not allowed", v)
+			}
 			pathPrefix = "export PATH=" + shellDoubleQuote(v) + "\n"
 			continue
 		}

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -25,6 +25,13 @@ const (
 	dockerDefaultWorkspace = "/workspace"
 	dockerDirMode          = 0o755
 	dockerNameRandomBytes  = 6
+	// dockerCleanupTimeout bounds best-effort rollback / preserve-path
+	// stops so a hung daemon can't keep the runtime mutex held forever.
+	// Long enough for a normal `docker rm -f` (a few seconds) plus some
+	// margin for an overloaded daemon; short enough that Create or Close
+	// still returns to its caller within a useful window even on a stuck
+	// daemon.
+	dockerCleanupTimeout = 30 * time.Second
 )
 
 // dockerCommandRunner is the seam unit tests use to capture or fake the
@@ -164,8 +171,11 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 	_, startStderr, startExit, startErr := r.run(ctx, r.cli, "start", id)
 	if startErr != nil || startExit != 0 {
 		// best-effort cleanup; ignore failure here since we already have
-		// a more informative error to return.
-		_, _, _, _ = r.run(context.WithoutCancel(ctx), r.cli, "rm", "-f", id)
+		// a more informative error to return. Bounded by dockerCleanupTimeout
+		// so a hung daemon can't keep r.mu held forever — without the
+		// timeout, context.WithoutCancel drops the parent deadline and a
+		// stuck docker would deadlock Create indefinitely.
+		r.rollbackRemove(ctx, id)
 		r.containerID = ""
 		return dockerCLIErr(startStderr, startExit, startErr, "docker start %s failed", id)
 	}
@@ -179,12 +189,24 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 	// here surfaces any real failure (read-only fs, permissions) right
 	// at Create() time instead.
 	if _, mkStderr, mkExit, mkErr := r.run(ctx, r.cli, "exec", id, "mkdir", "-p", r.workspace); mkErr != nil || mkExit != 0 {
-		_, _, _, _ = r.run(context.WithoutCancel(ctx), r.cli, "rm", "-f", id)
+		r.rollbackRemove(ctx, id)
 		r.containerID = ""
 		r.started = false
 		return dockerCLIErr(mkStderr, mkExit, mkErr, "docker exec mkdir -p %s failed", r.workspace)
 	}
 	return nil
+}
+
+// rollbackRemove tears down a half-created container after a failure in
+// Create. Detached from the caller's context so cancellation/deadline of
+// the original call doesn't skip cleanup, but bounded by dockerCleanupTimeout
+// so a wedged daemon still releases the runtime mutex within a usable
+// window. The cleanup is best-effort: any error is swallowed because we
+// already have a more informative one to return to the caller.
+func (r *DockerRuntime) rollbackRemove(_ context.Context, id string) {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), dockerCleanupTimeout)
+	defer cancel()
+	_, _, _, _ = r.run(cleanupCtx, r.cli, "rm", "-f", id)
 }
 
 // Close removes the container (when cfg.Delete is true) or just stops it.
@@ -261,14 +283,15 @@ func (r *DockerRuntime) Stop(ctx context.Context) error {
 // UploadFile copies a single file from the host into the container.
 // targetPath may be relative to the workspace or an absolute container path.
 func (r *DockerRuntime) UploadFile(ctx context.Context, sourcePath, targetPath string) error {
-	if err := r.ensureCreated(); err != nil {
+	id, err := r.snapshotContainerID()
+	if err != nil {
 		return err
 	}
 	target := r.remotePath(targetPath)
-	if err := r.ensureRemoteDir(ctx, path.Dir(target)); err != nil {
+	if err := r.ensureRemoteDir(ctx, id, path.Dir(target)); err != nil {
 		return err
 	}
-	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", sourcePath, r.containerID+":"+target)
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", sourcePath, id+":"+target)
 	if err != nil || exitCode != 0 {
 		return dockerCLIErr(stderr, exitCode, err, "docker cp %s -> %s failed", sourcePath, target)
 	}
@@ -277,17 +300,18 @@ func (r *DockerRuntime) UploadFile(ctx context.Context, sourcePath, targetPath s
 
 // UploadDir recursively copies a directory tree from the host into the container.
 func (r *DockerRuntime) UploadDir(ctx context.Context, sourceDir, targetDir string) error {
-	if err := r.ensureCreated(); err != nil {
+	id, err := r.snapshotContainerID()
+	if err != nil {
 		return err
 	}
 	target := r.remotePath(targetDir)
-	if err := r.ensureRemoteDir(ctx, target); err != nil {
+	if err := r.ensureRemoteDir(ctx, id, target); err != nil {
 		return err
 	}
 	// `docker cp <srcDir>/. <ctr>:<dst>` copies contents into dst, which
 	// matches the UploadDir contract (host srcDir tree → container dst tree).
 	src := strings.TrimRight(sourceDir, string(filepath.Separator)) + string(filepath.Separator) + "."
-	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", src, r.containerID+":"+target)
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", src, id+":"+target)
 	if err != nil || exitCode != 0 {
 		return dockerCLIErr(stderr, exitCode, err, "docker cp -r %s -> %s failed", sourceDir, target)
 	}
@@ -296,14 +320,15 @@ func (r *DockerRuntime) UploadDir(ctx context.Context, sourceDir, targetDir stri
 
 // DownloadFile copies a single file from the container to the host.
 func (r *DockerRuntime) DownloadFile(ctx context.Context, sourcePath, targetPath string) error {
-	if err := r.ensureCreated(); err != nil {
+	id, err := r.snapshotContainerID()
+	if err != nil {
 		return err
 	}
 	source := r.remotePath(sourcePath)
 	if err := os.MkdirAll(filepath.Dir(targetPath), dockerDirMode); err != nil {
 		return fmt.Errorf("docker runtime: create local target dir: %w", err)
 	}
-	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", r.containerID+":"+source, targetPath)
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", id+":"+source, targetPath)
 	if err != nil || exitCode != 0 {
 		return dockerCLIErr(stderr, exitCode, err, "docker cp %s -> %s failed", source, targetPath)
 	}
@@ -312,7 +337,8 @@ func (r *DockerRuntime) DownloadFile(ctx context.Context, sourcePath, targetPath
 
 // DownloadDir recursively copies a directory from the container to the host.
 func (r *DockerRuntime) DownloadDir(ctx context.Context, sourceDir, targetDir string) error {
-	if err := r.ensureCreated(); err != nil {
+	id, err := r.snapshotContainerID()
+	if err != nil {
 		return err
 	}
 	source := r.remotePath(sourceDir)
@@ -321,7 +347,7 @@ func (r *DockerRuntime) DownloadDir(ctx context.Context, sourceDir, targetDir st
 	}
 	// `<ctr>:<srcDir>/.` → host targetDir copies contents into targetDir.
 	src := strings.TrimRight(source, "/") + "/."
-	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", r.containerID+":"+src, targetDir)
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", id+":"+src, targetDir)
 	if err != nil || exitCode != 0 {
 		return dockerCLIErr(stderr, exitCode, err, "docker cp -r %s -> %s failed", source, targetDir)
 	}
@@ -330,7 +356,8 @@ func (r *DockerRuntime) DownloadDir(ctx context.Context, sourceDir, targetDir st
 
 // Exec runs a bash command inside the container.
 func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptions) (ExecResult, error) {
-	if err := r.ensureCreated(); err != nil {
+	id, err := r.snapshotContainerID()
+	if err != nil {
 		return ExecResult{}, err
 	}
 
@@ -364,7 +391,7 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 	// minimal base images (alpine, distroless, busybox, plain debian
 	// without bash). All shell snippets the rest of the codebase ships
 	// (setup_steps, judge scripts, agent commands) are POSIX-compatible.
-	args = append(args, r.containerID, "sh", "-c", command)
+	args = append(args, id, "sh", "-c", command)
 	span.SetAttributes(
 		attribute.String("process.command", command),
 		attribute.String("process.cwd", cwd),
@@ -429,20 +456,32 @@ func (r *DockerRuntime) RequiresProcessSandbox() bool {
 	return false
 }
 
-func (r *DockerRuntime) ensureCreated() error {
+// snapshotContainerID returns the current container id under the mutex,
+// so callers can use the captured local value through the rest of their
+// method without racing a concurrent Close. The lock is released on
+// return — `docker exec` / `docker cp` may take many seconds and holding
+// the lock for their duration would serialise every operation on the
+// runtime. If Close fires while exec/cp is in flight, the captured id
+// becomes stale and docker returns a "No such container" error, which
+// dockerExecLayerError catches and surfaces as a layer fault — much
+// better than a panic on a half-cleared field.
+func (r *DockerRuntime) snapshotContainerID() (string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.containerID == "" {
-		return errors.New("docker runtime: container not created (call Create first)")
+		return "", errors.New("docker runtime: container not created (call Create first)")
 	}
-	return nil
+	return r.containerID, nil
 }
 
-func (r *DockerRuntime) ensureRemoteDir(ctx context.Context, dir string) error {
+// ensureRemoteDir takes an explicit container id rather than reading
+// r.containerID so callers can keep using the snapshot captured under the
+// mutex at the top of their method. Avoids a second lock-and-read race.
+func (r *DockerRuntime) ensureRemoteDir(ctx context.Context, id, dir string) error {
 	if dir == "" || dir == "/" {
 		return nil
 	}
-	_, stderr, exitCode, err := r.run(ctx, r.cli, "exec", r.containerID, "mkdir", "-p", dir)
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "exec", id, "mkdir", "-p", dir)
 	if err != nil || exitCode != 0 {
 		return dockerCLIErr(stderr, exitCode, err, "docker exec mkdir -p %s failed", dir)
 	}
@@ -484,14 +523,22 @@ func dockerCLIErr(stderr string, exitCode int, err error, format string, args ..
 //	126 — container exists but the command cannot be invoked
 //	127 — command not found inside the container
 //
-// Plus stderr prefixes that mean "this never reached the user's command":
+// Plus daemon-emitted stderr that means "this never reached the user's
+// command". Match prefixes only (not bare substrings) so a user script
+// that legitimately prints e.g. `redis is not running` and exits 1 isn't
+// misclassified as an infra fault.
 //
-//	"Error response from daemon:"  — daemon refused
+//	"Error response from daemon:"  — daemon refused (covers the
+//	                                  stopped-container variant
+//	                                  "Error response from daemon:
+//	                                  Container X is not running")
 //	"Error: No such container"     — container vanished
-//	"OCI runtime exec failed"      — runtime couldn't set up the process
+//	"OCI runtime exec failed:"     — runtime couldn't set up the
+//	                                  process (always emitted with the
+//	                                  trailing colon by runc/crun)
 //
-// We check both: 125 alone is unambiguous, and the prefixes catch cases
-// where the daemon mapped its failure to a different exit code.
+// 125 alone is unambiguous; the prefixes catch cases where the daemon
+// mapped its failure to a different exit code.
 func dockerExecLayerError(stderr string, exitCode int) bool {
 	if exitCode == 125 {
 		return true
@@ -500,8 +547,7 @@ func dockerExecLayerError(stderr string, exitCode int) bool {
 	switch {
 	case strings.HasPrefix(s, "Error response from daemon:"),
 		strings.HasPrefix(s, "Error: No such container"),
-		strings.Contains(s, "OCI runtime exec failed"),
-		strings.Contains(s, "is not running"):
+		strings.HasPrefix(s, "OCI runtime exec failed:"):
 		return true
 	}
 	return false

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -126,12 +126,23 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 	// supported in busybox 1.30+, Alpine 3.10+, Debian/Ubuntu coreutils,
 	// and most distroless bases; users with stricter base images can
 	// override via environment.entrypoint.
+	//
+	// Docker treats positional args after the image as CMD, NOT as an
+	// ENTRYPOINT override. If the image already declares an ENTRYPOINT
+	// (e.g. `python`, `java -jar app.jar`), our `sleep infinity` would
+	// arrive as arguments to that entrypoint and the container would
+	// exit immediately. Using `--entrypoint` explicitly replaces the
+	// image's entrypoint with the user's chosen binary, and any
+	// remaining args go into the CMD slot.
 	entry := r.cfg.Entrypoint
 	if len(entry) == 0 {
 		entry = []string{"sleep", "infinity"}
 	}
+	args = append(args, "--entrypoint", entry[0])
 	args = append(args, r.cfg.Image)
-	args = append(args, entry...)
+	if len(entry) > 1 {
+		args = append(args, entry[1:]...)
+	}
 
 	stdout, stderr, exitCode, err := r.run(ctx, r.cli, args...)
 	if err != nil || exitCode != 0 {
@@ -177,6 +188,12 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 }
 
 // Close removes the container (when cfg.Delete is true) or just stops it.
+//
+// On the rm path the container handle is kept until rm -f reports success —
+// if the daemon hiccups, the caller can re-invoke Close on the same runtime
+// to retry cleanup. The preserve path (cfg.Delete=false) intentionally
+// clears the handle because the user has opted out of cleanup; the
+// container is theirs to manage from there.
 func (r *DockerRuntime) Close() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -186,19 +203,23 @@ func (r *DockerRuntime) Close() error {
 	}
 	ctx := context.Background()
 	id := r.containerID
-	r.containerID = ""
-	r.started = false
 
 	if !r.cfg.Delete {
 		logging.Debugf("DockerRuntime.Close: skipping rm, container preserved: %s", id)
 		// best-effort stop; ignore error so the user can still attach.
 		_, _, _, _ = r.run(ctx, r.cli, "stop", "--time", "5", id)
+		r.containerID = ""
+		r.started = false
 		return nil
 	}
 	_, stderr, exitCode, err := r.run(ctx, r.cli, "rm", "-f", id)
 	if err != nil || exitCode != 0 {
+		// Leave r.containerID / r.started intact so the caller can retry
+		// Close after the transient docker / daemon error clears.
 		return fmt.Errorf("docker rm -f %s failed (exit=%d): %s: %w", id, exitCode, strings.TrimSpace(stderr), err)
 	}
+	r.containerID = ""
+	r.started = false
 	return nil
 }
 
@@ -339,7 +360,11 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 	for _, kv := range overlayEnvList(r.cfg.Env, opts.Env) {
 		args = append(args, "--env", kv)
 	}
-	args = append(args, r.containerID, "bash", "-c", command)
+	// Use `sh -c` rather than `bash -c` so the docker runtime works on
+	// minimal base images (alpine, distroless, busybox, plain debian
+	// without bash). All shell snippets the rest of the codebase ships
+	// (setup_steps, judge scripts, agent commands) are POSIX-compatible.
+	args = append(args, r.containerID, "sh", "-c", command)
 	span.SetAttributes(
 		attribute.String("process.command", command),
 		attribute.String("process.cwd", cwd),
@@ -431,19 +456,26 @@ func dockerContainerName() (string, error) {
 }
 
 // overlayEnvList returns just the union of persistentEnv and callEnv as
-// KEY=VALUE strings (callEnv wins on key conflicts). Variable expansion uses
-// the host environment, mirroring mergeEnv's semantics for opts.Env values
-// that reference $VAR — so users can pass `KEY=${HOST_VAR}` and have it
-// resolve before the value lands inside the container.
+// KEY=VALUE strings (callEnv wins on key conflicts). Values are passed
+// LITERALLY — no host-env expansion happens here.
+//
+// Expanding `$VAR` against the host's environment before passing the value
+// to `docker --env` is dangerous: it silently rewrites container-relative
+// variables like PATH/HOME/USER with whatever the host's value happens to
+// be, which breaks command lookup inside otherwise valid images (e.g.
+// passing `PATH=$PATH:/tooling` would clobber the image's PATH with the
+// macOS `/opt/homebrew/...`).
+//
+// Users who genuinely need a host value forwarded into the container
+// should write the literal expansion themselves at the call site, or use
+// a setup_step that sources it inside the container.
 func overlayEnvList(persistentEnv, callEnv map[string]string) []string {
 	overlay := mergeEnvMaps(persistentEnv, callEnv)
 	if len(overlay) == 0 {
 		return nil
 	}
-	baseEnv := envMapFromList(os.Environ())
-	expanded := expandEnvMap(baseEnv, overlay)
-	out := make([]string, 0, len(expanded))
-	for k, v := range expanded {
+	out := make([]string, 0, len(overlay))
+	for k, v := range overlay {
 		out = append(out, k+"="+v)
 	}
 	return out

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -223,7 +223,10 @@ func (r *DockerRuntime) Close() error {
 
 	if !shouldDelete {
 		logging.Debugf("DockerRuntime.Close: skipping rm, container preserved: %s", id)
-		_, _, _, _ = r.run(ctx, r.cli, "stop", "--time", "5", id)
+		_, stderr, exitCode, err := r.run(ctx, r.cli, "stop", "--time", "5", id)
+		if err != nil || exitCode != 0 {
+			return dockerCLIErr(stderr, exitCode, err, "docker stop %s failed (preserve path)", id)
+		}
 		r.mu.Lock()
 		r.containerID = ""
 		r.started = false

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -170,13 +170,9 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 	// "Created"-state container hanging around forever.
 	_, startStderr, startExit, startErr := r.run(ctx, r.cli, "start", id)
 	if startErr != nil || startExit != 0 {
-		// best-effort cleanup; ignore failure here since we already have
-		// a more informative error to return. Bounded by dockerCleanupTimeout
-		// so a hung daemon can't keep r.mu held forever — without the
-		// timeout, context.WithoutCancel drops the parent deadline and a
-		// stuck docker would deadlock Create indefinitely.
-		r.rollbackRemove(ctx, id)
-		r.containerID = ""
+		if r.rollbackRemove(ctx, id) == nil {
+			r.containerID = ""
+		}
 		return dockerCLIErr(startStderr, startExit, startErr, "docker start %s failed", id)
 	}
 	r.started = true
@@ -189,9 +185,10 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 	// here surfaces any real failure (read-only fs, permissions) right
 	// at Create() time instead.
 	if _, mkStderr, mkExit, mkErr := r.run(ctx, r.cli, "exec", id, "mkdir", "-p", r.workspace); mkErr != nil || mkExit != 0 {
-		r.rollbackRemove(ctx, id)
-		r.containerID = ""
-		r.started = false
+		if r.rollbackRemove(ctx, id) == nil {
+			r.containerID = ""
+			r.started = false
+		}
 		return dockerCLIErr(mkStderr, mkExit, mkErr, "docker exec mkdir -p %s failed", r.workspace)
 	}
 	return nil
@@ -201,12 +198,18 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 // Create. Detached from the caller's context so cancellation/deadline of
 // the original call doesn't skip cleanup, but bounded by dockerCleanupTimeout
 // so a wedged daemon still releases the runtime mutex within a usable
-// window. The cleanup is best-effort: any error is swallowed because we
-// already have a more informative one to return to the caller.
-func (r *DockerRuntime) rollbackRemove(_ context.Context, id string) {
+// window. Returns nil when the container was successfully removed, or an
+// error if cleanup failed (in which case the caller should retain
+// containerID so a subsequent Close can retry).
+func (r *DockerRuntime) rollbackRemove(_ context.Context, id string) error {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), dockerCleanupTimeout)
 	defer cancel()
-	_, _, _, _ = r.run(cleanupCtx, r.cli, "rm", "-f", id)
+	_, stderr, exitCode, err := r.run(cleanupCtx, r.cli, "rm", "-f", id)
+	if err != nil || exitCode != 0 {
+		logging.Debugf("DockerRuntime.rollbackRemove: rm -f %s failed (exit=%d): %s", id, exitCode, strings.TrimSpace(stderr))
+		return dockerCLIErr(stderr, exitCode, err, "docker rm -f %s failed during rollback", id)
+	}
+	return nil
 }
 
 // Close removes the container (when cfg.Delete is true) or just stops it.
@@ -216,67 +219,86 @@ func (r *DockerRuntime) rollbackRemove(_ context.Context, id string) {
 // to retry cleanup. The preserve path (cfg.Delete=false) intentionally
 // clears the handle because the user has opted out of cleanup; the
 // container is theirs to manage from there.
+//
+// Close uses a bounded context (dockerCleanupTimeout) so a wedged daemon
+// cannot block the caller indefinitely.
 func (r *DockerRuntime) Close() error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	if r.containerID == "" {
+		r.mu.Unlock()
 		return nil
 	}
-	ctx := context.Background()
 	id := r.containerID
+	shouldDelete := r.cfg.Delete
+	r.mu.Unlock()
 
-	if !r.cfg.Delete {
+	ctx, cancel := context.WithTimeout(context.Background(), dockerCleanupTimeout)
+	defer cancel()
+
+	if !shouldDelete {
 		logging.Debugf("DockerRuntime.Close: skipping rm, container preserved: %s", id)
-		// best-effort stop; ignore error so the user can still attach.
 		_, _, _, _ = r.run(ctx, r.cli, "stop", "--time", "5", id)
+		r.mu.Lock()
 		r.containerID = ""
 		r.started = false
+		r.mu.Unlock()
 		return nil
 	}
 	_, stderr, exitCode, err := r.run(ctx, r.cli, "rm", "-f", id)
+	r.mu.Lock()
 	if err != nil || exitCode != 0 {
-		// Leave r.containerID / r.started intact so the caller can retry
-		// Close after the transient docker / daemon error clears.
+		r.mu.Unlock()
 		return dockerCLIErr(stderr, exitCode, err, "docker rm -f %s failed", id)
 	}
 	r.containerID = ""
 	r.started = false
+	r.mu.Unlock()
 	return nil
 }
 
 // Start starts the container if it is not already running.
 func (r *DockerRuntime) Start(ctx context.Context) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	if r.containerID == "" {
+		r.mu.Unlock()
 		return errors.New("docker runtime: Start called before Create")
 	}
 	if r.started {
+		r.mu.Unlock()
 		return nil
 	}
-	_, stderr, exitCode, err := r.run(ctx, r.cli, "start", r.containerID)
+	id := r.containerID
+	r.mu.Unlock()
+
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "start", id)
 	if err != nil || exitCode != 0 {
-		return dockerCLIErr(stderr, exitCode, err, "docker start %s failed", r.containerID)
+		return dockerCLIErr(stderr, exitCode, err, "docker start %s failed", id)
 	}
+
+	r.mu.Lock()
 	r.started = true
+	r.mu.Unlock()
 	return nil
 }
 
 // Stop stops the container with a graceful timeout. Idempotent.
 func (r *DockerRuntime) Stop(ctx context.Context) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	if r.containerID == "" || !r.started {
+		r.mu.Unlock()
 		return nil
 	}
-	_, stderr, exitCode, err := r.run(ctx, r.cli, "stop", "--time", "5", r.containerID)
+	id := r.containerID
+	r.mu.Unlock()
+
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "stop", "--time", "5", id)
 	if err != nil || exitCode != 0 {
-		return dockerCLIErr(stderr, exitCode, err, "docker stop %s failed", r.containerID)
+		return dockerCLIErr(stderr, exitCode, err, "docker stop %s failed", id)
 	}
+
+	r.mu.Lock()
 	r.started = false
+	r.mu.Unlock()
 	return nil
 }
 
@@ -378,6 +400,9 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 	}
 	if !path.IsAbs(cwd) {
 		cwd = path.Join(r.workspace, cwd)
+	}
+	if !isSubPath(r.workspace, cwd) {
+		return ExecResult{}, fmt.Errorf("docker runtime: cwd %q escapes workspace %q", opts.Cwd, r.workspace)
 	}
 	args = append(args, "--workdir", cwd)
 	// mergeEnv covers cfg.Env + opts.Env, but here we want to keep the
@@ -497,6 +522,17 @@ func (r *DockerRuntime) remotePath(p string) string {
 	return path.Join(r.workspace, c)
 }
 
+// isSubPath reports whether child is equal to parent or is a subdirectory
+// of parent. Both paths are cleaned before comparison.
+func isSubPath(parent, child string) bool {
+	p := path.Clean(parent)
+	c := path.Clean(child)
+	if c == p {
+		return true
+	}
+	return strings.HasPrefix(c, p+"/")
+}
+
 // dockerCLIErr formats a "docker CLI invocation failed" error. The CLI exits
 // non-zero with err==nil for ordinary process failures (runDockerCommand
 // returns err only when docker itself couldn't run), so a blind `%w, err`
@@ -528,14 +564,26 @@ func dockerCLIErr(stderr string, exitCode int, err error, format string, args ..
 // that legitimately prints e.g. `redis is not running` and exits 1 isn't
 // misclassified as an infra fault.
 //
-//	"Error response from daemon:"  — daemon refused (covers the
-//	                                  stopped-container variant
-//	                                  "Error response from daemon:
-//	                                  Container X is not running")
-//	"Error: No such container"     — container vanished
-//	"OCI runtime exec failed:"     — runtime couldn't set up the
-//	                                  process (always emitted with the
-//	                                  trailing colon by runc/crun)
+//	"Error response from daemon:"            — daemon refused (covers
+//	                                            the stopped-container
+//	                                            variant "Error response
+//	                                            from daemon: Container
+//	                                            X is not running")
+//	"Error: No such container"               — container vanished
+//	"OCI runtime exec failed:"               — runtime couldn't set
+//	                                            up the process (always
+//	                                            emitted with the
+//	                                            trailing colon by
+//	                                            runc/crun)
+//	"Cannot connect to the Docker daemon"    — CLI couldn't reach the
+//	                                            daemon at all (daemon
+//	                                            down, wrong socket path,
+//	                                            permission denied on
+//	                                            socket); always prefix.
+//	"error during connect:"                  — newer docker CLI variant
+//	                                            of the same disconnect
+//	                                            failure (TCP/TLS-backed
+//	                                            daemons in particular).
 //
 // 125 alone is unambiguous; the prefixes catch cases where the daemon
 // mapped its failure to a different exit code.
@@ -547,7 +595,9 @@ func dockerExecLayerError(stderr string, exitCode int) bool {
 	switch {
 	case strings.HasPrefix(s, "Error response from daemon:"),
 		strings.HasPrefix(s, "Error: No such container"),
-		strings.HasPrefix(s, "OCI runtime exec failed:"):
+		strings.HasPrefix(s, "OCI runtime exec failed:"),
+		strings.HasPrefix(s, "Cannot connect to the Docker daemon"),
+		strings.HasPrefix(s, "error during connect:"):
 		return true
 	}
 	return false

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -461,7 +461,7 @@ func classifyExecResult(ctx context.Context, result ExecResult, err error, comma
 	if err != nil {
 		return dockerCLIErr(result.Stderr, result.ExitCode, err, "docker exec failed")
 	}
-	if result.ExitCode != 0 && dockerExecLayerError(result.Stderr, result.ExitCode) {
+	if result.ExitCode != 0 && dockerExecLayerError(result.Stderr) {
 		return dockerCLIErr(result.Stderr, result.ExitCode, nil, "docker exec layer failure")
 	}
 	return nil
@@ -552,15 +552,8 @@ func dockerCLIErr(stderr string, exitCode int, err error, format string, args ..
 // evaluator's infra-fault retry path triggers instead of treating them as
 // ordinary FAIL results.
 //
-// docker exec exit-code conventions:
-//
-//	125 — daemon-level error (couldn't accept the exec request at all)
-//	126 — container exists but the command cannot be invoked
-//	127 — command not found inside the container
-//
-// Plus daemon-emitted stderr that means "this never reached the user's
-// command". Match prefixes only (not bare substrings) so a user script
-// that legitimately prints e.g. `redis is not running` and exits 1 isn't
+// Match prefixes only (not bare substrings) so a user script that
+// legitimately prints e.g. `redis is not running` and exits 1 isn't
 // misclassified as an infra fault.
 //
 //	"Error response from daemon:"            — daemon refused (covers
@@ -584,10 +577,12 @@ func dockerCLIErr(stderr string, exitCode int, err error, format string, args ..
 //	                                            failure (TCP/TLS-backed
 //	                                            daemons in particular).
 //
-// Exit code 125 combined with daemon/OCI stderr is a definitive layer
-// fault. Without confirming stderr, a user command that exits 125 would
-// be misclassified.
-func dockerExecLayerError(stderr string, exitCode int) bool {
+// Exit code is intentionally not used: docker-container-exec(1) only
+// reserves 126/127 for Docker's own use, and a user command that exits
+// 125 with empty stderr is indistinguishable from a daemon failure that
+// somehow emitted no stderr — be conservative and classify by stderr
+// only. Real daemon errors always print one of the prefixes above.
+func dockerExecLayerError(stderr string) bool {
 	s := strings.TrimSpace(stderr)
 	switch {
 	case strings.HasPrefix(s, "Error response from daemon:"),
@@ -595,8 +590,6 @@ func dockerExecLayerError(stderr string, exitCode int) bool {
 		strings.HasPrefix(s, "OCI runtime exec failed:"),
 		strings.HasPrefix(s, "Cannot connect to the Docker daemon"),
 		strings.HasPrefix(s, "error during connect:"):
-		return true
-	case exitCode == 125 && s == "":
 		return true
 	}
 	return false

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -146,7 +146,7 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 
 	stdout, stderr, exitCode, err := r.run(ctx, r.cli, args...)
 	if err != nil || exitCode != 0 {
-		return fmt.Errorf("docker create failed (exit=%d): %s: %w", exitCode, strings.TrimSpace(stderr), err)
+		return dockerCLIErr(stderr, exitCode, err, "docker create failed")
 	}
 	id := strings.TrimSpace(stdout)
 	if id == "" {
@@ -167,7 +167,7 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 		// a more informative error to return.
 		_, _, _, _ = r.run(context.WithoutCancel(ctx), r.cli, "rm", "-f", id)
 		r.containerID = ""
-		return fmt.Errorf("docker start %s failed (exit=%d): %s: %w", id, startExit, strings.TrimSpace(startStderr), startErr)
+		return dockerCLIErr(startStderr, startExit, startErr, "docker start %s failed", id)
 	}
 	r.started = true
 
@@ -182,7 +182,7 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 		_, _, _, _ = r.run(context.WithoutCancel(ctx), r.cli, "rm", "-f", id)
 		r.containerID = ""
 		r.started = false
-		return fmt.Errorf("docker exec mkdir -p %s failed (exit=%d): %s: %w", r.workspace, mkExit, strings.TrimSpace(mkStderr), mkErr)
+		return dockerCLIErr(mkStderr, mkExit, mkErr, "docker exec mkdir -p %s failed", r.workspace)
 	}
 	return nil
 }
@@ -216,7 +216,7 @@ func (r *DockerRuntime) Close() error {
 	if err != nil || exitCode != 0 {
 		// Leave r.containerID / r.started intact so the caller can retry
 		// Close after the transient docker / daemon error clears.
-		return fmt.Errorf("docker rm -f %s failed (exit=%d): %s: %w", id, exitCode, strings.TrimSpace(stderr), err)
+		return dockerCLIErr(stderr, exitCode, err, "docker rm -f %s failed", id)
 	}
 	r.containerID = ""
 	r.started = false
@@ -236,7 +236,7 @@ func (r *DockerRuntime) Start(ctx context.Context) error {
 	}
 	_, stderr, exitCode, err := r.run(ctx, r.cli, "start", r.containerID)
 	if err != nil || exitCode != 0 {
-		return fmt.Errorf("docker start %s failed (exit=%d): %s: %w", r.containerID, exitCode, strings.TrimSpace(stderr), err)
+		return dockerCLIErr(stderr, exitCode, err, "docker start %s failed", r.containerID)
 	}
 	r.started = true
 	return nil
@@ -252,7 +252,7 @@ func (r *DockerRuntime) Stop(ctx context.Context) error {
 	}
 	_, stderr, exitCode, err := r.run(ctx, r.cli, "stop", "--time", "5", r.containerID)
 	if err != nil || exitCode != 0 {
-		return fmt.Errorf("docker stop %s failed (exit=%d): %s: %w", r.containerID, exitCode, strings.TrimSpace(stderr), err)
+		return dockerCLIErr(stderr, exitCode, err, "docker stop %s failed", r.containerID)
 	}
 	r.started = false
 	return nil
@@ -270,7 +270,7 @@ func (r *DockerRuntime) UploadFile(ctx context.Context, sourcePath, targetPath s
 	}
 	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", sourcePath, r.containerID+":"+target)
 	if err != nil || exitCode != 0 {
-		return fmt.Errorf("docker cp %s -> %s failed (exit=%d): %s: %w", sourcePath, target, exitCode, strings.TrimSpace(stderr), err)
+		return dockerCLIErr(stderr, exitCode, err, "docker cp %s -> %s failed", sourcePath, target)
 	}
 	return nil
 }
@@ -289,7 +289,7 @@ func (r *DockerRuntime) UploadDir(ctx context.Context, sourceDir, targetDir stri
 	src := strings.TrimRight(sourceDir, string(filepath.Separator)) + string(filepath.Separator) + "."
 	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", src, r.containerID+":"+target)
 	if err != nil || exitCode != 0 {
-		return fmt.Errorf("docker cp -r %s -> %s failed (exit=%d): %s: %w", sourceDir, target, exitCode, strings.TrimSpace(stderr), err)
+		return dockerCLIErr(stderr, exitCode, err, "docker cp -r %s -> %s failed", sourceDir, target)
 	}
 	return nil
 }
@@ -305,7 +305,7 @@ func (r *DockerRuntime) DownloadFile(ctx context.Context, sourcePath, targetPath
 	}
 	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", r.containerID+":"+source, targetPath)
 	if err != nil || exitCode != 0 {
-		return fmt.Errorf("docker cp %s -> %s failed (exit=%d): %s: %w", source, targetPath, exitCode, strings.TrimSpace(stderr), err)
+		return dockerCLIErr(stderr, exitCode, err, "docker cp %s -> %s failed", source, targetPath)
 	}
 	return nil
 }
@@ -323,7 +323,7 @@ func (r *DockerRuntime) DownloadDir(ctx context.Context, sourceDir, targetDir st
 	src := strings.TrimRight(source, "/") + "/."
 	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", r.containerID+":"+src, targetDir)
 	if err != nil || exitCode != 0 {
-		return fmt.Errorf("docker cp -r %s -> %s failed (exit=%d): %s: %w", source, targetDir, exitCode, strings.TrimSpace(stderr), err)
+		return dockerCLIErr(stderr, exitCode, err, "docker cp -r %s -> %s failed", source, targetDir)
 	}
 	return nil
 }
@@ -396,11 +396,22 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 		logging.WarnContextf(ctx, "stderr: %s", result.Stderr)
 	}
 
-	// docker exec returns its own non-zero exit when the container is gone
-	// or the command failed to start; surface the error to callers without
-	// mistaking it for a script-level non-zero exit.
-	if err != nil && exitCode <= 0 {
-		return result, fmt.Errorf("docker exec failed: %w", err)
+	// Two distinct failure modes need to surface as errors so the
+	// evaluator routes them through its infra-retry path instead of the
+	// ordinary FAIL path:
+	//
+	//   1. r.run itself returned err — docker CLI couldn't run, or the
+	//      parent context was cancelled / timed out.
+	//   2. docker exec returned a non-zero exit AND stderr looks like a
+	//      daemon / OCI runtime fault (missing container, runtime exec
+	//      failed, etc) — see dockerExecLayerError. A user command that
+	//      legitimately exits non-zero must NOT be wrapped; the
+	//      evaluator inspects ExitCode for those.
+	if err != nil {
+		return result, dockerCLIErr(result.Stderr, result.ExitCode, err, "docker exec failed")
+	}
+	if result.ExitCode != 0 && dockerExecLayerError(result.Stderr, result.ExitCode) {
+		return result, dockerCLIErr(result.Stderr, result.ExitCode, nil, "docker exec layer failure")
 	}
 	return result, nil
 }
@@ -433,7 +444,7 @@ func (r *DockerRuntime) ensureRemoteDir(ctx context.Context, dir string) error {
 	}
 	_, stderr, exitCode, err := r.run(ctx, r.cli, "exec", r.containerID, "mkdir", "-p", dir)
 	if err != nil || exitCode != 0 {
-		return fmt.Errorf("docker exec mkdir -p %s failed (exit=%d): %s: %w", dir, exitCode, strings.TrimSpace(stderr), err)
+		return dockerCLIErr(stderr, exitCode, err, "docker exec mkdir -p %s failed", dir)
 	}
 	return nil
 }
@@ -445,6 +456,55 @@ func (r *DockerRuntime) remotePath(p string) string {
 		return c
 	}
 	return path.Join(r.workspace, c)
+}
+
+// dockerCLIErr formats a "docker CLI invocation failed" error. The CLI exits
+// non-zero with err==nil for ordinary process failures (runDockerCommand
+// returns err only when docker itself couldn't run), so a blind `%w, err`
+// renders `%!w(<nil>)` and breaks errors.Unwrap downstream. This helper
+// conditionally appends `: %w` only when there's a real error to wrap.
+func dockerCLIErr(stderr string, exitCode int, err error, format string, args ...any) error {
+	cleanStderr := strings.TrimSpace(stderr)
+	args = append(args, exitCode, cleanStderr)
+	if err == nil {
+		return fmt.Errorf(format+" (exit=%d): %s", args...)
+	}
+	return fmt.Errorf(format+" (exit=%d): %s: %w", append(args, err)...)
+}
+
+// dockerExecLayerError reports whether stderr from a non-zero `docker exec`
+// looks like a daemon / OCI runtime fault rather than the user's command
+// exiting non-zero on its own. These need to surface as Exec errors so the
+// evaluator's infra-fault retry path triggers instead of treating them as
+// ordinary FAIL results.
+//
+// docker exec exit-code conventions:
+//
+//	125 — daemon-level error (couldn't accept the exec request at all)
+//	126 — container exists but the command cannot be invoked
+//	127 — command not found inside the container
+//
+// Plus stderr prefixes that mean "this never reached the user's command":
+//
+//	"Error response from daemon:"  — daemon refused
+//	"Error: No such container"     — container vanished
+//	"OCI runtime exec failed"      — runtime couldn't set up the process
+//
+// We check both: 125 alone is unambiguous, and the prefixes catch cases
+// where the daemon mapped its failure to a different exit code.
+func dockerExecLayerError(stderr string, exitCode int) bool {
+	if exitCode == 125 {
+		return true
+	}
+	s := strings.TrimSpace(stderr)
+	switch {
+	case strings.HasPrefix(s, "Error response from daemon:"),
+		strings.HasPrefix(s, "Error: No such container"),
+		strings.Contains(s, "OCI runtime exec failed"),
+		strings.Contains(s, "is not running"):
+		return true
+	}
+	return false
 }
 
 func dockerContainerName() (string, error) {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -131,19 +131,23 @@ func (r *DockerRuntime) Create(ctx context.Context) error {
 
 	_, startStderr, startExit, startErr := r.run(ctx, r.cli, "start", id)
 	if startErr != nil || startExit != 0 {
-		if r.rollbackRemove(ctx, id) == nil {
-			r.containerID = ""
+		primary := dockerCLIErr(startStderr, startExit, startErr, "docker start %s failed", id)
+		if rbErr := r.rollbackRemove(ctx, id); rbErr != nil {
+			return errors.Join(primary, rbErr)
 		}
-		return dockerCLIErr(startStderr, startExit, startErr, "docker start %s failed", id)
+		r.containerID = ""
+		return primary
 	}
 	r.started = true
 
 	if _, mkStderr, mkExit, mkErr := r.run(ctx, r.cli, "exec", id, "mkdir", "-p", r.workspace); mkErr != nil || mkExit != 0 {
-		if r.rollbackRemove(ctx, id) == nil {
-			r.containerID = ""
-			r.started = false
+		primary := dockerCLIErr(mkStderr, mkExit, mkErr, "docker exec mkdir -p %s failed", r.workspace)
+		if rbErr := r.rollbackRemove(ctx, id); rbErr != nil {
+			return errors.Join(primary, rbErr)
 		}
-		return dockerCLIErr(mkStderr, mkExit, mkErr, "docker exec mkdir -p %s failed", r.workspace)
+		r.containerID = ""
+		r.started = false
+		return primary
 	}
 	return nil
 }
@@ -406,7 +410,7 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 	var pathPrefix string
 	for _, kv := range overlayEnvList(r.cfg.Env, opts.Env) {
 		if k, v, _ := strings.Cut(kv, "="); k == "PATH" && strings.Contains(v, "$") {
-			pathPrefix = "export PATH=\"" + v + "\"\n"
+			pathPrefix = "export PATH=" + shellDoubleQuote(v) + "\n"
 			continue
 		}
 		args = append(args, "--env", kv)

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -302,7 +302,10 @@ func (r *DockerRuntime) UploadFile(ctx context.Context, sourcePath, targetPath s
 	if err != nil {
 		return err
 	}
-	target := r.remotePath(targetPath)
+	target, err := r.remotePath(targetPath)
+	if err != nil {
+		return err
+	}
 	if err := r.ensureRemoteDir(ctx, id, path.Dir(target)); err != nil {
 		return err
 	}
@@ -319,7 +322,10 @@ func (r *DockerRuntime) UploadDir(ctx context.Context, sourceDir, targetDir stri
 	if err != nil {
 		return err
 	}
-	target := r.remotePath(targetDir)
+	target, err := r.remotePath(targetDir)
+	if err != nil {
+		return err
+	}
 	if err := r.ensureRemoteDir(ctx, id, target); err != nil {
 		return err
 	}
@@ -339,7 +345,10 @@ func (r *DockerRuntime) DownloadFile(ctx context.Context, sourcePath, targetPath
 	if err != nil {
 		return err
 	}
-	source := r.remotePath(sourcePath)
+	source, err := r.remotePath(sourcePath)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(targetPath), dockerDirMode); err != nil {
 		return fmt.Errorf("docker runtime: create local target dir: %w", err)
 	}
@@ -356,7 +365,10 @@ func (r *DockerRuntime) DownloadDir(ctx context.Context, sourceDir, targetDir st
 	if err != nil {
 		return err
 	}
-	source := r.remotePath(sourceDir)
+	source, err := r.remotePath(sourceDir)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(targetDir, dockerDirMode); err != nil {
 		return fmt.Errorf("docker runtime: create local target dir: %w", err)
 	}
@@ -416,9 +428,15 @@ func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptio
 		args = append(args, "--env", kv)
 	}
 	// Use `sh -c` rather than `bash -c` so the docker runtime works on
-	// minimal base images (alpine, distroless, busybox, plain debian
-	// without bash). All shell snippets the rest of the codebase ships
-	// (setup_steps, judge scripts, agent commands) are POSIX-compatible.
+	// minimal base images (alpine, busybox, plain debian without bash).
+	// All shell snippets the rest of the codebase ships (setup_steps,
+	// judge scripts, agent commands) are POSIX-compatible.
+	//
+	// Shell-less images (distroless, scratch + a single binary) are NOT
+	// supported: skill-up's evaluation lifecycle (setup_steps, agent
+	// install, MCP install, judge scripts) is shell-driven end-to-end,
+	// so an image without /bin/sh isn't usable here even if Exec
+	// itself bypassed `sh -c`. Pick a base image with a POSIX shell.
 	args = append(args, id, "sh", "-c", pathPrefix+command)
 	span.SetAttributes(
 		attribute.String("process.command", command),
@@ -513,12 +531,21 @@ func (r *DockerRuntime) ensureRemoteDir(ctx context.Context, id, dir string) err
 }
 
 // remotePath returns p if absolute, otherwise joins it under r.workspace.
-func (r *DockerRuntime) remotePath(p string) string {
+// Relative inputs that escape the workspace via `..` are rejected — without
+// the isSubPath check, `path.Join("/workspace", "../etc/shadow")` normalizes
+// to `/etc/shadow`, letting Upload/Download cross the workspace boundary
+// while callers think they passed a relative path. Mirrors the cwd-escape
+// check in Exec.
+func (r *DockerRuntime) remotePath(p string) (string, error) {
 	c := path.Clean(p)
 	if path.IsAbs(c) {
-		return c
+		return c, nil
 	}
-	return path.Join(r.workspace, c)
+	joined := path.Join(r.workspace, c)
+	if !isSubPath(r.workspace, joined) {
+		return "", fmt.Errorf("docker runtime: relative path %q escapes workspace %q", p, r.workspace)
+	}
+	return joined, nil
 }
 
 // isSubPath reports whether child is equal to parent or is a subdirectory

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -1,0 +1,466 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/alibaba/skill-up/internal/logging"
+	"github.com/alibaba/skill-up/internal/observability"
+)
+
+const (
+	dockerDefaultWorkspace = "/workspace"
+	dockerDirMode          = 0o755
+	dockerNameRandomBytes  = 6
+)
+
+// dockerCommandRunner is the seam unit tests use to capture or fake the
+// invocations DockerRuntime issues against the `docker` CLI. Production code
+// uses runDockerCommand, which shells out to whatever `docker` binary is on
+// PATH (or the override in DockerRuntime.cli).
+type dockerCommandRunner func(ctx context.Context, name string, args ...string) (stdout, stderr string, exitCode int, err error)
+
+// DockerRuntime executes commands inside a local Docker container.
+//
+// Lifecycle:
+//   - Create: docker create with the configured image, entrypoint sleep loop,
+//     workspace dir, optional --network=none, optional env from cfg.Env.
+//   - Start: docker start.
+//   - Stop:  docker stop --time=5.
+//   - Close: docker rm -f (skipped when cfg.Delete is false; the container
+//     is just stopped so the user can inspect it).
+//
+// All cross-environment access flows through `docker exec` / `docker cp`, so
+// no host bind mount is required. Callers that pass a host-absolute path to
+// UploadFile/DownloadFile get a sandboxed copy of that path inside the
+// container's workspace tree — the runtime never writes to host paths from
+// inside the container.
+type DockerRuntime struct {
+	cfg       Config
+	workspace string
+
+	// cli is the command name used to invoke docker. Defaults to "docker"
+	// but tests inject alternatives (e.g. a fake binary on PATH).
+	cli string
+	// run is the function used to run docker commands. Tests override this
+	// to avoid spawning real processes.
+	run dockerCommandRunner
+
+	mu          sync.Mutex
+	containerID string // set after Create
+	started     bool
+}
+
+// NewDockerRuntime constructs a DockerRuntime from the shared Config. The
+// returned runtime is inert until Create() runs.
+func NewDockerRuntime(cfg Config) (*DockerRuntime, error) {
+	if strings.TrimSpace(cfg.Image) == "" {
+		return nil, errors.New("docker runtime requires environment.image")
+	}
+	if policy := strings.TrimSpace(strings.ToLower(cfg.NetworkPolicy)); policy == "allow_declared" {
+		// allow_declared needs FQDN-level egress filtering. Implementing
+		// that for the local docker runtime requires either an egress
+		// proxy sidecar or iptables rules in the container — both out of
+		// scope for the initial cut. Refuse loudly instead of silently
+		// allowing all egress, which would violate the user's policy.
+		return nil, errors.New("docker runtime: network_policy=allow_declared is not yet supported; use deny_all or run on opensandbox")
+	}
+	workspace := strings.TrimSpace(cfg.WorkspaceMount)
+	if workspace == "" {
+		workspace = dockerDefaultWorkspace
+	}
+	if !path.IsAbs(workspace) {
+		return nil, fmt.Errorf("docker runtime: workspace_mount must be absolute, got %q", workspace)
+	}
+	return &DockerRuntime{
+		cfg:       cfg,
+		workspace: path.Clean(workspace),
+		cli:       "docker",
+		run:       runDockerCommand,
+	}, nil
+}
+
+// Create provisions the container and starts it so subsequent Exec / Upload /
+// Download calls work without an explicit Start. The evaluator does not call
+// Start between Create and the first Exec, so Create must leave the runtime
+// fully ready (mirrors OpenSandboxRuntime, where Create both provisions and
+// connects the sandbox).
+func (r *DockerRuntime) Create(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.containerID != "" {
+		return nil
+	}
+
+	name, err := dockerContainerName()
+	if err != nil {
+		return fmt.Errorf("docker runtime: generate container name: %w", err)
+	}
+
+	args := []string{
+		"create",
+		"--name", name,
+		"--workdir", r.workspace,
+	}
+	if policy := strings.TrimSpace(strings.ToLower(r.cfg.NetworkPolicy)); policy == "deny_all" {
+		args = append(args, "--network", "none")
+	}
+	for k, v := range r.cfg.Env {
+		args = append(args, "--env", k+"="+v)
+	}
+	// Persistent entrypoint so exec calls can attach. `sleep infinity` is
+	// supported in busybox 1.30+, Alpine 3.10+, Debian/Ubuntu coreutils,
+	// and most distroless bases; users with stricter base images can
+	// override via environment.entrypoint.
+	entry := r.cfg.Entrypoint
+	if len(entry) == 0 {
+		entry = []string{"sleep", "infinity"}
+	}
+	args = append(args, r.cfg.Image)
+	args = append(args, entry...)
+
+	stdout, stderr, exitCode, err := r.run(ctx, r.cli, args...)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("docker create failed (exit=%d): %s: %w", exitCode, strings.TrimSpace(stderr), err)
+	}
+	id := strings.TrimSpace(stdout)
+	if id == "" {
+		// `docker create --name X` echoes the long ID on success; if it
+		// doesn't, fall back to the name we chose so Close can still
+		// reach the container.
+		id = name
+	}
+	r.containerID = id
+
+	// Start the container so Exec / docker cp work immediately. If start
+	// fails, tear down the half-created container to avoid leaking it on
+	// the host; otherwise the error returned to the caller would leave a
+	// "Created"-state container hanging around forever.
+	_, startStderr, startExit, startErr := r.run(ctx, r.cli, "start", id)
+	if startErr != nil || startExit != 0 {
+		// best-effort cleanup; ignore failure here since we already have
+		// a more informative error to return.
+		_, _, _, _ = r.run(context.WithoutCancel(ctx), r.cli, "rm", "-f", id)
+		r.containerID = ""
+		return fmt.Errorf("docker start %s failed (exit=%d): %s: %w", id, startExit, strings.TrimSpace(startStderr), startErr)
+	}
+	r.started = true
+
+	// Defensively create the workspace dir. `--workdir` creates the dir
+	// for `docker run`, but in the `create + start` two-step the
+	// directory is only guaranteed to exist when the first exec runs
+	// with `--workdir` — and if it doesn't, that first exec errors out
+	// with an opaque "no such file or directory" message. mkdir -p
+	// here surfaces any real failure (read-only fs, permissions) right
+	// at Create() time instead.
+	if _, mkStderr, mkExit, mkErr := r.run(ctx, r.cli, "exec", id, "mkdir", "-p", r.workspace); mkErr != nil || mkExit != 0 {
+		_, _, _, _ = r.run(context.WithoutCancel(ctx), r.cli, "rm", "-f", id)
+		r.containerID = ""
+		r.started = false
+		return fmt.Errorf("docker exec mkdir -p %s failed (exit=%d): %s: %w", r.workspace, mkExit, strings.TrimSpace(mkStderr), mkErr)
+	}
+	return nil
+}
+
+// Close removes the container (when cfg.Delete is true) or just stops it.
+func (r *DockerRuntime) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.containerID == "" {
+		return nil
+	}
+	ctx := context.Background()
+	id := r.containerID
+	r.containerID = ""
+	r.started = false
+
+	if !r.cfg.Delete {
+		logging.Debugf("DockerRuntime.Close: skipping rm, container preserved: %s", id)
+		// best-effort stop; ignore error so the user can still attach.
+		_, _, _, _ = r.run(ctx, r.cli, "stop", "--time", "5", id)
+		return nil
+	}
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "rm", "-f", id)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("docker rm -f %s failed (exit=%d): %s: %w", id, exitCode, strings.TrimSpace(stderr), err)
+	}
+	return nil
+}
+
+// Start starts the container if it is not already running.
+func (r *DockerRuntime) Start(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.containerID == "" {
+		return errors.New("docker runtime: Start called before Create")
+	}
+	if r.started {
+		return nil
+	}
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "start", r.containerID)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("docker start %s failed (exit=%d): %s: %w", r.containerID, exitCode, strings.TrimSpace(stderr), err)
+	}
+	r.started = true
+	return nil
+}
+
+// Stop stops the container with a graceful timeout. Idempotent.
+func (r *DockerRuntime) Stop(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.containerID == "" || !r.started {
+		return nil
+	}
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "stop", "--time", "5", r.containerID)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("docker stop %s failed (exit=%d): %s: %w", r.containerID, exitCode, strings.TrimSpace(stderr), err)
+	}
+	r.started = false
+	return nil
+}
+
+// UploadFile copies a single file from the host into the container.
+// targetPath may be relative to the workspace or an absolute container path.
+func (r *DockerRuntime) UploadFile(ctx context.Context, sourcePath, targetPath string) error {
+	if err := r.ensureCreated(); err != nil {
+		return err
+	}
+	target := r.remotePath(targetPath)
+	if err := r.ensureRemoteDir(ctx, path.Dir(target)); err != nil {
+		return err
+	}
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", sourcePath, r.containerID+":"+target)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("docker cp %s -> %s failed (exit=%d): %s: %w", sourcePath, target, exitCode, strings.TrimSpace(stderr), err)
+	}
+	return nil
+}
+
+// UploadDir recursively copies a directory tree from the host into the container.
+func (r *DockerRuntime) UploadDir(ctx context.Context, sourceDir, targetDir string) error {
+	if err := r.ensureCreated(); err != nil {
+		return err
+	}
+	target := r.remotePath(targetDir)
+	if err := r.ensureRemoteDir(ctx, target); err != nil {
+		return err
+	}
+	// `docker cp <srcDir>/. <ctr>:<dst>` copies contents into dst, which
+	// matches the UploadDir contract (host srcDir tree → container dst tree).
+	src := strings.TrimRight(sourceDir, string(filepath.Separator)) + string(filepath.Separator) + "."
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", src, r.containerID+":"+target)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("docker cp -r %s -> %s failed (exit=%d): %s: %w", sourceDir, target, exitCode, strings.TrimSpace(stderr), err)
+	}
+	return nil
+}
+
+// DownloadFile copies a single file from the container to the host.
+func (r *DockerRuntime) DownloadFile(ctx context.Context, sourcePath, targetPath string) error {
+	if err := r.ensureCreated(); err != nil {
+		return err
+	}
+	source := r.remotePath(sourcePath)
+	if err := os.MkdirAll(filepath.Dir(targetPath), dockerDirMode); err != nil {
+		return fmt.Errorf("docker runtime: create local target dir: %w", err)
+	}
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", r.containerID+":"+source, targetPath)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("docker cp %s -> %s failed (exit=%d): %s: %w", source, targetPath, exitCode, strings.TrimSpace(stderr), err)
+	}
+	return nil
+}
+
+// DownloadDir recursively copies a directory from the container to the host.
+func (r *DockerRuntime) DownloadDir(ctx context.Context, sourceDir, targetDir string) error {
+	if err := r.ensureCreated(); err != nil {
+		return err
+	}
+	source := r.remotePath(sourceDir)
+	if err := os.MkdirAll(targetDir, dockerDirMode); err != nil {
+		return fmt.Errorf("docker runtime: create local target dir: %w", err)
+	}
+	// `<ctr>:<srcDir>/.` → host targetDir copies contents into targetDir.
+	src := strings.TrimRight(source, "/") + "/."
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "cp", r.containerID+":"+src, targetDir)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("docker cp -r %s -> %s failed (exit=%d): %s: %w", source, targetDir, exitCode, strings.TrimSpace(stderr), err)
+	}
+	return nil
+}
+
+// Exec runs a bash command inside the container.
+func (r *DockerRuntime) Exec(ctx context.Context, command string, opts ExecOptions) (ExecResult, error) {
+	if err := r.ensureCreated(); err != nil {
+		return ExecResult{}, err
+	}
+
+	ctx, span := observability.Tracer().Start(ctx, "runtime.exec")
+	defer span.End()
+	startTime := time.Now()
+
+	if opts.TimeoutSec > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(opts.TimeoutSec)*time.Second)
+		defer cancel()
+	}
+
+	args := []string{"exec"}
+	cwd := opts.Cwd
+	if cwd == "" {
+		cwd = r.workspace
+	}
+	if !path.IsAbs(cwd) {
+		cwd = path.Join(r.workspace, cwd)
+	}
+	args = append(args, "--workdir", cwd)
+	// mergeEnv covers cfg.Env + opts.Env, but here we want to keep the
+	// container's own env (PATH, HOME, ...) intact and just layer the
+	// caller-supplied vars on top — so pass only the merged overlay to
+	// docker, not the full host env.
+	for _, kv := range overlayEnvList(r.cfg.Env, opts.Env) {
+		args = append(args, "--env", kv)
+	}
+	args = append(args, r.containerID, "bash", "-c", command)
+	span.SetAttributes(
+		attribute.String("process.command", command),
+		attribute.String("process.cwd", cwd),
+		attribute.String("runtime.type", "docker"),
+	)
+
+	stdout, stderr, exitCode, err := r.run(ctx, r.cli, args...)
+	result := ExecResult{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		ExitCode: exitCode,
+	}
+	span.SetAttributes(attribute.Int("process.exit_code", result.ExitCode))
+	observability.RecordRuntimeExec(ctx, result.ExitCode, time.Since(startTime).Milliseconds())
+
+	switch {
+	case result.ExitCode == -1 && ctx.Err() != nil:
+		logging.ErrorContextf(ctx, "docker exec killed by context (%v); command: %s", ctx.Err(), maskCommand(command))
+		if result.Stderr != "" {
+			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
+		}
+		return result, ctx.Err()
+	case result.ExitCode != 0:
+		logNonZeroExit(ctx, result.ExitCode, command)
+		if result.Stderr != "" {
+			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
+		}
+	case result.Stderr != "":
+		logging.WarnContextf(ctx, "stderr: %s", result.Stderr)
+	}
+
+	// docker exec returns its own non-zero exit when the container is gone
+	// or the command failed to start; surface the error to callers without
+	// mistaking it for a script-level non-zero exit.
+	if err != nil && exitCode <= 0 {
+		return result, fmt.Errorf("docker exec failed: %w", err)
+	}
+	return result, nil
+}
+
+// Workspace returns the in-container workspace path. Unlike NoneRuntime, this
+// path is not directly accessible from the host — callers must use
+// UploadFile/DownloadFile to move data in and out.
+func (r *DockerRuntime) Workspace() string {
+	return r.workspace
+}
+
+// RequiresProcessSandbox reports that container isolation already constrains
+// agent execution; agents do not need to enable their own process sandbox.
+func (r *DockerRuntime) RequiresProcessSandbox() bool {
+	return false
+}
+
+func (r *DockerRuntime) ensureCreated() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.containerID == "" {
+		return errors.New("docker runtime: container not created (call Create first)")
+	}
+	return nil
+}
+
+func (r *DockerRuntime) ensureRemoteDir(ctx context.Context, dir string) error {
+	if dir == "" || dir == "/" {
+		return nil
+	}
+	_, stderr, exitCode, err := r.run(ctx, r.cli, "exec", r.containerID, "mkdir", "-p", dir)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("docker exec mkdir -p %s failed (exit=%d): %s: %w", dir, exitCode, strings.TrimSpace(stderr), err)
+	}
+	return nil
+}
+
+// remotePath returns p if absolute, otherwise joins it under r.workspace.
+func (r *DockerRuntime) remotePath(p string) string {
+	c := path.Clean(p)
+	if path.IsAbs(c) {
+		return c
+	}
+	return path.Join(r.workspace, c)
+}
+
+func dockerContainerName() (string, error) {
+	buf := make([]byte, dockerNameRandomBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return "skill-up-" + hex.EncodeToString(buf), nil
+}
+
+// overlayEnvList returns just the union of persistentEnv and callEnv as
+// KEY=VALUE strings (callEnv wins on key conflicts). Variable expansion uses
+// the host environment, mirroring mergeEnv's semantics for opts.Env values
+// that reference $VAR — so users can pass `KEY=${HOST_VAR}` and have it
+// resolve before the value lands inside the container.
+func overlayEnvList(persistentEnv, callEnv map[string]string) []string {
+	overlay := mergeEnvMaps(persistentEnv, callEnv)
+	if len(overlay) == 0 {
+		return nil
+	}
+	baseEnv := envMapFromList(os.Environ())
+	expanded := expandEnvMap(baseEnv, overlay)
+	out := make([]string, 0, len(expanded))
+	for k, v := range expanded {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+// runDockerCommand executes the docker CLI in a child process and returns
+// stdout, stderr, exit code, and an error if the process could not be run.
+// A non-zero docker exit code is NOT wrapped in err — callers inspect
+// exitCode directly so they can distinguish "command ran and failed" from
+// "could not run docker at all".
+func runDockerCommand(ctx context.Context, name string, args ...string) (stdout, stderr string, exitCode int, err error) {
+	//nolint:gosec // name is the docker CLI binary; args are constructed from validated config.
+	cmd := exec.CommandContext(ctx, name, args...)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	runErr := cmd.Run()
+	code, classified := classifyExecError(ctx, runErr)
+	return outBuf.String(), errBuf.String(), code, classified
+}

--- a/internal/runtime/docker_integration_test.go
+++ b/internal/runtime/docker_integration_test.go
@@ -405,8 +405,8 @@ func TestIntegration_DenyAllNetworkBlocksEgress(t *testing.T) {
 // TestIntegration_CustomEntrypointActuallyReplaces verifies that a
 // user-supplied Entrypoint is wired via `--entrypoint` and actually
 // replaces the image's own entrypoint (rather than being appended as CMD
-// and silently ignored). Uses `cat` as the long-lived entrypoint — it
-// blocks on stdin so the container stays up.
+// and silently ignored). Uses `tail -f /dev/null` as a long-lived
+// alternative to the default `sleep infinity`.
 //
 // Inspecting the container's Config.Entrypoint via `docker inspect`
 // confirms the override survives, regardless of what entrypoint the base
@@ -414,7 +414,7 @@ func TestIntegration_DenyAllNetworkBlocksEgress(t *testing.T) {
 func TestIntegration_CustomEntrypointActuallyReplaces(t *testing.T) {
 	ensureImage(t)
 	r := newIntegrationRuntime(t, Config{
-		Entrypoint: []string{"/bin/cat"},
+		Entrypoint: []string{"tail", "-f", "/dev/null"},
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -427,45 +427,13 @@ func TestIntegration_CustomEntrypointActuallyReplaces(t *testing.T) {
 	if err != nil {
 		t.Fatalf("docker inspect: %v", err)
 	}
-	if !strings.Contains(string(out), "/bin/cat") {
-		t.Fatalf("Config.Entrypoint did not record /bin/cat override: %s", out)
+	if !strings.Contains(string(out), "tail") {
+		t.Fatalf("Config.Entrypoint did not record custom override: %s", out)
 	}
 }
 
-// TestIntegration_RetainsIDOnRmFailure is the integration counterpart of
-// the unit test for Close's retry-friendly behaviour. We can't easily
-// induce a transient docker daemon error from outside, so we simulate it
-// by having Close hit a container that we removed under its feet — a
-// real-world equivalent — and then confirm the container handle is
-// retained so a second Close can converge.
-//
-// (This one is mostly a smoke test against the actual CLI exit codes;
-// the unit test owns the contract assertions.)
-func TestIntegration_CloseRetainsIDOnRmFailure(t *testing.T) {
-	ensureImage(t)
-	r := newIntegrationRuntime(t, Config{})
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if err := r.Create(ctx); err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	id := r.containerID
-
-	// Remove the container behind the runtime's back. The next Close
-	// call's `docker rm -f` will fail with "No such container".
-	if out, err := exec.CommandContext(ctx, "docker", "rm", "-f", id).CombinedOutput(); err != nil {
-		t.Fatalf("external rm: %v\n%s", err, out)
-	}
-
-	if err := r.Close(); err == nil {
-		t.Fatal("expected Close to error against missing container")
-	}
-	if r.containerID != id {
-		t.Fatalf("containerID should be retained after rm failure, got %q want %q", r.containerID, id)
-	}
-	// Manually clear so the t.Cleanup Close is a no-op (the container is
-	// already gone; we just need the runtime to forget it).
-	r.containerID = ""
-	r.started = false
-}
+// NOTE: The integration equivalent of TestDockerRuntime_CloseKeepsContainerIDOnRmFailure
+// is intentionally absent. `docker rm -f <nonexistent>` is idempotent (exit 0)
+// in real Docker, so there is no way to induce an rm failure from outside the
+// daemon without actually crashing/stopping the daemon. The unit test owns
+// this contract via fakeDocker.

--- a/internal/runtime/docker_integration_test.go
+++ b/internal/runtime/docker_integration_test.go
@@ -1,0 +1,471 @@
+//go:build docker_integration
+
+// Package runtime — docker_integration_test.go
+//
+// End-to-end integration tests that exercise DockerRuntime against a real
+// `docker` daemon. The unit tests in docker_test.go fake the CLI and only
+// verify the argv we build; these tests prove the runtime actually works
+// against `docker create` / `start` / `exec` / `cp` / `rm` as shipped.
+//
+// Gated by the `docker_integration` build tag so a plain `go test ./...`
+// never tries to talk to docker. Run with:
+//
+//	go test -tags docker_integration -count=1 -v ./internal/runtime/
+//
+// Tests skip cleanly if the docker daemon is unreachable, so the same
+// command is safe to run on a machine without docker — you just get
+// "SKIP" lines instead of failures.
+//
+// Image: dockerIntegrationImage (default alpine:3.20). Alpine ships busybox
+// + `sh` but no `bash` — picked deliberately so the test would fail if the
+// runtime's switch from `bash -c` to `sh -c` ever regressed.
+
+package runtime
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// dockerIntegrationImage is the base image used for every integration test.
+// Override via the SKILL_UP_DOCKER_INTEGRATION_IMAGE env var to point at a
+// mirror or pinned digest in CI.
+func dockerIntegrationImage() string {
+	if v := strings.TrimSpace(os.Getenv("SKILL_UP_DOCKER_INTEGRATION_IMAGE")); v != "" {
+		return v
+	}
+	return "alpine:3.20"
+}
+
+// requireDocker skips the test when the docker CLI is missing or the daemon
+// is unreachable. Pulled into a package-level once so we only probe once
+// per test binary run.
+var (
+	dockerProbeOnce sync.Once
+	dockerProbeErr  error
+)
+
+func requireDocker(t *testing.T) {
+	t.Helper()
+	dockerProbeOnce.Do(func() {
+		if _, err := exec.LookPath("docker"); err != nil {
+			dockerProbeErr = err
+			return
+		}
+		// `docker version --format {{.Server.Version}}` reaches the
+		// daemon — if it fails, the daemon is down even if the CLI
+		// exists.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "docker", "version", "--format", "{{.Server.Version}}")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			dockerProbeErr = errFromProbe(out, err)
+		}
+	})
+	if dockerProbeErr != nil {
+		t.Skipf("skipping docker integration test: %v", dockerProbeErr)
+	}
+}
+
+func errFromProbe(out []byte, err error) error {
+	if len(out) == 0 {
+		return err
+	}
+	return &dockerProbeError{msg: strings.TrimSpace(string(out)), wrapped: err}
+}
+
+type dockerProbeError struct {
+	msg     string
+	wrapped error
+}
+
+func (e *dockerProbeError) Error() string { return e.msg + ": " + e.wrapped.Error() }
+func (e *dockerProbeError) Unwrap() error { return e.wrapped }
+
+// ensureImagePulled pulls dockerIntegrationImage the first time a test asks
+// for it. Tests can run on hosts with the image cached or fresh; pulling
+// up-front keeps later `docker create` calls fast and predictable.
+var (
+	pullOnce sync.Once
+	pullErr  error
+)
+
+func ensureImage(t *testing.T) {
+	t.Helper()
+	requireDocker(t)
+	pullOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		image := dockerIntegrationImage()
+		cmd := exec.CommandContext(ctx, "docker", "pull", image)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			pullErr = errFromProbe(out, err)
+		}
+	})
+	if pullErr != nil {
+		t.Skipf("docker pull failed (likely offline): %v", pullErr)
+	}
+}
+
+// newIntegrationRuntime returns a DockerRuntime backed by the real CLI plus
+// a t.Cleanup that calls Close — every test that creates a container gets
+// guaranteed cleanup even when it fails.
+func newIntegrationRuntime(t *testing.T, cfg Config) *DockerRuntime {
+	t.Helper()
+	if cfg.Image == "" {
+		cfg.Image = dockerIntegrationImage()
+	}
+	cfg.Delete = true
+	r, err := NewDockerRuntime(cfg)
+	if err != nil {
+		t.Fatalf("NewDockerRuntime: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Logf("Close: %v", err)
+		}
+	})
+	return r
+}
+
+// TestIntegration_Lifecycle is the smoke test: create → exec a tiny
+// command → confirm it ran inside the container → Close cleans up.
+func TestIntegration_Lifecycle(t *testing.T) {
+	ensureImage(t)
+
+	r := newIntegrationRuntime(t, Config{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := r.Create(ctx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	res, err := r.Exec(ctx, "uname -a && id -u", ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit=%d stderr=%q", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "Linux") {
+		t.Errorf("expected Linux in uname output, got %q", res.Stdout)
+	}
+}
+
+// TestIntegration_NoBashStillWorks proves the docker runtime is usable on
+// minimal images that don't ship bash — this is the regression guard for
+// the `bash -c` → `sh -c` fix. Alpine has no bash by default; if Exec
+// silently regressed to `bash -c`, every command would fail with
+// "exec: bash: not found" / OCI runtime error.
+func TestIntegration_NoBashStillWorks(t *testing.T) {
+	ensureImage(t)
+	r := newIntegrationRuntime(t, Config{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := r.Create(ctx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Confirm bash really is absent in the image (sanity check).
+	probe, err := r.Exec(ctx, "command -v bash || echo NOBASH", ExecOptions{})
+	if err != nil {
+		t.Fatalf("probe Exec: %v", err)
+	}
+	if !strings.Contains(probe.Stdout, "NOBASH") {
+		t.Skipf("base image %q has bash; this test only makes sense on a bash-less image", dockerIntegrationImage())
+	}
+
+	// Real Exec must still work despite no bash.
+	res, err := r.Exec(ctx, "echo from-sh", ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit=%d stderr=%q", res.ExitCode, res.Stderr)
+	}
+	if strings.TrimSpace(res.Stdout) != "from-sh" {
+		t.Fatalf("stdout=%q", res.Stdout)
+	}
+}
+
+// TestIntegration_UploadDownloadFile round-trips a single file: write on
+// host → UploadFile → exec to read the in-container content → DownloadFile
+// to a fresh host path → compare bytes.
+func TestIntegration_UploadDownloadFile(t *testing.T) {
+	ensureImage(t)
+	r := newIntegrationRuntime(t, Config{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := r.Create(ctx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	host := t.TempDir()
+	src := filepath.Join(host, "src.txt")
+	const payload = "hello docker integration\n"
+	if err := os.WriteFile(src, []byte(payload), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.UploadFile(ctx, src, "nested/dst.txt"); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+
+	// Confirm the file landed at the expected in-container path.
+	cat, err := r.Exec(ctx, "cat nested/dst.txt", ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec cat: %v", err)
+	}
+	if cat.ExitCode != 0 {
+		t.Fatalf("cat exit=%d stderr=%q", cat.ExitCode, cat.Stderr)
+	}
+	if cat.Stdout != payload {
+		t.Fatalf("in-container payload mismatch: %q", cat.Stdout)
+	}
+
+	dst := filepath.Join(host, "out", "downloaded.txt")
+	if err := r.DownloadFile(ctx, "nested/dst.txt", dst); err != nil {
+		t.Fatalf("DownloadFile: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read downloaded: %v", err)
+	}
+	if string(got) != payload {
+		t.Fatalf("downloaded bytes mismatch: %q", string(got))
+	}
+}
+
+// TestIntegration_UploadDownloadDir round-trips a directory tree containing
+// nested subdirs and binary content. Confirms the `src/.` dot-syntax both
+// directions actually puts the *contents* of src into the destination.
+func TestIntegration_UploadDownloadDir(t *testing.T) {
+	ensureImage(t)
+	r := newIntegrationRuntime(t, Config{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := r.Create(ctx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	host := t.TempDir()
+	src := filepath.Join(host, "tree")
+	files := map[string]string{
+		"a.txt":          "alpha\n",
+		"sub/b.txt":      "bravo\n",
+		"sub/deep/c.txt": "charlie\n",
+	}
+	for rel, content := range files {
+		p := filepath.Join(src, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := r.UploadDir(ctx, src, "uploaded"); err != nil {
+		t.Fatalf("UploadDir: %v", err)
+	}
+
+	// Walk the in-container tree to make sure every file landed at the
+	// expected relative path with the expected content.
+	list, err := r.Exec(ctx, "find uploaded -type f | sort", ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec find: %v", err)
+	}
+	if list.ExitCode != 0 {
+		t.Fatalf("find exit=%d stderr=%q", list.ExitCode, list.Stderr)
+	}
+	wantPaths := []string{"uploaded/a.txt", "uploaded/sub/b.txt", "uploaded/sub/deep/c.txt"}
+	for _, p := range wantPaths {
+		if !strings.Contains(list.Stdout, p) {
+			t.Errorf("expected %q in find output, got %q", p, list.Stdout)
+		}
+	}
+
+	dst := filepath.Join(host, "downloaded")
+	if err := r.DownloadDir(ctx, "uploaded", dst); err != nil {
+		t.Fatalf("DownloadDir: %v", err)
+	}
+	for rel, want := range files {
+		got, err := os.ReadFile(filepath.Join(dst, rel))
+		if err != nil {
+			t.Fatalf("read downloaded %s: %v", rel, err)
+		}
+		if string(got) != want {
+			t.Fatalf("downloaded %s mismatch: got %q want %q", rel, string(got), want)
+		}
+	}
+}
+
+// TestIntegration_EnvLayering verifies that Env from cfg + opts arrives in
+// the container, callEnv wins on conflict, and crucially that PATH is NOT
+// clobbered by host expansion (this is the regression guard for the
+// overlayEnvList host-expansion fix).
+func TestIntegration_EnvLayering(t *testing.T) {
+	ensureImage(t)
+
+	// Set a unique host PATH that should NOT leak into the container.
+	t.Setenv("DOCKER_INT_TEST_HOST_ONLY", "this-must-not-appear-in-container")
+
+	r := newIntegrationRuntime(t, Config{
+		Env: map[string]string{
+			"FROM_CFG":     "cfgvalue",
+			"BOTH":         "from-cfg",
+			"PATH_LITERAL": "$PATH:/extra", // must arrive literally, not expanded
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := r.Create(ctx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	res, err := r.Exec(ctx, `printf 'FROM_CFG=%s\nBOTH=%s\nFROM_OPTS=%s\nPATH_LITERAL=%s\nHOSTLEAK=%s\nCONTAINER_PATH=%s\n' "$FROM_CFG" "$BOTH" "$FROM_OPTS" "$PATH_LITERAL" "$DOCKER_INT_TEST_HOST_ONLY" "$PATH"`, ExecOptions{
+		Env: map[string]string{
+			"BOTH":      "from-opts", // wins
+			"FROM_OPTS": "optsvalue",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit=%d stderr=%q", res.ExitCode, res.Stderr)
+	}
+	out := res.Stdout
+	checks := map[string]string{
+		"FROM_CFG=cfgvalue":         "cfg.Env value should arrive in container",
+		"BOTH=from-opts":            "opts.Env should override cfg.Env on conflict",
+		"FROM_OPTS=optsvalue":       "opts.Env value should arrive in container",
+		"PATH_LITERAL=$PATH:/extra": "values must NOT be expanded against host env before docker --env",
+		"HOSTLEAK=":                 "unrelated host env vars must NOT leak into container",
+	}
+	for substr, why := range checks {
+		if !strings.Contains(out, substr) {
+			t.Errorf("missing %q in container output (%s):\n%s", substr, why, out)
+		}
+	}
+	// CONTAINER_PATH is whatever the image set — should NOT be the host's
+	// macOS-y PATH. Cheap heuristic: alpine's default contains /usr/local/sbin.
+	if !strings.Contains(out, "CONTAINER_PATH=/usr/local/sbin") && !strings.Contains(out, "CONTAINER_PATH=/usr/sbin") {
+		t.Errorf("container PATH looks suspiciously like a host PATH leak:\n%s", out)
+	}
+}
+
+// TestIntegration_DenyAllNetworkBlocksEgress verifies network_policy=deny_all
+// actually disables network access at the container level.
+func TestIntegration_DenyAllNetworkBlocksEgress(t *testing.T) {
+	ensureImage(t)
+
+	// Baseline: without policy, the container can resolve+reach a public
+	// DNS name. Some CI environments have flaky egress, so we skip the
+	// whole test (not just the policy half) when the baseline doesn't
+	// behave — otherwise we'd report a false positive for deny_all.
+	baseline := newIntegrationRuntime(t, Config{})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := baseline.Create(ctx); err != nil {
+		t.Fatalf("baseline Create: %v", err)
+	}
+	res, err := baseline.Exec(ctx, "wget -q -O- --timeout=5 https://example.com/ >/dev/null 2>&1; echo $?", ExecOptions{})
+	if err != nil {
+		t.Fatalf("baseline Exec: %v", err)
+	}
+	if strings.TrimSpace(res.Stdout) != "0" {
+		t.Skipf("baseline egress unavailable (CI offline?), skipping deny_all check; baseline output: %q", res.Stdout)
+	}
+
+	// Now: deny_all should fail egress fast.
+	denied := newIntegrationRuntime(t, Config{NetworkPolicy: "deny_all"})
+	if err := denied.Create(ctx); err != nil {
+		t.Fatalf("denied Create: %v", err)
+	}
+	res2, err := denied.Exec(ctx, "wget -q -O- --timeout=5 https://example.com/ >/dev/null 2>&1; echo $?", ExecOptions{})
+	if err != nil {
+		t.Fatalf("denied Exec: %v", err)
+	}
+	if strings.TrimSpace(res2.Stdout) == "0" {
+		t.Fatalf("expected egress to fail under deny_all; got success: %q", res2.Stdout)
+	}
+}
+
+// TestIntegration_CustomEntrypointActuallyReplaces verifies that a
+// user-supplied Entrypoint is wired via `--entrypoint` and actually
+// replaces the image's own entrypoint (rather than being appended as CMD
+// and silently ignored). Uses `cat` as the long-lived entrypoint — it
+// blocks on stdin so the container stays up.
+//
+// Inspecting the container's Config.Entrypoint via `docker inspect`
+// confirms the override survives, regardless of what entrypoint the base
+// image declared.
+func TestIntegration_CustomEntrypointActuallyReplaces(t *testing.T) {
+	ensureImage(t)
+	r := newIntegrationRuntime(t, Config{
+		Entrypoint: []string{"/bin/cat"},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := r.Create(ctx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	out, err := exec.CommandContext(ctx, "docker", "inspect", "--format", "{{json .Config.Entrypoint}}", r.containerID).Output()
+	if err != nil {
+		t.Fatalf("docker inspect: %v", err)
+	}
+	if !strings.Contains(string(out), "/bin/cat") {
+		t.Fatalf("Config.Entrypoint did not record /bin/cat override: %s", out)
+	}
+}
+
+// TestIntegration_RetainsIDOnRmFailure is the integration counterpart of
+// the unit test for Close's retry-friendly behaviour. We can't easily
+// induce a transient docker daemon error from outside, so we simulate it
+// by having Close hit a container that we removed under its feet — a
+// real-world equivalent — and then confirm the container handle is
+// retained so a second Close can converge.
+//
+// (This one is mostly a smoke test against the actual CLI exit codes;
+// the unit test owns the contract assertions.)
+func TestIntegration_CloseRetainsIDOnRmFailure(t *testing.T) {
+	ensureImage(t)
+	r := newIntegrationRuntime(t, Config{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := r.Create(ctx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := r.containerID
+
+	// Remove the container behind the runtime's back. The next Close
+	// call's `docker rm -f` will fail with "No such container".
+	if out, err := exec.CommandContext(ctx, "docker", "rm", "-f", id).CombinedOutput(); err != nil {
+		t.Fatalf("external rm: %v\n%s", err, out)
+	}
+
+	if err := r.Close(); err == nil {
+		t.Fatal("expected Close to error against missing container")
+	}
+	if r.containerID != id {
+		t.Fatalf("containerID should be retained after rm failure, got %q want %q", r.containerID, id)
+	}
+	// Manually clear so the t.Cleanup Close is a no-op (the container is
+	// already gone; we just need the runtime to forget it).
+	r.containerID = ""
+	r.started = false
+}

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -654,6 +654,23 @@ func TestDockerRuntime_ExecExpandsPATHInCommand(t *testing.T) {
 	}
 }
 
+func TestDockerRuntime_ExecRejectsCommandSubstitutionInPATH(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, createScript("abc"))
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	_, err := r.Exec(context.Background(), "echo hi", ExecOptions{
+		Env: map[string]string{
+			"PATH": "$(touch /tmp/pwn):$PATH",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "command substitution") {
+		t.Fatalf("Exec with PATH=$(...) should fail with command-substitution error, got %v", err)
+	}
+}
+
 func TestDockerRuntime_ExecRejectsWorkdirEscape(t *testing.T) {
 	t.Parallel()
 	fd := newFakeDocker(t, createScript("abc"))

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -590,6 +590,27 @@ func TestDockerRuntime_ExecRejectsWorkdirEscape(t *testing.T) {
 	}
 }
 
+func TestDockerRuntime_ExecAllowsAbsoluteCwd(t *testing.T) {
+	t.Parallel()
+	script := append(createScript("abc"),
+		scriptedCall{match: "exec", response: fakeDockerResponse{stdout: "ok"}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	_, err := r.Exec(context.Background(), "id", ExecOptions{Cwd: "/"})
+	if err != nil {
+		t.Fatalf("absolute cwd should be allowed, got %v", err)
+	}
+	args := fd.callArgs(createCallCount)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--workdir /") {
+		t.Errorf("expected --workdir /; got %v", args)
+	}
+}
+
 func TestDockerRuntime_ExecPropagatesNonZeroExit(t *testing.T) {
 	t.Parallel()
 	script := append(createScript("abc"),

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -682,7 +682,10 @@ func TestDockerRuntime_ExecSurfacesLayerFailureAsError(t *testing.T) {
 		wantErr  bool
 		wantText string
 	}{
-		{"exit 125 is daemon-layer", 125, "", true, "layer failure"},
+		// exit 125 with empty stderr is NOT classified as infra: docker-container-exec(1)
+		// reserves 126/127 only; user commands (e.g. `sh -c 'exit 125'`) can legitimately
+		// exit 125 and must not be misrouted to infra-fault handling.
+		{"exit 125 with empty stderr is NOT layer", 125, "", false, ""},
 		{"daemon refused prefix", 1, "Error response from daemon: No such exec instance", true, "layer failure"},
 		{"no such container", 1, "Error: No such container: abc", true, "layer failure"},
 		{"OCI runtime failed", 126, "OCI runtime exec failed: cannot exec in stopped container", true, "layer failure"},

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -615,10 +616,15 @@ func TestDockerRuntime_ExecSurfacesLayerFailureAsError(t *testing.T) {
 		{"daemon refused prefix", 1, "Error response from daemon: No such exec instance", true, "layer failure"},
 		{"no such container", 1, "Error: No such container: abc", true, "layer failure"},
 		{"OCI runtime failed", 126, "OCI runtime exec failed: cannot exec in stopped container", true, "layer failure"},
-		{"container not running", 1, "Error response from daemon: Container abc is not running", true, "layer failure"},
+		{"container not running (daemon-prefixed)", 1, "Error response from daemon: Container abc is not running", true, "layer failure"},
 		{"plain non-zero is NOT layer error", 1, "assertion failed", false, ""},
 		{"common 2 (misuse of shell builtins) is NOT layer", 2, "syntax error", false, ""},
 		{"127 cmd-not-found stays as cmd error", 127, "sh: bogus: not found", false, ""},
+		// Regression guards against the previous over-broad substring
+		// matching: user scripts that happen to print "is not running"
+		// or "OCI runtime" must NOT be misclassified as infra faults.
+		{"user script saying redis is not running", 1, "redis is not running on port 6379", false, ""},
+		{"user script with OCI runtime in plain text", 1, "checking OCI runtime version output: skipped", false, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -642,6 +648,100 @@ func TestDockerRuntime_ExecSurfacesLayerFailureAsError(t *testing.T) {
 				t.Errorf("ExitCode = %d, want %d", res.ExitCode, tc.exit)
 			}
 		})
+	}
+}
+
+// Concurrent Close during in-flight Exec/Upload/Download must not race on
+// r.containerID. Run with -race to actually catch the regression: with the
+// old `r.containerID` reads outside the mutex, the data-race detector
+// flags the test; with snapshotContainerID under the lock, it passes.
+//
+// We use a permissive runner here (not the scripted one) because Exec and
+// Close fire in a non-deterministic order, so the call sequence isn't
+// known up front.
+func TestDockerRuntime_ExecRaceWithCloseIsSafe(t *testing.T) {
+	t.Parallel()
+
+	// Permissive runner: any subcommand is fine, return success. We
+	// just need the calls to happen so the goroutines actually exercise
+	// snapshotContainerID under contention.
+	var callCount int64
+	r, err := NewDockerRuntime(Config{Image: "alpine:3.20", Delete: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.run = func(_ context.Context, _ string, args ...string) (string, string, int, error) {
+		atomic.AddInt64(&callCount, 1)
+		// `docker create` is expected to echo the id on stdout.
+		if len(args) > 0 && args[0] == "create" {
+			return "abc\n", "", 0, nil
+		}
+		return "", "", 0, nil
+	}
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Spawn many concurrent Exec/Upload + a Close. With the old
+	// outside-the-lock reads, -race would flag this; with the snapshot
+	// pattern, every goroutine reads the id under mu and then proceeds
+	// with the local copy.
+	const workers = 16
+	var wg sync.WaitGroup
+	wg.Add(workers + 1)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			_, _ = r.Exec(context.Background(), "echo hi", ExecOptions{})
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		_ = r.Close()
+	}()
+	wg.Wait()
+
+	// Sanity check: at least some calls actually ran (Create plus
+	// either Close or some Execs). The exact number is racy because
+	// Execs that lose the race to Close return early from snapshot.
+	if atomic.LoadInt64(&callCount) < 3 {
+		t.Fatalf("expected at least 3 docker calls (create+start+mkdir), got %d", callCount)
+	}
+}
+
+// rollbackRemove must NOT block forever when the parent context has a
+// deadline and the cleanup docker call hangs. We can't easily simulate
+// a hung docker without time injection, but we can confirm the cleanup
+// runs on a context detached from the parent (a canceled parent must
+// not cancel the rollback).
+func TestDockerRuntime_RollbackUsesDetachedTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Parent context that's already canceled when Create's rollback
+	// fires. If rollbackRemove inherited the parent context's
+	// cancellation, the rm call would never reach the runner — but
+	// our script REQUIRES the rm call to happen (script consumed in
+	// order). The runner asserts unexpected leftover steps.
+	parentCtx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately so Create's parent is dead before start fails.
+
+	fd := newFakeDocker(t, []scriptedCall{
+		{match: "create", response: fakeDockerResponse{stdout: "abc\n"}},
+		{match: "start", response: fakeDockerResponse{stderr: "boom", exitCode: 125}},
+		// This rm MUST still run despite the parent context being
+		// canceled — that's the contract.
+		{match: "rm", response: fakeDockerResponse{}},
+	})
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(parentCtx); err == nil {
+		t.Fatal("expected Create to error on start failure")
+	}
+	// Verify both create AND rm fired (script fully consumed). If the
+	// rollback got skipped, the fake docker test helper would have
+	// triggered an "unexpected extra call" failure during the test —
+	// but it would NOT have flagged a missed call, so re-check here.
+	if got := len(fd.calls); got != 3 {
+		t.Fatalf("expected 3 docker calls (create, start, rm), got %d: %v", got, fd.calls)
 	}
 }
 

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -458,6 +458,47 @@ func TestDockerRuntime_UploadFileEnsuresParentDir(t *testing.T) {
 	}
 }
 
+func TestDockerRuntime_UploadDownloadRejectsRelativePathEscape(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src.txt")
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fd := newFakeDocker(t, createScript("abc"))
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cases := []string{"../etc/shadow", "../../etc/passwd", "sub/../../escape"}
+	for _, p := range cases {
+		t.Run("UploadFile/"+p, func(t *testing.T) {
+			err := r.UploadFile(context.Background(), src, p)
+			if err == nil || !strings.Contains(err.Error(), "escapes workspace") {
+				t.Fatalf("UploadFile(%q) want escape error, got %v", p, err)
+			}
+		})
+		t.Run("UploadDir/"+p, func(t *testing.T) {
+			err := r.UploadDir(context.Background(), tmp, p)
+			if err == nil || !strings.Contains(err.Error(), "escapes workspace") {
+				t.Fatalf("UploadDir(%q) want escape error, got %v", p, err)
+			}
+		})
+		t.Run("DownloadFile/"+p, func(t *testing.T) {
+			err := r.DownloadFile(context.Background(), p, filepath.Join(tmp, "out"))
+			if err == nil || !strings.Contains(err.Error(), "escapes workspace") {
+				t.Fatalf("DownloadFile(%q) want escape error, got %v", p, err)
+			}
+		})
+		t.Run("DownloadDir/"+p, func(t *testing.T) {
+			err := r.DownloadDir(context.Background(), p, filepath.Join(tmp, "outd"))
+			if err == nil || !strings.Contains(err.Error(), "escapes workspace") {
+				t.Fatalf("DownloadDir(%q) want escape error, got %v", p, err)
+			}
+		})
+	}
+}
+
 func TestDockerRuntime_DownloadFileWritesLocalDir(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -598,6 +598,74 @@ func TestDockerRuntime_ExecPropagatesNonZeroExit(t *testing.T) {
 	}
 }
 
+// Exec must surface docker-layer failures as errors (container vanished,
+// daemon refused the exec), not as ordinary non-zero exits — otherwise the
+// evaluator routes them through the normal FAIL path and skips its
+// infra-fault retry handling.
+func TestDockerRuntime_ExecSurfacesLayerFailureAsError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		exit     int
+		stderr   string
+		wantErr  bool
+		wantText string
+	}{
+		{"exit 125 is daemon-layer", 125, "", true, "layer failure"},
+		{"daemon refused prefix", 1, "Error response from daemon: No such exec instance", true, "layer failure"},
+		{"no such container", 1, "Error: No such container: abc", true, "layer failure"},
+		{"OCI runtime failed", 126, "OCI runtime exec failed: cannot exec in stopped container", true, "layer failure"},
+		{"container not running", 1, "Error response from daemon: Container abc is not running", true, "layer failure"},
+		{"plain non-zero is NOT layer error", 1, "assertion failed", false, ""},
+		{"common 2 (misuse of shell builtins) is NOT layer", 2, "syntax error", false, ""},
+		{"127 cmd-not-found stays as cmd error", 127, "sh: bogus: not found", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			script := append(createScript("abc"),
+				scriptedCall{match: "exec", response: fakeDockerResponse{stderr: tc.stderr, exitCode: tc.exit}},
+			)
+			fd := newFakeDocker(t, script)
+			r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+			if err := r.Create(context.Background()); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			res, err := r.Exec(context.Background(), "x", ExecOptions{})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v, got err=%v", tc.wantErr, err)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("err = %v, want substring %q", err, tc.wantText)
+			}
+			if res.ExitCode != tc.exit {
+				t.Errorf("ExitCode = %d, want %d", res.ExitCode, tc.exit)
+			}
+		})
+	}
+}
+
+// dockerCLIErr formats cleanly whether or not a wrapped error is present.
+// Without this, `%w, nil` renders as `%!w(<nil>)` and pollutes diagnostics.
+func TestDockerCLIErr_FormattingWithAndWithoutWrap(t *testing.T) {
+	t.Parallel()
+	// No wrapped err — must not contain %!w or <nil>.
+	clean := dockerCLIErr("boom\n", 7, nil, "docker something failed for %s", "x")
+	got := clean.Error()
+	if strings.Contains(got, "%!w") || strings.Contains(got, "<nil>") {
+		t.Fatalf("nil-wrap leaked: %q", got)
+	}
+	if !strings.Contains(got, "docker something failed for x") || !strings.Contains(got, "exit=7") || !strings.Contains(got, "boom") {
+		t.Errorf("unexpected message: %q", got)
+	}
+
+	// With a wrapped err — errors.Is must find it.
+	wrapped := dockerCLIErr("ignored", 0, context.Canceled, "docker did fail")
+	if !errors.Is(wrapped, context.Canceled) {
+		t.Fatalf("expected wrapped err to be unwrappable to context.Canceled, got %v", wrapped)
+	}
+}
+
 func TestDockerRuntime_ExecSurfacesStartupErrorWhenNoExit(t *testing.T) {
 	t.Parallel()
 	bad := errors.New("dial unix /var/run/docker.sock: no such file")

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -189,14 +189,19 @@ func TestDockerRuntime_CreatePassesNetworkAndEnvAndImage(t *testing.T) {
 	if !strings.Contains(joined, "--env FOO=bar") {
 		t.Errorf("create should pass --env FOO=bar; got %v", args)
 	}
-	// Image must appear before the entrypoint argv. Find the image and
-	// confirm `sleep infinity` follows it.
+	// Default entrypoint must be passed via the `--entrypoint sleep`
+	// flag (otherwise it lands in CMD and gets ignored when the image
+	// has its own ENTRYPOINT), and `infinity` must appear after the
+	// image as the CMD arg.
+	if !strings.Contains(joined, "--entrypoint sleep") {
+		t.Errorf("expected --entrypoint sleep for default entrypoint; got %v", args)
+	}
 	imgIdx := indexOf(args, "ubuntu:22.04")
 	if imgIdx < 0 {
 		t.Fatalf("image not in args: %v", args)
 	}
-	if imgIdx+2 >= len(args) || args[imgIdx+1] != "sleep" || args[imgIdx+2] != "infinity" {
-		t.Errorf("expected default entrypoint `sleep infinity` after image; got tail %v", args[imgIdx:])
+	if imgIdx+1 >= len(args) || args[imgIdx+1] != "infinity" {
+		t.Errorf("expected `infinity` as CMD after image; got tail %v", args[imgIdx:])
 	}
 	if !strings.Contains(joined, "--workdir "+dockerDefaultWorkspace) {
 		t.Errorf("create should set --workdir to workspace; got %v", args)
@@ -226,12 +231,50 @@ func TestDockerRuntime_CreateUsesCustomEntrypoint(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	args := fd.callArgs(0)
-	tail := args[len(args)-4:]
-	want := []string{"/usr/bin/env", "tail", "-f", "/dev/null"}
+	// User-supplied Entrypoint[0] becomes --entrypoint, remaining
+	// elements become CMD args after the image. This is what actually
+	// overrides the image's ENTRYPOINT — appending positional args
+	// after the image only sets CMD, which is masked when the image
+	// declares ENTRYPOINT.
+	if !strings.Contains(strings.Join(args, " "), "--entrypoint /usr/bin/env") {
+		t.Errorf("expected --entrypoint /usr/bin/env; got %v", args)
+	}
+	imgIdx := indexOf(args, "alpine:3.20")
+	if imgIdx < 0 {
+		t.Fatalf("image not in args: %v", args)
+	}
+	tail := args[imgIdx+1:]
+	want := []string{"tail", "-f", "/dev/null"}
+	if len(tail) != len(want) {
+		t.Fatalf("CMD tail = %v, want %v", tail, want)
+	}
 	for i, v := range want {
 		if tail[i] != v {
-			t.Fatalf("entrypoint tail = %v, want %v", tail, want)
+			t.Fatalf("CMD tail = %v, want %v", tail, want)
 		}
+	}
+}
+
+// Single-element Entrypoint should produce --entrypoint X with no trailing
+// CMD args after the image. This is the common "I just want to override
+// the image's entrypoint with a long-lived sleep binary" case.
+func TestDockerRuntime_CreateUsesSingleArgCustomEntrypoint(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, createScript("abc"))
+	r := newDockerRuntimeForTest(t, Config{
+		Image:      "alpine:3.20",
+		Entrypoint: []string{"/bin/cat"},
+	}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	args := fd.callArgs(0)
+	if !strings.Contains(strings.Join(args, " "), "--entrypoint /bin/cat") {
+		t.Errorf("expected --entrypoint /bin/cat; got %v", args)
+	}
+	imgIdx := indexOf(args, "alpine:3.20")
+	if imgIdx == -1 || imgIdx != len(args)-1 {
+		t.Errorf("image should be the last arg with no CMD; got args %v", args)
 	}
 }
 
@@ -267,6 +310,36 @@ func TestDockerRuntime_CreateRollsBackOnStartFailure(t *testing.T) {
 	}
 	if r.started {
 		t.Fatal("started should be false after rollback")
+	}
+}
+
+// Close must keep r.containerID set when `docker rm -f` errors, so the
+// caller can retry Close after a transient daemon hiccup instead of
+// silently leaking the container on the host.
+func TestDockerRuntime_CloseKeepsContainerIDOnRmFailure(t *testing.T) {
+	t.Parallel()
+	script := append(createScript("abc"),
+		scriptedCall{match: "rm", response: fakeDockerResponse{stderr: "daemon busy", exitCode: 1}},
+		scriptedCall{match: "rm", response: fakeDockerResponse{}}, // retry succeeds
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20", Delete: true}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := r.Close(); err == nil {
+		t.Fatal("expected Close to surface rm failure")
+	}
+	if r.containerID != "abc" {
+		t.Fatalf("containerID should be retained on rm failure, got %q", r.containerID)
+	}
+	// Retrying Close after the transient error must actually invoke rm
+	// again and clear the handle on success.
+	if err := r.Close(); err != nil {
+		t.Fatalf("retry Close: %v", err)
+	}
+	if r.containerID != "" {
+		t.Fatalf("containerID should be cleared after successful retry, got %q", r.containerID)
 	}
 }
 
@@ -495,9 +568,11 @@ func TestDockerRuntime_ExecPassesCwdEnvAndCommand(t *testing.T) {
 	if !strings.Contains(joined, "--env GLOBAL=yes") {
 		t.Errorf("expected --env GLOBAL=yes from cfg.Env; got %v", args)
 	}
-	// Command must be the last token, after `bash -c`.
-	if args[len(args)-3] != "bash" || args[len(args)-2] != "-c" || args[len(args)-1] != "echo hi" {
-		t.Fatalf("expected ... bash -c \"echo hi\" at tail, got %v", args)
+	// Command must be the last token, after `sh -c` (not bash — many
+	// base images don't ship bash). All shell snippets the rest of the
+	// codebase emits are POSIX-compatible.
+	if args[len(args)-3] != "sh" || args[len(args)-2] != "-c" || args[len(args)-1] != "echo hi" {
+		t.Fatalf("expected ... sh -c \"echo hi\" at tail, got %v", args)
 	}
 }
 

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -577,6 +577,19 @@ func TestDockerRuntime_ExecPassesCwdEnvAndCommand(t *testing.T) {
 	}
 }
 
+func TestDockerRuntime_ExecRejectsWorkdirEscape(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, createScript("abc"))
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	_, err := r.Exec(context.Background(), "id", ExecOptions{Cwd: "../../etc"})
+	if err == nil || !strings.Contains(err.Error(), "escapes workspace") {
+		t.Fatalf("expected workspace-escape error, got %v", err)
+	}
+}
+
 func TestDockerRuntime_ExecPropagatesNonZeroExit(t *testing.T) {
 	t.Parallel()
 	script := append(createScript("abc"),
@@ -742,6 +755,25 @@ func TestDockerRuntime_RollbackUsesDetachedTimeout(t *testing.T) {
 	// but it would NOT have flagged a missed call, so re-check here.
 	if got := len(fd.calls); got != 3 {
 		t.Fatalf("expected 3 docker calls (create, start, rm), got %d: %v", got, fd.calls)
+	}
+}
+
+// When rollbackRemove itself fails (daemon down, rm times out), Create must
+// retain containerID so the caller can still reach the container via Close.
+func TestDockerRuntime_CreateRetainsIDWhenRollbackFails(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, []scriptedCall{
+		{match: "create", response: fakeDockerResponse{stdout: "abc\n"}},
+		{match: "start", response: fakeDockerResponse{stderr: "no cgroups", exitCode: 125}},
+		{match: "rm", response: fakeDockerResponse{stderr: "daemon down", exitCode: 1}},
+	})
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	err := r.Create(context.Background())
+	if err == nil {
+		t.Fatal("expected Create to fail")
+	}
+	if r.containerID != "abc" {
+		t.Fatalf("containerID should be retained when rollback fails, got %q", r.containerID)
 	}
 }
 

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -1,0 +1,618 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeDockerCall is one captured invocation of the docker CLI.
+type fakeDockerCall struct {
+	args []string
+}
+
+// fakeDockerResponse drives what the fake CLI returns for a given call.
+type fakeDockerResponse struct {
+	stdout   string
+	stderr   string
+	exitCode int
+	err      error
+}
+
+// newFakeDocker returns a dockerCommandRunner that records every call and
+// answers each according to the supplied script (in order). The first arg
+// passed to docker (the subcommand) is asserted against script[i].match
+// when match is non-empty, so a typo in the implementation is caught loudly.
+type scriptedCall struct {
+	match    string // expected first arg (subcommand); empty = any
+	response fakeDockerResponse
+}
+
+type fakeDocker struct {
+	mu     sync.Mutex
+	calls  []fakeDockerCall
+	script []scriptedCall
+	idx    int
+	t      *testing.T
+}
+
+func newFakeDocker(t *testing.T, script []scriptedCall) *fakeDocker {
+	t.Helper()
+	return &fakeDocker{script: script, t: t}
+}
+
+func (f *fakeDocker) runner() dockerCommandRunner {
+	return func(_ context.Context, name string, args ...string) (string, string, int, error) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if name != "docker" {
+			f.t.Fatalf("unexpected docker binary name %q", name)
+		}
+		f.calls = append(f.calls, fakeDockerCall{args: append([]string(nil), args...)})
+		if f.idx >= len(f.script) {
+			f.t.Fatalf("unexpected extra docker call #%d: %v", f.idx, args)
+		}
+		step := f.script[f.idx]
+		f.idx++
+		if step.match != "" && (len(args) == 0 || args[0] != step.match) {
+			f.t.Fatalf("expected docker subcommand %q at step %d, got %v", step.match, f.idx-1, args)
+		}
+		return step.response.stdout, step.response.stderr, step.response.exitCode, step.response.err
+	}
+}
+
+func (f *fakeDocker) callArgs(i int) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[i].args
+}
+
+func newDockerRuntimeForTest(t *testing.T, cfg Config, fd *fakeDocker) *DockerRuntime {
+	t.Helper()
+	if cfg.Image == "" {
+		cfg.Image = "alpine:3.20"
+	}
+	r, err := NewDockerRuntime(cfg)
+	if err != nil {
+		t.Fatalf("NewDockerRuntime: %v", err)
+	}
+	r.run = fd.runner()
+	return r
+}
+
+// createScript returns the canonical scripted-call sequence that Create
+// performs (docker create → docker start → docker exec mkdir -p workspace).
+// Test scripts prepend this before the steps they actually want to exercise.
+// id is the container ID echoed back by the fake create call.
+func createScript(id string) []scriptedCall {
+	return []scriptedCall{
+		{match: "create", response: fakeDockerResponse{stdout: id + "\n"}},
+		{match: "start", response: fakeDockerResponse{}},
+		{match: "exec", response: fakeDockerResponse{}}, // workspace mkdir -p
+	}
+}
+
+// createCallCount is how many scripted calls createScript consumes; tests
+// add this to local offsets so they reference the right post-Create call.
+const createCallCount = 3
+
+func TestNewDockerRuntime_RequiresImage(t *testing.T) {
+	t.Parallel()
+	if _, err := NewDockerRuntime(Config{}); err == nil {
+		t.Fatal("expected error when image is missing")
+	}
+}
+
+func TestNewDockerRuntime_RejectsAllowDeclared(t *testing.T) {
+	t.Parallel()
+	_, err := NewDockerRuntime(Config{Image: "alpine:3.20", NetworkPolicy: "allow_declared"})
+	if err == nil || !strings.Contains(err.Error(), "allow_declared") {
+		t.Fatalf("expected allow_declared rejection, got %v", err)
+	}
+}
+
+func TestNewDockerRuntime_RequiresAbsoluteWorkspace(t *testing.T) {
+	t.Parallel()
+	_, err := NewDockerRuntime(Config{Image: "alpine:3.20", WorkspaceMount: "rel/path"})
+	if err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("expected absolute-path rejection, got %v", err)
+	}
+}
+
+func TestDockerRuntime_RequiresProcessSandboxFalse(t *testing.T) {
+	t.Parallel()
+	r, err := NewDockerRuntime(Config{Image: "alpine:3.20"})
+	if err != nil {
+		t.Fatalf("NewDockerRuntime: %v", err)
+	}
+	if r.RequiresProcessSandbox() {
+		t.Fatal("docker runtime should not require additional process sandbox")
+	}
+}
+
+func TestDockerRuntime_WorkspaceDefault(t *testing.T) {
+	t.Parallel()
+	r, err := NewDockerRuntime(Config{Image: "alpine:3.20"})
+	if err != nil {
+		t.Fatalf("NewDockerRuntime: %v", err)
+	}
+	if r.Workspace() != dockerDefaultWorkspace {
+		t.Fatalf("Workspace = %q, want %q", r.Workspace(), dockerDefaultWorkspace)
+	}
+}
+
+func TestDockerRuntime_CreateAndCloseDeletesContainer(t *testing.T) {
+	t.Parallel()
+	script := append(createScript("deadbeef"),
+		scriptedCall{match: "rm", response: fakeDockerResponse{}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20", Delete: true}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if r.containerID != "deadbeef" {
+		t.Fatalf("containerID = %q, want %q", r.containerID, "deadbeef")
+	}
+	if !r.started {
+		t.Fatal("Create should leave container started")
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	rmArgs := fd.callArgs(createCallCount)
+	if rmArgs[0] != "rm" || rmArgs[1] != "-f" || rmArgs[2] != "deadbeef" {
+		t.Fatalf("unexpected rm args: %v", rmArgs)
+	}
+}
+
+func TestDockerRuntime_CreatePassesNetworkAndEnvAndImage(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, createScript("abc"))
+	r := newDockerRuntimeForTest(t, Config{
+		Image:         "ubuntu:22.04",
+		NetworkPolicy: "deny_all",
+		Env:           map[string]string{"FOO": "bar"},
+	}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	args := fd.callArgs(0)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--network none") {
+		t.Errorf("create should set --network none for deny_all; got %v", args)
+	}
+	if !strings.Contains(joined, "--env FOO=bar") {
+		t.Errorf("create should pass --env FOO=bar; got %v", args)
+	}
+	// Image must appear before the entrypoint argv. Find the image and
+	// confirm `sleep infinity` follows it.
+	imgIdx := indexOf(args, "ubuntu:22.04")
+	if imgIdx < 0 {
+		t.Fatalf("image not in args: %v", args)
+	}
+	if imgIdx+2 >= len(args) || args[imgIdx+1] != "sleep" || args[imgIdx+2] != "infinity" {
+		t.Errorf("expected default entrypoint `sleep infinity` after image; got tail %v", args[imgIdx:])
+	}
+	if !strings.Contains(joined, "--workdir "+dockerDefaultWorkspace) {
+		t.Errorf("create should set --workdir to workspace; got %v", args)
+	}
+}
+
+func TestDockerRuntime_CreateOmitsNetworkArgsWithoutPolicy(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, createScript("abc"))
+	r := newDockerRuntimeForTest(t, Config{Image: "ubuntu:22.04"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if strings.Contains(strings.Join(fd.callArgs(0), " "), "--network") {
+		t.Errorf("no network flag expected when NetworkPolicy is unset; got %v", fd.callArgs(0))
+	}
+}
+
+func TestDockerRuntime_CreateUsesCustomEntrypoint(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, createScript("abc"))
+	r := newDockerRuntimeForTest(t, Config{
+		Image:      "alpine:3.20",
+		Entrypoint: []string{"/usr/bin/env", "tail", "-f", "/dev/null"},
+	}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	args := fd.callArgs(0)
+	tail := args[len(args)-4:]
+	want := []string{"/usr/bin/env", "tail", "-f", "/dev/null"}
+	for i, v := range want {
+		if tail[i] != v {
+			t.Fatalf("entrypoint tail = %v, want %v", tail, want)
+		}
+	}
+}
+
+func TestDockerRuntime_CreateFailsSurfacesStderr(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, []scriptedCall{
+		{match: "create", response: fakeDockerResponse{stderr: "image not found", exitCode: 1}},
+	})
+	r := newDockerRuntimeForTest(t, Config{Image: "missing:tag"}, fd)
+	err := r.Create(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "image not found") {
+		t.Fatalf("expected stderr in error, got %v", err)
+	}
+}
+
+// If `docker create` succeeds but `docker start` fails, Create must rm -f
+// the half-created container so it doesn't leak on the host.
+func TestDockerRuntime_CreateRollsBackOnStartFailure(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, []scriptedCall{
+		{match: "create", response: fakeDockerResponse{stdout: "abc\n"}},
+		{match: "start", response: fakeDockerResponse{stderr: "no permission", exitCode: 125}},
+		{match: "rm", response: fakeDockerResponse{}}, // cleanup
+	})
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	err := r.Create(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "no permission") {
+		t.Fatalf("expected start failure, got %v", err)
+	}
+	// Runtime state was reset so a retry is possible.
+	if r.containerID != "" {
+		t.Fatalf("containerID should be cleared on rollback, got %q", r.containerID)
+	}
+	if r.started {
+		t.Fatal("started should be false after rollback")
+	}
+}
+
+// If the workspace mkdir after start fails, Create must also rm -f the
+// running container — partial state on the host is worse than no state.
+func TestDockerRuntime_CreateRollsBackOnWorkspaceMkdirFailure(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, []scriptedCall{
+		{match: "create", response: fakeDockerResponse{stdout: "abc\n"}},
+		{match: "start", response: fakeDockerResponse{}},
+		{match: "exec", response: fakeDockerResponse{stderr: "read-only fs", exitCode: 1}},
+		{match: "rm", response: fakeDockerResponse{}}, // cleanup
+	})
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	err := r.Create(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "read-only fs") {
+		t.Fatalf("expected mkdir failure, got %v", err)
+	}
+	if r.containerID != "" {
+		t.Fatalf("containerID should be cleared on rollback, got %q", r.containerID)
+	}
+}
+
+func TestDockerRuntime_CloseSkipsRmWhenDeleteFalse(t *testing.T) {
+	t.Parallel()
+	script := append(createScript("abc"),
+		scriptedCall{match: "stop", response: fakeDockerResponse{}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20", Delete: false}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	stop := fd.callArgs(createCallCount)
+	if stop[0] != "stop" {
+		t.Fatalf("expected stop, got %v", stop)
+	}
+}
+
+func TestDockerRuntime_StartStopAndIdempotency(t *testing.T) {
+	t.Parallel()
+	// Create already starts; further Start calls are no-ops. Then Stop,
+	// followed by Close which rm -f's the (stopped) container.
+	script := append(createScript("abc"),
+		scriptedCall{match: "stop", response: fakeDockerResponse{}},
+		scriptedCall{match: "rm", response: fakeDockerResponse{}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20", Delete: true}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Already started by Create; this Start must be a no-op (consumes no
+	// extra scripted call).
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("Start (idempotent after Create): %v", err)
+	}
+	if err := r.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	// Second Stop is also a no-op when not started.
+	if err := r.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop (idempotent): %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestDockerRuntime_StartFailsBeforeCreate(t *testing.T) {
+	t.Parallel()
+	fd := newFakeDocker(t, nil)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Start(context.Background()); err == nil {
+		t.Fatal("Start before Create should error")
+	}
+}
+
+func TestDockerRuntime_UploadFileEnsuresParentDir(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src.txt")
+	if err := os.WriteFile(src, []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	script := append(createScript("abc"),
+		scriptedCall{match: "exec", response: fakeDockerResponse{}}, // upload's mkdir -p
+		scriptedCall{match: "cp", response: fakeDockerResponse{}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := r.UploadFile(context.Background(), src, "sub/dst.txt"); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+	mkdir := fd.callArgs(createCallCount)
+	if mkdir[0] != "exec" || mkdir[len(mkdir)-3] != "mkdir" || mkdir[len(mkdir)-2] != "-p" {
+		t.Fatalf("expected exec mkdir -p, got %v", mkdir)
+	}
+	if mkdir[len(mkdir)-1] != dockerDefaultWorkspace+"/sub" {
+		t.Fatalf("mkdir target = %q, want %q", mkdir[len(mkdir)-1], dockerDefaultWorkspace+"/sub")
+	}
+	cp := fd.callArgs(createCallCount + 1)
+	want := "abc:" + dockerDefaultWorkspace + "/sub/dst.txt"
+	if cp[len(cp)-1] != want {
+		t.Fatalf("cp dest = %q, want %q", cp[len(cp)-1], want)
+	}
+	if cp[len(cp)-2] != src {
+		t.Fatalf("cp src = %q, want %q", cp[len(cp)-2], src)
+	}
+}
+
+func TestDockerRuntime_DownloadFileWritesLocalDir(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	dst := filepath.Join(tmp, "nested", "out.txt")
+	script := append(createScript("abc"),
+		scriptedCall{match: "cp", response: fakeDockerResponse{}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := r.DownloadFile(context.Background(), "/abs/file.txt", dst); err != nil {
+		t.Fatalf("DownloadFile: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(dst)); err != nil {
+		t.Fatalf("target dir was not created: %v", err)
+	}
+	cp := fd.callArgs(createCallCount)
+	if cp[len(cp)-2] != "abc:/abs/file.txt" {
+		t.Fatalf("cp src = %q, want %q", cp[len(cp)-2], "abc:/abs/file.txt")
+	}
+	if cp[len(cp)-1] != dst {
+		t.Fatalf("cp dst = %q, want %q", cp[len(cp)-1], dst)
+	}
+}
+
+func TestDockerRuntime_UploadDirUsesDotSyntax(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	script := append(createScript("abc"),
+		scriptedCall{match: "exec", response: fakeDockerResponse{}}, // ensure dest dir
+		scriptedCall{match: "cp", response: fakeDockerResponse{}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := r.UploadDir(context.Background(), src, "into"); err != nil {
+		t.Fatalf("UploadDir: %v", err)
+	}
+	cp := fd.callArgs(createCallCount + 1)
+	wantSrc := src + string(filepath.Separator) + "."
+	if cp[len(cp)-2] != wantSrc {
+		t.Fatalf("cp src = %q, want %q", cp[len(cp)-2], wantSrc)
+	}
+	wantDst := "abc:" + dockerDefaultWorkspace + "/into"
+	if cp[len(cp)-1] != wantDst {
+		t.Fatalf("cp dst = %q, want %q", cp[len(cp)-1], wantDst)
+	}
+}
+
+func TestDockerRuntime_DownloadDirUsesDotSyntax(t *testing.T) {
+	t.Parallel()
+	dst := t.TempDir()
+	script := append(createScript("abc"),
+		scriptedCall{match: "cp", response: fakeDockerResponse{}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := r.DownloadDir(context.Background(), "outputs", dst); err != nil {
+		t.Fatalf("DownloadDir: %v", err)
+	}
+	cp := fd.callArgs(createCallCount)
+	wantSrc := "abc:" + dockerDefaultWorkspace + "/outputs/."
+	if cp[len(cp)-2] != wantSrc {
+		t.Fatalf("cp src = %q, want %q", cp[len(cp)-2], wantSrc)
+	}
+	if cp[len(cp)-1] != dst {
+		t.Fatalf("cp dst = %q, want %q", cp[len(cp)-1], dst)
+	}
+}
+
+func TestDockerRuntime_ExecPassesCwdEnvAndCommand(t *testing.T) {
+	t.Parallel()
+	script := append(createScript("abc"),
+		scriptedCall{match: "exec", response: fakeDockerResponse{stdout: "ok", exitCode: 0}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{
+		Image: "alpine:3.20",
+		Env:   map[string]string{"GLOBAL": "yes"},
+	}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	res, err := r.Exec(context.Background(), "echo hi", ExecOptions{
+		Cwd: "sub",
+		Env: map[string]string{"FOO": "bar"},
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if res.ExitCode != 0 || res.Stdout != "ok" {
+		t.Fatalf("unexpected result %+v", res)
+	}
+	args := fd.callArgs(createCallCount)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--workdir "+dockerDefaultWorkspace+"/sub") {
+		t.Errorf("expected workdir join under workspace; got %v", args)
+	}
+	if !strings.Contains(joined, "--env FOO=bar") {
+		t.Errorf("expected --env FOO=bar; got %v", args)
+	}
+	if !strings.Contains(joined, "--env GLOBAL=yes") {
+		t.Errorf("expected --env GLOBAL=yes from cfg.Env; got %v", args)
+	}
+	// Command must be the last token, after `bash -c`.
+	if args[len(args)-3] != "bash" || args[len(args)-2] != "-c" || args[len(args)-1] != "echo hi" {
+		t.Fatalf("expected ... bash -c \"echo hi\" at tail, got %v", args)
+	}
+}
+
+func TestDockerRuntime_ExecPropagatesNonZeroExit(t *testing.T) {
+	t.Parallel()
+	script := append(createScript("abc"),
+		scriptedCall{match: "exec", response: fakeDockerResponse{stderr: "boom", exitCode: 42}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	res, err := r.Exec(context.Background(), "false", ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec: unexpected error %v", err)
+	}
+	if res.ExitCode != 42 {
+		t.Fatalf("ExitCode = %d, want 42", res.ExitCode)
+	}
+	if res.Stderr != "boom" {
+		t.Fatalf("Stderr = %q, want %q", res.Stderr, "boom")
+	}
+}
+
+func TestDockerRuntime_ExecSurfacesStartupErrorWhenNoExit(t *testing.T) {
+	t.Parallel()
+	bad := errors.New("dial unix /var/run/docker.sock: no such file")
+	script := append(createScript("abc"),
+		scriptedCall{match: "exec", response: fakeDockerResponse{exitCode: -1, err: bad}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	_, err := r.Exec(context.Background(), "true", ExecOptions{})
+	if err == nil || !strings.Contains(err.Error(), "docker exec failed") {
+		t.Fatalf("expected wrapped docker exec error, got %v", err)
+	}
+}
+
+func TestDockerRuntime_NewRuntimeWiresDocker(t *testing.T) {
+	t.Parallel()
+	rt, err := NewRuntime(Config{Type: "docker", Image: "alpine:3.20"})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if _, ok := rt.(*DockerRuntime); !ok {
+		t.Fatalf("NewRuntime returned %T, want *DockerRuntime", rt)
+	}
+}
+
+func indexOf(ss []string, want string) int {
+	for i, v := range ss {
+		if v == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// Sanity check that the dockerCommandRunner signature actually behaves the
+// way the production helper does — exec error with no real exit becomes -1
+// + the error from classifyExecError. This guards against accidental
+// reshuffling of the contract DockerRuntime relies on.
+func TestRunDockerCommand_NonexistentBinarySurfaces(t *testing.T) {
+	t.Parallel()
+	_, _, exit, err := runDockerCommand(context.Background(), "/nonexistent/skill-up-docker-fake-binary", "version")
+	if err == nil {
+		t.Fatal("expected error when running nonexistent binary")
+	}
+	if exit != -1 {
+		t.Fatalf("exitCode = %d, want -1", exit)
+	}
+	if !strings.Contains(err.Error(), "no such file") && !strings.Contains(err.Error(), "not found") && !strings.Contains(err.Error(), "executable file not found") {
+		// Different OSes phrase this differently; just make sure we got
+		// *some* useful diagnostic.
+		t.Logf("note: runDockerCommand surfaced error: %v", err)
+	}
+}
+
+// Ensure dockerContainerName returns unique, prefixed names.
+func TestDockerContainerName(t *testing.T) {
+	t.Parallel()
+	seen := map[string]bool{}
+	for i := range 32 {
+		n, err := dockerContainerName()
+		if err != nil {
+			t.Fatalf("name: %v", err)
+		}
+		if !strings.HasPrefix(n, "skill-up-") {
+			t.Fatalf("name %q missing prefix", n)
+		}
+		if seen[n] {
+			t.Fatalf("duplicate name %q on iter %d", n, i)
+		}
+		seen[n] = true
+	}
+}
+
+// overlayEnvList must respect callEnv-wins ordering.
+func TestOverlayEnvList_CallEnvWins(t *testing.T) {
+	t.Parallel()
+	got := overlayEnvList(map[string]string{"A": "1", "B": "2"}, map[string]string{"B": "override"})
+	// build a map for assertion since order is non-deterministic
+	m := map[string]string{}
+	for _, kv := range got {
+		k, v, _ := strings.Cut(kv, "=")
+		m[k] = v
+	}
+	if m["A"] != "1" || m["B"] != "override" {
+		t.Fatalf("unexpected env overlay: %v", m)
+	}
+}
+
+// Compile-time check: DockerRuntime satisfies Runtime.
+var _ Runtime = (*DockerRuntime)(nil)

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -473,24 +473,28 @@ func TestDockerRuntime_UploadDownloadRejectsRelativePathEscape(t *testing.T) {
 	cases := []string{"../etc/shadow", "../../etc/passwd", "sub/../../escape"}
 	for _, p := range cases {
 		t.Run("UploadFile/"+p, func(t *testing.T) {
+			t.Parallel()
 			err := r.UploadFile(context.Background(), src, p)
 			if err == nil || !strings.Contains(err.Error(), "escapes workspace") {
 				t.Fatalf("UploadFile(%q) want escape error, got %v", p, err)
 			}
 		})
 		t.Run("UploadDir/"+p, func(t *testing.T) {
+			t.Parallel()
 			err := r.UploadDir(context.Background(), tmp, p)
 			if err == nil || !strings.Contains(err.Error(), "escapes workspace") {
 				t.Fatalf("UploadDir(%q) want escape error, got %v", p, err)
 			}
 		})
 		t.Run("DownloadFile/"+p, func(t *testing.T) {
+			t.Parallel()
 			err := r.DownloadFile(context.Background(), p, filepath.Join(tmp, "out"))
 			if err == nil || !strings.Contains(err.Error(), "escapes workspace") {
 				t.Fatalf("DownloadFile(%q) want escape error, got %v", p, err)
 			}
 		})
 		t.Run("DownloadDir/"+p, func(t *testing.T) {
+			t.Parallel()
 			err := r.DownloadDir(context.Background(), p, filepath.Join(tmp, "outd"))
 			if err == nil || !strings.Contains(err.Error(), "escapes workspace") {
 				t.Fatalf("DownloadDir(%q) want escape error, got %v", p, err)

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -577,6 +577,42 @@ func TestDockerRuntime_ExecPassesCwdEnvAndCommand(t *testing.T) {
 	}
 }
 
+func TestDockerRuntime_ExecExpandsPATHInCommand(t *testing.T) {
+	t.Parallel()
+	script := append(createScript("abc"),
+		scriptedCall{match: "exec", response: fakeDockerResponse{stdout: "ok", exitCode: 0}},
+	)
+	fd := newFakeDocker(t, script)
+	r := newDockerRuntimeForTest(t, Config{Image: "alpine:3.20"}, fd)
+	if err := r.Create(context.Background()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	_, err := r.Exec(context.Background(), "echo hi", ExecOptions{
+		Env: map[string]string{
+			"PATH":    "$HOME/.local/bin:$PATH",
+			"API_KEY": "secret",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	args := fd.callArgs(createCallCount)
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--env PATH=") {
+		t.Errorf("PATH with $ should NOT be passed via --env; got %v", args)
+	}
+	if !strings.Contains(joined, "--env API_KEY=secret") {
+		t.Errorf("expected --env API_KEY=secret; got %v", args)
+	}
+	cmd := args[len(args)-1]
+	if !strings.HasPrefix(cmd, "export PATH=\"$HOME/.local/bin:$PATH\"\n") {
+		t.Errorf("expected PATH export prepended to command; got command: %q", cmd)
+	}
+	if !strings.HasSuffix(cmd, "echo hi") {
+		t.Errorf("expected original command at end; got command: %q", cmd)
+	}
+}
+
 func TestDockerRuntime_ExecRejectsWorkdirEscape(t *testing.T) {
 	t.Parallel()
 	fd := newFakeDocker(t, createScript("abc"))

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -181,6 +181,8 @@ func NewRuntime(cfg Config) (Runtime, error) {
 		return &NoneRuntime{cfg: cfg}, nil
 	case "opensandbox":
 		return NewOpenSandboxRuntime(cfg)
+	case "docker":
+		return NewDockerRuntime(cfg)
 	default:
 		return nil, errors.New("unknown runtime type: " + cfg.Type)
 	}

--- a/skills/skill-upper/references/cli.md
+++ b/skills/skill-upper/references/cli.md
@@ -29,6 +29,7 @@ skill-up run [path] [flags]
 | `--output-dir`        | eval.yaml 同级目录 | 报告和产物的输出目录                                                                                                                                                              |
 | `--iteration`         | `0`（auto）        | 总运行次数。`0` = 自动：在最后一个已有 `iteration-N/` 之后追加一轮；正整数 = 显式运行 N 轮，产物写入 `iteration-1/` … `iteration-N/`                                              |
 | `--engine`            | 配置中的值         | 覆盖 Engine 名称                                                                                                                                                                  |
+| `--runtime`           | 配置中的值         | 覆盖 `environment.type`（`none`、`opensandbox`、`docker`）                                                                                                                        |
 | `--model`             | 配置中的值         | 覆盖模型（格式：`provider/name`）                                                                                                                                                 |
 | `--parallelism`       | 配置中的值         | 覆盖 `cases.parallelism`，临时调整用例并行数，取值 1–256                                                                                                                          |
 | `--api-key`           | —                  | 传入 API Key（优先级高于环境变量）                                                                                                                                                |

--- a/skills/skill-upper/references/eval-yaml.md
+++ b/skills/skill-upper/references/eval-yaml.md
@@ -8,7 +8,7 @@
 schema_version: v1alpha1
 
 environment:
-  type: none                      # none | opensandbox
+  type: none                      # none | opensandbox | docker
 
 mcp:
   servers:
@@ -55,6 +55,7 @@ report:
 | --- | --- | --- |
 | `none` | 纯文本 I/O、不强依赖沙箱 | 冷启动最快 |
 | `opensandbox` | 需要远程沙箱（文件、命令执行等） | 需 `OPENSANDBOX_API_KEY`；服务地址等可放在 `environment.kwargs` 或 `OPENSANDBOX_BASE_URL` |
+| `docker` | 本地容器隔离，无需远程服务 | 需本地 `docker` CLI 和 Docker daemon；镜像需提前拉取 |
 
 ### OpenSandbox 示例
 
@@ -72,6 +73,22 @@ environment:
 ```
 
 常用 `kwargs`：`base_url`、`extensions`（JSON 字符串）、`request_timeout_seconds`、`file_transfer_parallelism` 等。鉴权密钥来自环境变量 `OPENSANDBOX_API_KEY`。
+
+### Docker 示例
+
+```yaml
+environment:
+  type: docker
+  image: node:22                    # 必填，需提前 docker pull
+  workspace_mount: /workspace       # 默认 /workspace
+  env:
+    NPM_CONFIG_REGISTRY: https://registry.npmmirror.com
+  setup_steps:
+    - run: npm install -g typescript
+  entrypoint: ["sleep", "infinity"] # 默认 sleep infinity
+```
+
+前置条件：本地 `docker` CLI 和 Docker daemon。`network_policy: deny_all` 以 `--network=none` 创建容器；`allow_declared` 暂不支持。
 
 
 ## MCP


### PR DESCRIPTION
Closes #32.

## Summary

Adds a third runtime type, `docker`, that runs each eval inside a local Docker container — container-level filesystem/process/network isolation, reproducible via pinned images, and **no external service dependency** (unlike `opensandbox`).

| Runtime | Isolation | Service dep |
|---------|-----------|-------------|
| `none` | none (host shell) | none |
| `opensandbox` | full sandbox | remote sandbox API |
| `docker` (new) | container | local Docker daemon |

## Design choices worth flagging for review

1. **`Create` also starts the container and `mkdir -p`s the workspace.** The evaluator calls `Create → Exec` without a separate `Start`, so `Create` must leave the container fully ready. Half-created containers are rolled back with `docker rm -f` on any failure path during `Create` so we don't leak state on the host.
2. **`RequiresProcessSandbox()` returns `false`.** The container already isolates the agent's processes, mirroring how `OpenSandboxRuntime` reports.
3. **Network policy:**
   - `deny_all` → `docker create --network=none` ✅
   - `allow_declared` → **explicitly rejected** in both `NewDockerRuntime` and the config validator. FQDN-level egress filtering needs an egress proxy or in-container iptables sidecar that's out of scope for this initial cut. Silently allowing all egress would violate the user's stated policy. Users who need `allow_declared` should use `opensandbox`.
4. **`overlayEnvList` passes only the user-specified env to `--env`**, not the full host environment. The container keeps its own `PATH`/`HOME`/etc. from the image. This intentionally differs from `none.go`, which seeds with `os.Environ()` because there the subprocess runs on the host.

## Test approach

`DockerRuntime` holds a `dockerCommandRunner` function field that production wires to `exec.CommandContext`. Tests inject a `fakeDocker` that:
- Records every CLI call.
- Asserts the first arg (subcommand) matches what each step expects.
- Drives a scripted response (stdout/stderr/exitCode/err) per call.

A `createScript()` helper centralises the three calls `Create` makes (`create → start → exec mkdir`), so each test only declares its post-Create calls. This means future tweaks to `Create` only need updating the helper, not every test.

Tests cover: lifecycle (create/start/stop/rm), env+network+entrypoint args, file & dir upload/download (including the `docker cp src/.` dot-syntax), Exec cwd+env+command, non-zero exit propagation, docker daemon errors, rollback when start or workspace-mkdir fails, validator behaviour for the new runtime type.

## Files

- `internal/runtime/docker.go` (new) — DockerRuntime implementation.
- `internal/runtime/docker_test.go` (new) — comprehensive unit tests via the docker CLI seam.
- `internal/runtime/runtime.go` — `NewRuntime` switches on `"docker"`.
- `internal/runtime/README.md` — DockerRuntime section + network-policy matrix.
- `internal/config/validator.go` — accept `docker`, reject `docker + allow_declared`.
- `internal/config/schema.go` — `Environment.Type` comment now lists `docker`.
- `internal/config/validator_test.go` — three new validator cases for docker.

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (full suite, every package green)
- `go vet ./...` ✅
- pre-commit `revive` + incremental `golangci-lint` ✅ (0 issues)