### PR TITLE
fix(runtime): surface stdout when runtime.exec exits non-zero

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -476,11 +476,17 @@ func classifyExecResult(ctx context.Context, result ExecResult, err error, comma
 		if result.Stderr != "" {
 			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
 		}
+		if result.Stdout != "" {
+			logNonZeroStdout(ctx, result.ExitCode, result.Stdout)
+		}
 		return ctx.Err()
 	case result.ExitCode != 0:
 		logNonZeroExit(ctx, result.ExitCode, command)
 		if result.Stderr != "" {
 			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
+		}
+		if result.Stdout != "" {
+			logNonZeroStdout(ctx, result.ExitCode, result.Stdout)
 		}
 	case result.Stderr != "":
 		logging.WarnContextf(ctx, "stderr: %s", result.Stderr)

--- a/internal/runtime/none.go
+++ b/internal/runtime/none.go
@@ -205,10 +205,16 @@ func (r *NoneRuntime) Exec(ctx context.Context, command string, opts ExecOptions
 		if result.Stderr != "" {
 			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
 		}
+		if result.Stdout != "" {
+			logNonZeroStdout(ctx, result.ExitCode, result.Stdout)
+		}
 	case result.ExitCode != 0:
 		logNonZeroExit(ctx, result.ExitCode, command)
 		if result.Stderr != "" {
 			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
+		}
+		if result.Stdout != "" {
+			logNonZeroStdout(ctx, result.ExitCode, result.Stdout)
 		}
 	case result.Stderr != "":
 		logging.WarnContextf(ctx, "stderr: %s", result.Stderr)
@@ -266,6 +272,18 @@ func logNonZeroStderr(ctx context.Context, exitCode int, stderr string) {
 		return
 	}
 	logging.ErrorContextf(ctx, "stderr: %s", stderr)
+}
+
+// logNonZeroStdout surfaces captured stdout when a command exits non-zero.
+// Many tools write diagnostic context (build output, test failures, traces)
+// to stdout rather than stderr, so dropping it on failure leaves the user
+// with only the exit code and an empty stderr line.
+func logNonZeroStdout(ctx context.Context, exitCode int, stdout string) {
+	if exitCode == 1 {
+		logging.WarnContextf(ctx, "stdout: %s", stdout)
+		return
+	}
+	logging.ErrorContextf(ctx, "stdout: %s", stdout)
 }
 
 // Workspace returns the runtime workspace path on the host.

--- a/internal/runtime/none_test.go
+++ b/internal/runtime/none_test.go
@@ -285,6 +285,24 @@ func TestNoneRuntime_ExecLogsExitCodeSeverity(t *testing.T) {
 	if !strings.Contains(errorOutput, "level=ERROR") {
 		t.Fatalf("expected error log for exit 5, got %q", errorOutput)
 	}
+
+	// Many CLIs (build tools, test runners) write the actual failure
+	// context to stdout, not stderr. Ensure that on non-zero exit we
+	// surface stdout so users don't see only an exit code with no
+	// explanation.
+	stdoutOnExit1 := captureStdout(t, func() {
+		_, _ = rt.Exec(context.Background(), "echo build-failed-on-stdout; exit 1", ExecOptions{})
+	})
+	if !strings.Contains(stdoutOnExit1, "stdout: build-failed-on-stdout") {
+		t.Fatalf("expected stdout to be logged on exit 1, got %q", stdoutOnExit1)
+	}
+
+	stdoutOnExit5 := captureStdout(t, func() {
+		_, _ = rt.Exec(context.Background(), "echo build-failed-on-stdout; exit 5", ExecOptions{})
+	})
+	if !strings.Contains(stdoutOnExit5, "stdout: build-failed-on-stdout") {
+		t.Fatalf("expected stdout to be logged on exit 5, got %q", stdoutOnExit5)
+	}
 }
 
 func assertSpanAttr(t *testing.T, attrs []attribute.KeyValue, key, want string) {

--- a/internal/runtime/opensandbox.go
+++ b/internal/runtime/opensandbox.go
@@ -521,10 +521,16 @@ func (r *OpenSandboxRuntime) Exec(ctx context.Context, command string, opts Exec
 		if result.Stderr != "" {
 			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
 		}
+		if result.Stdout != "" {
+			logNonZeroStdout(ctx, result.ExitCode, result.Stdout)
+		}
 	case result.ExitCode != 0:
 		logNonZeroExit(ctx, result.ExitCode, command)
 		if result.Stderr != "" {
 			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
+		}
+		if result.Stdout != "" {
+			logNonZeroStdout(ctx, result.ExitCode, result.Stdout)
 		}
 	case result.Stderr != "":
 		logging.WarnContextf(ctx, "stderr: %s", result.Stderr)


### PR DESCRIPTION
## Summary

- When `runtime.Exec` (NoneRuntime, DockerRuntime, OpenSandboxRuntime) returned a non-zero exit code, only `stderr` was logged. Many CLIs (build tools, test runners, package managers) write their actual failure context to **stdout**, so users were left with `exited with code 1` and no diagnostics.
- Adds a `logNonZeroStdout` sibling to `logNonZeroStderr` (same warn-for-exit-1 / error-otherwise severity), and surfaces it in all three runtimes on both the non-zero-exit and the context-killed / SDK-failure branches.
- Stdout is **only** logged on failure — the success-with-stderr-noise branch is unchanged so we don't spam logs with expected output.

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test ./internal/runtime/...` — all pass
- [x] Extended `TestNoneRuntime_ExecLogsExitCodeSeverity` to assert stdout shows up in the captured log for both exit 1 (warn) and exit 5 (error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)