### PR TITLE
fix(config): apply documented defaults when loading eval.yaml

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -57,7 +57,11 @@ func NewLoader(evalPath string) *Loader {
 	}
 }
 
-// LoadEvalConfig loads the eval.yaml file.
+// LoadEvalConfig loads the eval.yaml file and fills in the documented
+// implicit defaults (timeout_seconds, max_turns, parallelism, report.formats)
+// for fields the user omitted. Other unset fields keep their zero value so the
+// validator can still reject documents that omit required keys like
+// schema_version, environment.type, and engine.name.
 func (l *Loader) LoadEvalConfig() (*EvalConfig, error) {
 	data, err := os.ReadFile(l.evalPath)
 	if err != nil {
@@ -69,7 +73,30 @@ func (l *Loader) LoadEvalConfig() (*EvalConfig, error) {
 		return nil, fmt.Errorf("failed to parse eval.yaml: %w", err)
 	}
 
+	applyDocumentedDefaults(&cfg)
 	return &cfg, nil
+}
+
+// applyDocumentedDefaults fills the four implicit defaults documented in
+// README.md and docs/guide/getting-started.md, sourcing values from
+// defaults.yaml so the code and the documented values cannot drift apart.
+// Use -1 (or any negative value) to opt out of the case-level timeout —
+// withCaseTimeout treats <=0 as "no deadline", but 0 is reserved here for
+// "not configured, use default".
+func applyDocumentedDefaults(cfg *EvalConfig) {
+	d := DefaultEvalConfig()
+	if cfg.Cases.Defaults.TimeoutSeconds == 0 {
+		cfg.Cases.Defaults.TimeoutSeconds = d.Cases.Defaults.TimeoutSeconds
+	}
+	if cfg.Cases.Defaults.MaxTurns == 0 {
+		cfg.Cases.Defaults.MaxTurns = d.Cases.Defaults.MaxTurns
+	}
+	if cfg.Cases.Parallelism == 0 {
+		cfg.Cases.Parallelism = d.Cases.Parallelism
+	}
+	if cfg.Report.Formats == nil {
+		cfg.Report.Formats = d.Report.Formats
+	}
 }
 
 // LoadCaseConfig loads a single case file.

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -219,6 +219,172 @@ cases:
 	}
 }
 
+// nolint:funlen // table-driven matrix over the documented defaults; keeping
+// each case inline beats spreading them across helpers.
+func TestLoader_LoadEvalConfig_AppliesDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		evalYAML       string
+		wantTimeout    int
+		wantMaxTurns   int
+		wantParallel   int
+		wantWorkspace  string
+		wantReportFmts []string
+	}{
+		{
+			name: "omitted cases.defaults inherits 300s timeout and 10 turns",
+			evalYAML: `schema_version: v1alpha1
+cases:
+  files:
+    - evals/cases/test1.yaml
+`,
+			wantTimeout:    300,
+			wantMaxTurns:   10,
+			wantParallel:   1,
+			wantWorkspace:  "",
+			wantReportFmts: []string{"json"},
+		},
+		{
+			name: "partial cases.defaults keeps unspecified timeout at 300",
+			evalYAML: `schema_version: v1alpha1
+cases:
+  files:
+    - evals/cases/test1.yaml
+  defaults:
+    max_turns: 5
+`,
+			wantTimeout:    300,
+			wantMaxTurns:   5,
+			wantParallel:   1,
+			wantWorkspace:  "",
+			wantReportFmts: []string{"json"},
+		},
+		{
+			name: "explicit timeout overrides default",
+			evalYAML: `schema_version: v1alpha1
+cases:
+  files:
+    - evals/cases/test1.yaml
+  defaults:
+    timeout_seconds: 600
+`,
+			wantTimeout:    600,
+			wantMaxTurns:   10,
+			wantParallel:   1,
+			wantWorkspace:  "",
+			wantReportFmts: []string{"json"},
+		},
+		{
+			name: "explicit zero timeout falls back to documented default",
+			evalYAML: `schema_version: v1alpha1
+cases:
+  files:
+    - evals/cases/test1.yaml
+  defaults:
+    timeout_seconds: 0
+`,
+			wantTimeout:    300,
+			wantMaxTurns:   10,
+			wantParallel:   1,
+			wantWorkspace:  "",
+			wantReportFmts: []string{"json"},
+		},
+		{
+			name: "explicit negative timeout opts out of the deadline",
+			evalYAML: `schema_version: v1alpha1
+cases:
+  files:
+    - evals/cases/test1.yaml
+  defaults:
+    timeout_seconds: -1
+`,
+			wantTimeout:    -1,
+			wantMaxTurns:   10,
+			wantParallel:   1,
+			wantWorkspace:  "",
+			wantReportFmts: []string{"json"},
+		},
+		{
+			name: "user-supplied report.formats replaces default",
+			evalYAML: `schema_version: v1alpha1
+cases:
+  files:
+    - evals/cases/test1.yaml
+report:
+  formats: [json, junit, html]
+`,
+			wantTimeout:    300,
+			wantMaxTurns:   10,
+			wantParallel:   1,
+			wantWorkspace:  "",
+			wantReportFmts: []string{"json", "junit", "html"},
+		},
+		{
+			name: "user-supplied workspace_mount is preserved (not auto-defaulted)",
+			evalYAML: `schema_version: v1alpha1
+environment:
+  type: none
+  workspace_mount: /custom
+cases:
+  files:
+    - evals/cases/test1.yaml
+`,
+			wantTimeout:    300,
+			wantMaxTurns:   10,
+			wantParallel:   1,
+			wantWorkspace:  "/custom",
+			wantReportFmts: []string{"json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			evalPath := filepath.Join(tmpDir, "eval.yaml")
+			if err := os.WriteFile(evalPath, []byte(tt.evalYAML), 0o600); err != nil {
+				t.Fatalf("failed to write temp eval.yaml: %v", err)
+			}
+
+			cfg, err := NewLoader(evalPath).LoadEvalConfig()
+			if err != nil {
+				t.Fatalf("LoadEvalConfig failed: %v", err)
+			}
+
+			if cfg.Cases.Defaults.TimeoutSeconds != tt.wantTimeout {
+				t.Errorf("Cases.Defaults.TimeoutSeconds = %d, want %d", cfg.Cases.Defaults.TimeoutSeconds, tt.wantTimeout)
+			}
+			if cfg.Cases.Defaults.MaxTurns != tt.wantMaxTurns {
+				t.Errorf("Cases.Defaults.MaxTurns = %d, want %d", cfg.Cases.Defaults.MaxTurns, tt.wantMaxTurns)
+			}
+			if cfg.Cases.Parallelism != tt.wantParallel {
+				t.Errorf("Cases.Parallelism = %d, want %d", cfg.Cases.Parallelism, tt.wantParallel)
+			}
+			if cfg.Environment.WorkspaceMount != tt.wantWorkspace {
+				t.Errorf("Environment.WorkspaceMount = %q, want %q", cfg.Environment.WorkspaceMount, tt.wantWorkspace)
+			}
+			if !equalStringSlice(cfg.Report.Formats, tt.wantReportFmts) {
+				t.Errorf("Report.Formats = %v, want %v", cfg.Report.Formats, tt.wantReportFmts)
+			}
+		})
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestLoader_LoadCaseConfig(t *testing.T) {
 	t.Parallel()
 	content := `id: my-test-case


### PR DESCRIPTION
## Summary

- `LoadEvalConfig` previously unmarshalled `eval.yaml` into a zero-value struct, so the implicit defaults documented in `README.md:167` and `docs/guide/getting-started.md:140` (`timeout_seconds: 300`, `max_turns: 10`, `parallelism: 1`, `report.formats: [json]`) only applied on the *no-eval.yaml* code path through `DefaultEvalConfig()`.
- With an `eval.yaml` present, an omitted `timeout_seconds` resolved to `0` and `withCaseTimeout` (`internal/evaluator/evaluator.go:661`) treats `<= 0` as **no deadline** — the opposite of what the docs promise.
- Now apply those four documented defaults after unmarshalling, sourcing values from `DefaultEvalConfig()` so `defaults.yaml` stays the single source of truth.

## Why this scope (only 4 fields)

`DefaultEvalConfig()` also has values for `schema_version: v1alpha1`, `environment.type: none`, `engine.name: claude_code`, but those are *required* per `internal/config/validator.go:34-53`. Layering the full defaults onto user input would silently mask documents that forgot to declare them — a regression in validation. So this PR only fills the four fields the documentation actually advertises as having defaults.

## Semantics: `timeout_seconds: 0`

To keep the "use default if unset" rule simple, `timeout_seconds: 0` is treated as *not configured* and resolves to 300. Users who genuinely want no deadline can pass `-1` (or any negative value) — `withCaseTimeout` already treats `<= 0` as "no deadline". A regression test for the `-1` form is included.

## Real-world trigger

Came up while diagnosing a CI run where one `update-user-name` case timed out at ~3 min in `agent_judge`. The author had not set `timeout_seconds` themselves and reasonably expected the documented 300s default — but no deadline was being applied at all, so the actual budget was implicit/unbounded until something else interrupted.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages green, including `internal/cli` which exercises `loadFromEvalYAML` + `applyImplicitSkills`)
- [x] New table-driven `TestLoader_LoadEvalConfig_AppliesDefaults` covers: omitted `cases.defaults`, partial `cases.defaults`, explicit override, `0` → falls back to default, `-1` → no deadline, user `report.formats`, user `workspace_mount` (not auto-defaulted).
- [x] `TestLoadFromEvalYAML_AddsImplicitLocalSkillWhenSkillsOmitted` and `TestLoadFromEvalYAML_RespectsExplicitEmptySkills` still pass (the `Skills==nil` vs `Skills==[]` distinction is preserved because we don't touch `Skills`).
- [x] `gofmt`, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)