### PR TITLE
fix(runner): generate report.json when --format json is specified for run subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-22
+
+### Fixed
+- `skill-up run --format json` now generates `report.json` in the iteration
+  output directory. Previously the `"json"` format was silently skipped
+  because `result.json` is always written unconditionally; this made
+  `--format json` a no-op and was inconsistent with `skill-up report --format json`
+  which correctly produced `report.json`.
+
 ## [0.2.0] - 2026-05-21
 
 ### Changed
@@ -98,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project and delivers the end-to-end capability to declare eval environments,
   run cases and emit structured reports as described in [README.md](README.md).
 
+[0.2.1]: https://github.com/alibaba/skill-up/releases/tag/v0.2.1
 [0.2.0]: https://github.com/alibaba/skill-up/releases/tag/v0.2.0
 [0.1.2]: https://github.com/alibaba/skill-up/releases/tag/v0.1.2
 [0.1.1]: https://github.com/alibaba/skill-up/releases/tag/v0.1.1

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -309,12 +309,16 @@ func (r *Runner) writeGroupedCaseArtifacts(ws *report.IterationWorkspace, groupe
 }
 
 // writeFormattedReports generates report files for each requested format.
-// "json" is silently skipped because result.json is always written by the caller.
+// Note: result.json is always written by the caller as the raw data source;
+// "json" here additionally produces report.json for consistency with other formats.
 func writeFormattedReports(ctx context.Context, iterDir string, formats []string, input report.Input) error {
 	for _, format := range formats {
 		switch format {
 		case "json":
-			// result.json already written; skip.
+			reporter := &report.JSONReporter{OutputPath: filepath.Join(iterDir, "report.json")}
+			if err := reporter.Write(ctx, input); err != nil {
+				return fmt.Errorf("write json report: %w", err)
+			}
 		case "junit":
 			reporter := &report.JUnitReporter{OutputPath: filepath.Join(iterDir, "report.xml")}
 			if err := reporter.Write(ctx, input); err != nil {


### PR DESCRIPTION
## Summary

When using `skill-up run --format json` (or `formats: [json]` in eval.yaml), no `report.json` file was generated. The `"json"` case in `writeFormattedReports` was silently skipped with the assumption that `result.json` (always written unconditionally) was sufficient. This created an inconsistency with `skill-up report --format json`, which correctly produces `report.json`.

This PR makes the `run` subcommand also emit `report.json` when `--format json` is requested, aligning behavior across both entry points.

## Related issues

Closes #57 

## Changes

- **`internal/runner/runner.go`**: Updated `writeFormattedReports` to write `report.json` via `JSONReporter` instead of silently skipping the `"json"` format. `result.json` continues to be written unconditionally as the raw data source.

## Test plan

- [x] `make test` passes
- [x] `make verify` passes (fmt + vet + lint)
- [ ] Manual testing steps (if applicable):
  1. Run `skill-up run ./evals/eval.yaml --format json`
  2. Verify `report.json` exists in the iteration output directory
  3. Verify `result.json` is still present (unchanged behavior)

## Notes for reviewers

- `result.json` is still always written regardless of `--format` flags — this is intentional and unchanged.
- The new `report.json` is identical in content to `result.json`; the difference is that it is only produced when explicitly requested via `--format json`.
- This aligns `skill-up run` with `skill-up report`, where `--format json` already produces `report.json` (see `internal/cli/report.go` line 97).
