### PR TITLE
fix(timeout): strict case-timeout budget, judge knob for agent_judge, named errors

### DIFF
--- a/docs/guide/writing-evals.md
+++ b/docs/guide/writing-evals.md
@@ -385,6 +385,7 @@ judge:
     - "Does not flag correct code as a bug"
     - "Recommendations are actionable, not generic"
   pass_threshold: 0.7                        # Default 0.7
+  timeout_seconds: 60                        # Optional: bound a single judge call (0 = no judge-level deadline, parent case timeout still applies)
 ```
 
 > **Cost note:** `agent_judge` consumes additional tokens. Prefer `expect` or `rule_based` for deterministic checks and reserve `agent_judge` for assertions that genuinely require semantic understanding.

--- a/docs/zh/guide/writing-evals.md
+++ b/docs/zh/guide/writing-evals.md
@@ -385,6 +385,7 @@ judge:
     - "没有将正确代码误报为 bug"
     - "建议具有可操作性，不是泛泛而谈"
   pass_threshold: 0.7                        # 通过率阈值，默认 0.7
+  timeout_seconds: 60                        # 可选：限制单次 judge 调用时长（0 = 不加 judge 级 deadline，仍受 case timeout 约束）
 ```
 
 > **成本提示**：`agent_judge` 会消耗额外的 token。建议对关键断言先用 `expect` 或 `rule_based` 做确定性检查，只对需要语义理解的部分使用 `agent_judge`。

--- a/internal/cli/judge_debug.go
+++ b/internal/cli/judge_debug.go
@@ -309,7 +309,7 @@ func buildMockAgentJudge(cfg config.JudgeConfig, mockResults []judge.CriterionRe
 	}
 
 	ag := &mockJudgeAgent{results: mockResults}
-	return judge.NewAgentJudge(ag, nil, cfg.Model, cfg.Criteria, cfg.PassThreshold), nil
+	return judge.NewAgentJudge(ag, nil, cfg.Model, cfg.Criteria, cfg.PassThreshold, 0), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -137,10 +137,11 @@ type JudgeConfig struct {
 	// Nil means "not configured", so the judge layer applies its default of 0.7.
 	// When set explicitly, the value must be in the inclusive range [0.0, 1.0].
 	PassThreshold *float64 `json:"pass_threshold,omitempty" yaml:"pass_threshold,omitempty"`
-	// TimeoutSeconds overrides the default script judge timeout.
-	// Nil means "not configured" — the global value is inherited (via MergeJudgeConfig).
-	// When set, 0 uses the judge package default; positive values set an explicit timeout.
-	// Only applicable when Type is "script".
+	// TimeoutSeconds bounds a single judge invocation in seconds (applied on
+	// top of any case-level timeout). Nil means "not configured" — the global
+	// value is inherited via MergeJudgeConfig. When set, the meaning of 0
+	// depends on judge type: script judges fall back to DefaultScriptTimeout
+	// (30s); agent_judge treats 0 as "no judge-level deadline".
 	TimeoutSeconds *int   `json:"timeout_seconds,omitempty" yaml:"timeout_seconds,omitempty"`
 	Success        []Rule `json:"success,omitempty"        yaml:"success,omitempty"`
 	Failure        []Rule `json:"failure,omitempty"        yaml:"failure,omitempty"`

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -35,8 +35,6 @@ var (
 	agentDetectWithInitParams = agent.DetectAgentWithInitParams
 )
 
-const minRecoverableSessionTextLen = 16
-
 // ProgressObserver receives progress notifications during evaluation.
 // Implementations must be safe for concurrent use.
 type ProgressObserver interface {
@@ -265,9 +263,10 @@ func (e *defaultEvaluator) executeCase(ctx context.Context, caseCfg *config.Case
 
 	var result EvalResult
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		attemptCtx, cancel := withCaseTimeout(ctx, e.evalCfg.Cases.Defaults.TimeoutSeconds, caseCfg.Constraints.TimeoutSeconds)
+		attemptCtx, cancel, timeoutSource, timeoutSec := withCaseTimeout(ctx, e.evalCfg.Cases.Defaults.TimeoutSeconds, caseCfg.Constraints.TimeoutSeconds)
 		result = e.executeCaseOnce(attemptCtx, caseCfg, configName, overrideRT, overrideAgent)
 		cancel()
+		annotateCaseTimeoutError(&result, timeoutSource, timeoutSec)
 
 		retryReason, ok := retryReasonForResult(result)
 		if !ok || !retryAllowed(e.evalCfg.Cases.RetryPolicy, retryReason) || attempt == maxAttempts {
@@ -381,32 +380,27 @@ func (e *defaultEvaluator) executeCaseOnce(ctx context.Context, caseCfg *config.
 	if shouldReturn := e.handleExecutionResult(ctx, caseCfg, configName, startTime, &result, execErr); shouldReturn {
 		return result
 	}
-	recoveredExecution := execErr != nil
-	// A genuine non-zero exit without a Go-level execution error may still be
-	// handled by expect.exit_code or a configured judge. Recovered timeout/cancel
-	// paths also flow through here, but if nothing is configured to interpret the
-	// partial result they remain execution errors rather than ordinary FAILs.
-	if sessionResult != nil && sessionResult.ExitCode != 0 { //nolint:nestif // exit-code triage requires correlating multiple flags (expect / judge / recoveredExecution) before deciding the terminal status.
+	// A genuine non-zero exit may still be handled by expect.exit_code or a
+	// configured judge; otherwise it's just a FAIL. (handleExecutionResult
+	// already converted any execErr — including ctx.DeadlineExceeded — into
+	// an ERROR return above, so we're guaranteed execErr == nil here and the
+	// case timeout strictly bounds agent + judge as a single budget.)
+	if sessionResult != nil && sessionResult.ExitCode != 0 {
 		hasExitCodeCheck := caseCfg.Expect.ExitCode != nil
 		hasJudge := judgeCfg.Type != ""
 		if !hasExitCodeCheck && !hasJudge {
 			if result.DurationMs == 0 {
 				result.DurationMs = time.Since(startTime).Milliseconds()
 			}
-			if recoveredExecution {
-				result.Status = judge.StatusError
-				result.Error = fmt.Errorf("agent execution failed: %w", execErr)
-			} else {
-				result.Status = judge.StatusFail
-			}
+			result.Status = judge.StatusFail
 			result.Configuration = configName
-			logging.DebugContextf(ctx, "Evaluator: case %s agent exited with code %d (no expect.exit_code or judge), marking %s", caseCfg.ID, sessionResult.ExitCode, result.Status)
+			logging.DebugContextf(ctx, "Evaluator: case %s agent exited with code %d (no expect.exit_code or judge), marking FAIL", caseCfg.ID, sessionResult.ExitCode)
 			return result
 		}
 		logging.DebugContextf(ctx, "Evaluator: case %s agent exited with code %d, proceeding to evaluation", caseCfg.ID, sessionResult.ExitCode)
 	}
 
-	return e.evaluateCaseSession(e.evaluationContext(ctx, execErr), rt, caseCfg, configName, judgeCfg, turnsTotal, runAgent, sessionResult, &result)
+	return e.evaluateCaseSession(ctx, rt, caseCfg, configName, judgeCfg, turnsTotal, runAgent, sessionResult, &result)
 }
 
 //nolint:spancheck // caller owns the returned span and must end it.
@@ -658,15 +652,35 @@ func resolveJudgeScriptPath(skillDir string, judgeCfg config.JudgeConfig) config
 	return judgeCfg
 }
 
-func withCaseTimeout(ctx context.Context, defaultTimeoutSec, caseTimeoutSec int) (context.Context, context.CancelFunc) {
-	timeoutSec := caseTimeoutSec
-	if timeoutSec <= 0 {
-		timeoutSec = defaultTimeoutSec
+// annotateCaseTimeoutError attaches the configured case timeout and its
+// source config key to a result whose error chain contains
+// context.DeadlineExceeded. The annotation is purely informational; the
+// original DeadlineExceeded is preserved via %w so callers (and isTimeoutError)
+// still match it.
+func annotateCaseTimeoutError(result *EvalResult, source string, seconds int) {
+	if result == nil || result.Error == nil || source == "" || seconds <= 0 {
+		return
 	}
-	if timeoutSec <= 0 {
-		return ctx, func() {}
+	if !errors.Is(result.Error, context.DeadlineExceeded) {
+		return
 	}
-	return context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
+	result.Error = fmt.Errorf("%w (case timeout %ds via %s)", result.Error, seconds, source)
+}
+
+// withCaseTimeout returns a derived context bounded by the case-level
+// timeout, along with the resolved value and the config key that supplied it
+// (so timeout errors can name the knob users need to adjust). source/seconds
+// are empty/zero when no timeout is configured.
+func withCaseTimeout(ctx context.Context, defaultTimeoutSec, caseTimeoutSec int) (context.Context, context.CancelFunc, string, int) {
+	if caseTimeoutSec > 0 {
+		c, cancel := context.WithTimeout(ctx, time.Duration(caseTimeoutSec)*time.Second)
+		return c, cancel, "case.constraints.timeout_seconds", caseTimeoutSec
+	}
+	if defaultTimeoutSec > 0 {
+		c, cancel := context.WithTimeout(ctx, time.Duration(defaultTimeoutSec)*time.Second)
+		return c, cancel, "cases.defaults.timeout_seconds", defaultTimeoutSec
+	}
+	return ctx, func() {}, "", 0
 }
 
 func retryAllowed(policy config.RetryPolicy, reason string) bool {
@@ -691,9 +705,14 @@ func retryReasonForResult(result EvalResult) (string, bool) {
 	return "error", true
 }
 
+// handleExecutionResult finalises the EvalResult when the agent run returned an
+// error. Any execErr (including ctx.DeadlineExceeded) terminates the case as
+// ERROR: the case timeout is treated as a single budget for agent + judge, so
+// we do not try to salvage partial output by running the judge against a
+// truncated agent transcript.
 func (e *defaultEvaluator) handleExecutionResult(
-	ctx context.Context,
-	caseCfg *config.CaseConfig,
+	_ context.Context,
+	_ *config.CaseConfig,
 	configName string,
 	startTime time.Time,
 	result *EvalResult,
@@ -702,61 +721,13 @@ func (e *defaultEvaluator) handleExecutionResult(
 	if execErr == nil {
 		return false
 	}
-	if !canContinueAfterExecutionError(execErr, result.SessionResult) {
-		if result.DurationMs == 0 {
-			result.DurationMs = time.Since(startTime).Milliseconds()
-		}
-		result.Status = judge.StatusError
-		result.Error = fmt.Errorf("agent execution failed: %w", execErr)
-		result.Configuration = configName
-		return true
-	}
 	if result.DurationMs == 0 {
 		result.DurationMs = time.Since(startTime).Milliseconds()
 	}
-	logging.WarnContextf(
-		ctx,
-		"Runner: case %s (%s) continuing with recovered agent result after %v",
-		caseCfg.ID,
-		configName,
-		execErr,
-	)
-	return false
-}
-
-func (e *defaultEvaluator) evaluationContext(ctx context.Context, execErr error) context.Context {
-	if !isInterruptedError(execErr) || ctx.Err() == nil {
-		return ctx
-	}
-	return context.WithoutCancel(ctx)
-}
-
-func canContinueAfterExecutionError(err error, sessionResult *agent.SessionResult) bool {
-	return isInterruptedError(err) && hasRecoverableSessionResult(sessionResult)
-}
-
-func hasRecoverableSessionResult(sessionResult *agent.SessionResult) bool {
-	if sessionResult == nil {
-		return false
-	}
-	if hasRecoverableText(sessionResult.FinalMessage) {
-		return true
-	}
-	if hasRecoverableText(sessionResult.Transcript.FinalAssistantMessage()) {
-		return true
-	}
-	if sessionResult.Artifacts == nil {
-		return false
-	}
-	return hasRecoverableText(sessionResult.Artifacts.WorkspaceDiff)
-}
-
-func isInterruptedError(err error) bool {
-	return errors.Is(err, context.DeadlineExceeded)
-}
-
-func hasRecoverableText(text string) bool {
-	return len(strings.TrimSpace(text)) >= minRecoverableSessionTextLen
+	result.Status = judge.StatusError
+	result.Error = fmt.Errorf("agent execution failed: %w", execErr)
+	result.Configuration = configName
+	return true
 }
 
 func isTimeoutError(err error) bool {

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -265,11 +265,15 @@ func (e *defaultEvaluator) executeCase(ctx context.Context, caseCfg *config.Case
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		attemptCtx, cancel, timeoutSource, timeoutSec := withCaseTimeout(ctx, e.evalCfg.Cases.Defaults.TimeoutSeconds, caseCfg.Constraints.TimeoutSeconds)
 		result = e.executeCaseOnce(attemptCtx, caseCfg, configName, overrideRT, overrideAgent)
-		// Snapshot the case ctx deadline state *before* cancel() so a tighter
-		// child deadline (e.g. judge.timeout_seconds) firing without the case
-		// ctx ever expiring isn't relabelled as a case timeout. cancel() would
-		// overwrite Err with Canceled and erase the signal.
-		caseDeadlineFired := errors.Is(attemptCtx.Err(), context.DeadlineExceeded)
+		// Snapshot both the case ctx and the parent ctx *before* cancel() so
+		// (a) cancel doesn't overwrite Err with Canceled and erase the signal,
+		// and (b) a parent-supplied deadline (e.g. a caller wrapping
+		// EvaluateAll in context.WithTimeout) firing through attemptCtx isn't
+		// relabelled as a case timeout — that would point users at the wrong
+		// YAML knob. A tighter child deadline (e.g. judge.timeout_seconds)
+		// gets the same protection because attemptCtx.Err() stays nil when
+		// the case-level deadline never fires.
+		caseDeadlineFired := errors.Is(attemptCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil
 		cancel()
 		annotateCaseTimeoutError(&result, timeoutSource, timeoutSec, caseDeadlineFired)
 

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -265,8 +265,13 @@ func (e *defaultEvaluator) executeCase(ctx context.Context, caseCfg *config.Case
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		attemptCtx, cancel, timeoutSource, timeoutSec := withCaseTimeout(ctx, e.evalCfg.Cases.Defaults.TimeoutSeconds, caseCfg.Constraints.TimeoutSeconds)
 		result = e.executeCaseOnce(attemptCtx, caseCfg, configName, overrideRT, overrideAgent)
+		// Snapshot the case ctx deadline state *before* cancel() so a tighter
+		// child deadline (e.g. judge.timeout_seconds) firing without the case
+		// ctx ever expiring isn't relabelled as a case timeout. cancel() would
+		// overwrite Err with Canceled and erase the signal.
+		caseDeadlineFired := errors.Is(attemptCtx.Err(), context.DeadlineExceeded)
 		cancel()
-		annotateCaseTimeoutError(&result, timeoutSource, timeoutSec)
+		annotateCaseTimeoutError(&result, timeoutSource, timeoutSec, caseDeadlineFired)
 
 		retryReason, ok := retryReasonForResult(result)
 		if !ok || !retryAllowed(e.evalCfg.Cases.RetryPolicy, retryReason) || attempt == maxAttempts {
@@ -654,11 +659,18 @@ func resolveJudgeScriptPath(skillDir string, judgeCfg config.JudgeConfig) config
 
 // annotateCaseTimeoutError attaches the configured case timeout and its
 // source config key to a result whose error chain contains
-// context.DeadlineExceeded. The annotation is purely informational; the
-// original DeadlineExceeded is preserved via %w so callers (and isTimeoutError)
-// still match it.
-func annotateCaseTimeoutError(result *EvalResult, source string, seconds int) {
+// context.DeadlineExceeded — but only when the case-level context itself
+// expired. A tighter child deadline (e.g. judge.timeout_seconds firing while
+// the case ctx still has budget) would otherwise be mislabeled as a case
+// timeout and point users at the wrong YAML knob. The caller passes
+// caseDeadlineFired as a pre-cancel snapshot to avoid that race. The original
+// DeadlineExceeded is preserved via %w so callers (and isTimeoutError) still
+// match it.
+func annotateCaseTimeoutError(result *EvalResult, source string, seconds int, caseDeadlineFired bool) {
 	if result == nil || result.Error == nil || source == "" || seconds <= 0 {
+		return
+	}
+	if !caseDeadlineFired {
 		return
 	}
 	if !errors.Is(result.Error, context.DeadlineExceeded) {

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -265,17 +265,19 @@ func (e *defaultEvaluator) executeCase(ctx context.Context, caseCfg *config.Case
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		attemptCtx, cancel, timeoutSource, timeoutSec := withCaseTimeout(ctx, e.evalCfg.Cases.Defaults.TimeoutSeconds, caseCfg.Constraints.TimeoutSeconds)
 		result = e.executeCaseOnce(attemptCtx, caseCfg, configName, overrideRT, overrideAgent)
-		// Snapshot both the case ctx and the parent ctx *before* cancel() so
-		// (a) cancel doesn't overwrite Err with Canceled and erase the signal,
-		// and (b) a parent-supplied deadline (e.g. a caller wrapping
-		// EvaluateAll in context.WithTimeout) firing through attemptCtx isn't
-		// relabelled as a case timeout — that would point users at the wrong
-		// YAML knob. A tighter child deadline (e.g. judge.timeout_seconds)
-		// gets the same protection because attemptCtx.Err() stays nil when
-		// the case-level deadline never fires.
-		caseDeadlineFired := errors.Is(attemptCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil
+		// Decide whether to annotate *before* cancel() so (a) cancel doesn't
+		// overwrite Err with Canceled and erase the signal, and (b) a
+		// parent-supplied deadline (e.g. a caller wrapping EvaluateAll in
+		// context.WithTimeout) firing through attemptCtx isn't relabelled as a
+		// case timeout — that would point users at the wrong YAML knob. A
+		// tighter child deadline (e.g. judge.timeout_seconds) gets the same
+		// protection because attemptCtx.Err() stays nil when the case-level
+		// deadline never fires. The decision lives at the caller so the
+		// annotate helper stays free of a control-flag parameter.
+		if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			annotateCaseTimeoutError(&result, timeoutSource, timeoutSec)
+		}
 		cancel()
-		annotateCaseTimeoutError(&result, timeoutSource, timeoutSec, caseDeadlineFired)
 
 		retryReason, ok := retryReasonForResult(result)
 		if !ok || !retryAllowed(e.evalCfg.Cases.RetryPolicy, retryReason) || attempt == maxAttempts {
@@ -663,18 +665,12 @@ func resolveJudgeScriptPath(skillDir string, judgeCfg config.JudgeConfig) config
 
 // annotateCaseTimeoutError attaches the configured case timeout and its
 // source config key to a result whose error chain contains
-// context.DeadlineExceeded — but only when the case-level context itself
-// expired. A tighter child deadline (e.g. judge.timeout_seconds firing while
-// the case ctx still has budget) would otherwise be mislabeled as a case
-// timeout and point users at the wrong YAML knob. The caller passes
-// caseDeadlineFired as a pre-cancel snapshot to avoid that race. The original
-// DeadlineExceeded is preserved via %w so callers (and isTimeoutError) still
-// match it.
-func annotateCaseTimeoutError(result *EvalResult, source string, seconds int, caseDeadlineFired bool) {
+// context.DeadlineExceeded. The caller is responsible for ensuring this is
+// only invoked when the case-level deadline actually fired (see executeCase);
+// here we just wrap. The original DeadlineExceeded is preserved via %w so
+// callers (and isTimeoutError) still match it.
+func annotateCaseTimeoutError(result *EvalResult, source string, seconds int) {
 	if result == nil || result.Error == nil || source == "" || seconds <= 0 {
-		return
-	}
-	if !caseDeadlineFired {
 		return
 	}
 	if !errors.Is(result.Error, context.DeadlineExceeded) {

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -516,6 +516,54 @@ func TestExecuteCase_ChildDeadlineNotMislabeledAsCaseTimeout(t *testing.T) {
 	}
 }
 
+// Regression: a deadline supplied by the caller (e.g. an API caller wrapping
+// EvaluateAll in context.WithTimeout) propagates through attemptCtx and
+// makes attemptCtx.Err() == DeadlineExceeded — but the case-level timeout
+// knob never actually fired. Annotating that as "case timeout via ..."
+// would point users at the wrong YAML knob.
+func TestExecuteCase_ParentDeadlineNotMislabeledAsCaseTimeout(t *testing.T) {
+	e := newTestEvaluator(EvalOptions{
+		Agent: &mockAgent{name: "test"},
+		EvalCfg: &config.EvalConfig{
+			// Generous case budget — should never be the binding deadline.
+			Cases: config.CasesConfig{
+				Defaults: config.CaseDefaults{TimeoutSeconds: 60},
+			},
+		},
+	})
+
+	caseCfg := &config.CaseConfig{
+		ID:    "case-parent-deadline",
+		Title: "Parent ctx deadline must not be labelled as case timeout",
+		Input: config.Input{Prompt: "hello"},
+	}
+
+	// Agent blocks until ctx is done — the parent-supplied deadline below
+	// (much tighter than the 60s case budget) is what will fire.
+	ag := &mockAgent{
+		name: "test",
+		runFunc: func(ctx context.Context, _ runtime.Runtime, _ agent.ExecOptions, _ []transcript.Message) (*agent.SessionResult, error) {
+			<-ctx.Done()
+			return &agent.SessionResult{ExitCode: -1}, ctx.Err()
+		},
+	}
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result := e.executeCase(parentCtx, caseCfg, "with_skill", &mockRuntime{workspace: t.TempDir()}, ag)
+
+	if result.Status != judge.StatusError {
+		t.Fatalf("expected ERROR, got %s", result.Status)
+	}
+	if !errors.Is(result.Error, context.DeadlineExceeded) {
+		t.Fatalf("expected error chain to contain context.DeadlineExceeded, got %v", result.Error)
+	}
+	if strings.Contains(result.Error.Error(), "case timeout") {
+		t.Fatalf("parent ctx fired (case knob never bound), error must not be annotated with 'case timeout', got %v", result.Error)
+	}
+}
+
 func TestExecuteCase_TimeoutWithoutJudgeIsError(t *testing.T) {
 	e := newTestEvaluator(EvalOptions{
 		Agent: &mockAgent{name: "test"},

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -469,6 +469,53 @@ func TestExecuteCase_TimeoutErrorNamesConfigKey(t *testing.T) {
 	}
 }
 
+// Regression: a child deadline that fires while the case context still has
+// budget (e.g. judge.timeout_seconds shorter than cases.defaults.timeout_seconds)
+// must NOT be relabelled as a case timeout. Pointing users at the wrong YAML
+// knob is the exact problem this PR's error annotation is meant to prevent.
+func TestExecuteCase_ChildDeadlineNotMislabeledAsCaseTimeout(t *testing.T) {
+	e := newTestEvaluator(EvalOptions{
+		Agent: &mockAgent{name: "test"},
+		EvalCfg: &config.EvalConfig{
+			// Generous case budget — should never fire in this test.
+			Cases: config.CasesConfig{
+				Defaults: config.CaseDefaults{TimeoutSeconds: 60},
+			},
+		},
+	})
+
+	caseCfg := &config.CaseConfig{
+		ID:    "case-child-deadline",
+		Title: "Child deadline does not get a case-timeout label",
+		Input: config.Input{Prompt: "hello"},
+	}
+
+	// Agent returns DeadlineExceeded immediately from a fresh, expired child
+	// ctx. This simulates a tighter inner timeout (judge.timeout_seconds or
+	// any other layer) firing while the case ctx is still well within budget.
+	ag := &mockAgent{
+		name: "test",
+		runFunc: func(_ context.Context, _ runtime.Runtime, _ agent.ExecOptions, _ []transcript.Message) (*agent.SessionResult, error) {
+			child, cancel := context.WithTimeout(context.Background(), 0)
+			defer cancel()
+			<-child.Done()
+			return &agent.SessionResult{ExitCode: -1}, child.Err()
+		},
+	}
+
+	result := e.executeCase(context.Background(), caseCfg, "with_skill", &mockRuntime{workspace: t.TempDir()}, ag)
+
+	if result.Status != judge.StatusError {
+		t.Fatalf("expected ERROR, got %s", result.Status)
+	}
+	if !errors.Is(result.Error, context.DeadlineExceeded) {
+		t.Fatalf("expected error chain to contain context.DeadlineExceeded, got %v", result.Error)
+	}
+	if strings.Contains(result.Error.Error(), "case timeout") {
+		t.Fatalf("case ctx did not fire, error must not be annotated with 'case timeout', got %v", result.Error)
+	}
+}
+
 func TestExecuteCase_TimeoutWithoutJudgeIsError(t *testing.T) {
 	e := newTestEvaluator(EvalOptions{
 		Agent: &mockAgent{name: "test"},

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -324,7 +324,12 @@ func TestExecuteCase_PassesAgentArtifactDir(t *testing.T) {
 	}
 }
 
-func TestExecuteCase_AgentTimeoutWithRecoveredResultContinuesJudge(t *testing.T) {
+// Strict-budget regression: an agent run that returns context.DeadlineExceeded
+// must surface as ERROR regardless of whether the partial sessionResult would
+// have satisfied the judge. Previously this case was salvaged by re-running
+// the judge against the truncated transcript; that behaviour is intentionally
+// removed so the case timeout strictly bounds agent + judge together.
+func TestExecuteCase_AgentTimeoutWithPartialResultStillErrors(t *testing.T) {
 	e := newTestEvaluator(EvalOptions{
 		Agent: &mockAgent{name: "test"},
 		EvalCfg: &config.EvalConfig{
@@ -338,8 +343,8 @@ func TestExecuteCase_AgentTimeoutWithRecoveredResultContinuesJudge(t *testing.T)
 	})
 
 	caseCfg := &config.CaseConfig{
-		ID:    "case-timeout-recover",
-		Title: "Recovered timeout result",
+		ID:    "case-timeout-no-salvage",
+		Title: "Timed-out agent is not salvaged through judge",
 		Input: config.Input{Prompt: "hello"},
 	}
 
@@ -355,11 +360,11 @@ func TestExecuteCase_AgentTimeoutWithRecoveredResultContinuesJudge(t *testing.T)
 
 	result := e.executeCase(context.Background(), caseCfg, "with_skill", &mockRuntime{workspace: t.TempDir()}, ag)
 
-	if result.Status != judge.StatusPass {
-		t.Fatalf("expected PASS after recovering timed out agent result, got %s (err=%v)", result.Status, result.Error)
+	if result.Status != judge.StatusError {
+		t.Fatalf("expected ERROR (no salvage), got %s (err=%v)", result.Status, result.Error)
 	}
-	if result.Error != nil {
-		t.Fatalf("expected nil error after recovery, got %v", result.Error)
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "agent execution failed") {
+		t.Fatalf("expected agent execution failed error, got %v", result.Error)
 	}
 }
 
@@ -391,14 +396,87 @@ func TestExecuteCase_AgentTimeoutWithoutRecoveredResultErrors(t *testing.T) {
 	}
 }
 
-func TestExecuteCase_RecoveredTimeoutWithoutJudgeStaysError(t *testing.T) {
+func TestExecuteCase_TimeoutErrorNamesConfigKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		evalDefault int
+		caseLimit   int
+		wantSource  string
+		wantSeconds int
+	}{
+		{
+			name:        "case constraint wins over eval default",
+			evalDefault: 60,
+			caseLimit:   1,
+			wantSource:  "case.constraints.timeout_seconds",
+			wantSeconds: 1,
+		},
+		{
+			name:        "eval default applies when case has none",
+			evalDefault: 1,
+			caseLimit:   0,
+			wantSource:  "cases.defaults.timeout_seconds",
+			wantSeconds: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := newTestEvaluator(EvalOptions{
+				Agent: &mockAgent{name: "test"},
+				EvalCfg: &config.EvalConfig{
+					Cases: config.CasesConfig{
+						Defaults: config.CaseDefaults{TimeoutSeconds: tt.evalDefault},
+					},
+				},
+			})
+
+			caseCfg := &config.CaseConfig{
+				ID:          "case-timeout-annotation",
+				Title:       "Timeout error names the configured knob",
+				Input:       config.Input{Prompt: "hello"},
+				Constraints: config.Constraints{TimeoutSeconds: tt.caseLimit},
+			}
+
+			ag := &mockAgent{
+				name: "test",
+				runFunc: func(ctx context.Context, _ runtime.Runtime, _ agent.ExecOptions, _ []transcript.Message) (*agent.SessionResult, error) {
+					<-ctx.Done()
+					return &agent.SessionResult{ExitCode: -1}, ctx.Err()
+				},
+			}
+
+			result := e.executeCase(context.Background(), caseCfg, "with_skill", &mockRuntime{workspace: t.TempDir()}, ag)
+
+			if result.Status != judge.StatusError {
+				t.Fatalf("expected ERROR, got %s", result.Status)
+			}
+			if result.Error == nil {
+				t.Fatal("expected non-nil error")
+			}
+			if !errors.Is(result.Error, context.DeadlineExceeded) {
+				t.Fatalf("expected error chain to contain context.DeadlineExceeded, got %v", result.Error)
+			}
+			want := fmt.Sprintf("case timeout %ds via %s", tt.wantSeconds, tt.wantSource)
+			if !strings.Contains(result.Error.Error(), want) {
+				t.Fatalf("expected error to mention %q, got %v", want, result.Error)
+			}
+		})
+	}
+}
+
+func TestExecuteCase_TimeoutWithoutJudgeIsError(t *testing.T) {
 	e := newTestEvaluator(EvalOptions{
 		Agent: &mockAgent{name: "test"},
 	})
 
 	caseCfg := &config.CaseConfig{
 		ID:    "case-timeout-no-judge",
-		Title: "Recovered timeout without judge",
+		Title: "Timed-out agent without judge stays ERROR",
 		Input: config.Input{Prompt: "hello"},
 	}
 
@@ -461,19 +539,17 @@ func TestExecuteCase_AgentCanceledWithPartialResultErrors(t *testing.T) {
 	}
 }
 
-func TestExecuteCase_RecoveredTimeoutAgentJudgeUsesFreshContext(t *testing.T) {
-	parentCtx, cancel := context.WithCancel(context.Background())
-	cancel()
-
+// Strict-budget regression: when the agent run times out, agent_judge MUST
+// NOT be invoked against a fresh context to salvage a verdict. The old
+// behaviour (evaluator.evaluationContext rewrapping ctx with WithoutCancel)
+// is intentionally gone so the case timeout strictly bounds agent + judge.
+func TestExecuteCase_AgentTimeoutDoesNotInvokeAgentJudge(t *testing.T) {
+	judgeRuns := atomic.Int32{}
 	judgeAgent := &mockAgent{
 		name: "judge",
-		runFunc: func(ctx context.Context, _ runtime.Runtime, _ agent.ExecOptions, _ []transcript.Message) (*agent.SessionResult, error) {
-			if ctx.Err() != nil {
-				return nil, fmt.Errorf("judge received canceled context: %w", ctx.Err())
-			}
-			return &agent.SessionResult{
-				FinalMessage: `{"passed":true,"summary":"ok","criteria":[{"name":"recovered","passed":true,"evidence":"ok"}]}`,
-			}, nil
+		runFunc: func(_ context.Context, _ runtime.Runtime, _ agent.ExecOptions, _ []transcript.Message) (*agent.SessionResult, error) {
+			judgeRuns.Add(1)
+			return &agent.SessionResult{FinalMessage: `{"results":[{"criterion":"recovered","passed":true,"evidence":"ok"}]}`}, nil
 		},
 	}
 
@@ -482,7 +558,8 @@ func TestExecuteCase_RecoveredTimeoutAgentJudgeUsesFreshContext(t *testing.T) {
 		EvalCfg: &config.EvalConfig{
 			Engine: config.EngineConfig{Name: "mock"},
 			Judge: config.JudgeConfig{
-				Type: "agent_judge",
+				Type:     "agent_judge",
+				Criteria: []string{"recovered"},
 			},
 		},
 	})
@@ -494,11 +571,12 @@ func TestExecuteCase_RecoveredTimeoutAgentJudgeUsesFreshContext(t *testing.T) {
 	defer func() { agentDetectWithInitParams = origDetect }()
 
 	caseCfg := &config.CaseConfig{
-		ID:    "case-timeout-agent-judge",
-		Title: "Recovered timeout continues into agent judge",
+		ID:    "case-timeout-no-judge-salvage",
+		Title: "Timed-out agent does not invoke agent_judge",
 		Input: config.Input{Prompt: "hello"},
 		Judge: config.JudgeConfig{
-			Type: "agent_judge",
+			Type:     "agent_judge",
+			Criteria: []string{"recovered"},
 		},
 	}
 
@@ -512,13 +590,13 @@ func TestExecuteCase_RecoveredTimeoutAgentJudgeUsesFreshContext(t *testing.T) {
 		},
 	}
 
-	result := e.executeCase(parentCtx, caseCfg, "with_skill", &mockRuntime{workspace: t.TempDir()}, runAgent)
+	result := e.executeCase(context.Background(), caseCfg, "with_skill", &mockRuntime{workspace: t.TempDir()}, runAgent)
 
-	if result.Status != judge.StatusPass {
-		t.Fatalf("expected PASS after recovered timeout enters agent_judge with fresh context, got %s (err=%v)", result.Status, result.Error)
+	if result.Status != judge.StatusError {
+		t.Fatalf("expected ERROR (no salvage), got %s (err=%v)", result.Status, result.Error)
 	}
-	if result.Error != nil {
-		t.Fatalf("expected nil error, got %v", result.Error)
+	if got := judgeRuns.Load(); got != 0 {
+		t.Fatalf("agent_judge must not be invoked when the agent run timed out, got %d runs", got)
 	}
 }
 

--- a/internal/judge/agent_judge.go
+++ b/internal/judge/agent_judge.go
@@ -107,16 +107,20 @@ func (j *AgentJudge) Evaluate(ctx context.Context, in Input) (*Result, error) {
 
 	// Get criterion results via agent.Agent. Snapshot parentCtx.Err() the
 	// instant Run returns, before parent's timer has any chance to fire on
-	// its own; this is what annotateTimeoutError uses to distinguish a
-	// judge-level deadline from a parent (case-level) one. Reading
+	// its own; this is how we distinguish a judge-level deadline from a
+	// parent (case-level) one and decide whether to annotate. Reading
 	// parentCtx.Err() later would race against the parent timer in the
 	// caseTimeout ≈ judgeTimeout boundary.
 	sessionResult, err := j.Agent.Run(ctx, j.Runtime, agent.ExecOptions{ArtifactDir: in.ArtifactDir}, messages)
 	parentExpired := parentCtx.Err() != nil
 	if err != nil {
+		annotated := err
+		if !parentExpired {
+			annotated = j.annotateTimeoutError(ctx, err)
+		}
 		if !canRecoverAgentJudgeResult(err, sessionResult) {
 			return nil, &SessionResultError{
-				Err:     fmt.Errorf("agent_judge agent call failed: %w", j.annotateTimeoutError(err, ctx, parentExpired)),
+				Err:     fmt.Errorf("agent_judge agent call failed: %w", annotated),
 				Session: sessionResult,
 			}
 		}
@@ -355,12 +359,13 @@ func findJSONObjectEnd(output string, start int) (int, bool) {
 }
 
 // annotateTimeoutError tags a context.DeadlineExceeded chain with the
-// judge-level timeout knob and seconds, but only when *we* are responsible
-// for that deadline — meaning judgeCtx really fired AND the parent context
-// had not already expired at the moment Run returned. The latter is passed
-// in as parentExpired (snapshotted at Run-return) instead of read here, to
-// avoid a race against the parent timer when caseTimeout ≈ judgeTimeout.
-func (j *AgentJudge) annotateTimeoutError(err error, judgeCtx context.Context, parentExpired bool) error {
+// judge-level timeout knob and seconds. The caller (Evaluate) decides whether
+// to invoke this — specifically, only when the parent context had not already
+// expired at the moment Run returned — so this function does not re-check the
+// parent. It only verifies that *our* judge ctx really fired before labeling
+// (an upstream HTTP layer can also return DeadlineExceeded with its own
+// shorter deadline, which is not ours to label).
+func (j *AgentJudge) annotateTimeoutError(judgeCtx context.Context, err error) error {
 	if err == nil || j.TimeoutSeconds <= 0 {
 		return err
 	}
@@ -368,14 +373,6 @@ func (j *AgentJudge) annotateTimeoutError(err error, judgeCtx context.Context, p
 		return err
 	}
 	if judgeCtx.Err() == nil {
-		// Inner ctx didn't fire; the DeadlineExceeded came from somewhere
-		// else (e.g. an HTTP layer with its own short deadline). Not ours
-		// to label.
-		return err
-	}
-	if parentExpired {
-		// Parent was already done at Run-return — the case-level layer will
-		// annotate that.
 		return err
 	}
 	return fmt.Errorf("%w (judge timeout %ds via judge.timeout_seconds)", err, j.TimeoutSeconds)

--- a/internal/judge/agent_judge.go
+++ b/internal/judge/agent_judge.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/alibaba/skill-up/internal/agent"
 	"github.com/alibaba/skill-up/internal/logging"
@@ -65,20 +66,25 @@ type AgentJudge struct {
 
 	// PassThreshold is the minimum pass rate (default 0.7).
 	PassThreshold float64
+
+	// TimeoutSeconds bounds a single Evaluate call. <=0 means no judge-level
+	// deadline; the parent context still applies.
+	TimeoutSeconds int
 }
 
 // NewAgentJudge creates an AgentJudge with sensible defaults.
-func NewAgentJudge(ag agent.Agent, rt runtime.Runtime, model string, criteria []string, passThreshold *float64) *AgentJudge {
+func NewAgentJudge(ag agent.Agent, rt runtime.Runtime, model string, criteria []string, passThreshold *float64, timeoutSeconds int) *AgentJudge {
 	threshold := DefaultPassThreshold
 	if passThreshold != nil {
 		threshold = *passThreshold
 	}
 	return &AgentJudge{
-		Agent:         ag,
-		Runtime:       rt,
-		Model:         model,
-		Criteria:      criteria,
-		PassThreshold: threshold,
+		Agent:          ag,
+		Runtime:        rt,
+		Model:          model,
+		Criteria:       criteria,
+		PassThreshold:  threshold,
+		TimeoutSeconds: timeoutSeconds,
 	}
 }
 
@@ -88,20 +94,33 @@ func (j *AgentJudge) Evaluate(ctx context.Context, in Input) (*Result, error) {
 		return NewResult(nil, in.TurnsExecuted, in.TurnsTotal), nil
 	}
 
+	parentCtx := ctx
+	if j.TimeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(j.TimeoutSeconds)*time.Second)
+		defer cancel()
+	}
+
 	// Build the judge prompt.
 	prompt := buildJudgePrompt(ctx, j.Criteria, in.FinalMessage, in.WorkspaceDiff, in.Transcript)
 	messages := []transcript.Message{{Role: transcript.RoleUser, Content: prompt, Turn: 1}}
 
-	// Get criterion results via agent.Agent.
+	// Get criterion results via agent.Agent. Snapshot parentCtx.Err() the
+	// instant Run returns, before parent's timer has any chance to fire on
+	// its own; this is what annotateTimeoutError uses to distinguish a
+	// judge-level deadline from a parent (case-level) one. Reading
+	// parentCtx.Err() later would race against the parent timer in the
+	// caseTimeout ≈ judgeTimeout boundary.
 	sessionResult, err := j.Agent.Run(ctx, j.Runtime, agent.ExecOptions{ArtifactDir: in.ArtifactDir}, messages)
+	parentExpired := parentCtx.Err() != nil
 	if err != nil {
 		if !canRecoverAgentJudgeResult(err, sessionResult) {
 			return nil, &SessionResultError{
-				Err:     fmt.Errorf("agent_judge agent call failed: %w", err),
+				Err:     fmt.Errorf("agent_judge agent call failed: %w", j.annotateTimeoutError(err, ctx, parentExpired)),
 				Session: sessionResult,
 			}
 		}
-		logging.WarnContextf(ctx, "agent_judge recovering judge output despite agent error: %v", err)
+		logging.WarnContextf(ctx, "agent_judge recovering judge output despite agent error: %v (judge.timeout_seconds=%d, parent_ctx_expired=%t)", err, j.TimeoutSeconds, parentExpired)
 	}
 
 	var resp judgeResponse
@@ -333,6 +352,33 @@ func findJSONObjectEnd(output string, start int) (int, bool) {
 	}
 
 	return 0, false
+}
+
+// annotateTimeoutError tags a context.DeadlineExceeded chain with the
+// judge-level timeout knob and seconds, but only when *we* are responsible
+// for that deadline — meaning judgeCtx really fired AND the parent context
+// had not already expired at the moment Run returned. The latter is passed
+// in as parentExpired (snapshotted at Run-return) instead of read here, to
+// avoid a race against the parent timer when caseTimeout ≈ judgeTimeout.
+func (j *AgentJudge) annotateTimeoutError(err error, judgeCtx context.Context, parentExpired bool) error {
+	if err == nil || j.TimeoutSeconds <= 0 {
+		return err
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	if judgeCtx.Err() == nil {
+		// Inner ctx didn't fire; the DeadlineExceeded came from somewhere
+		// else (e.g. an HTTP layer with its own short deadline). Not ours
+		// to label.
+		return err
+	}
+	if parentExpired {
+		// Parent was already done at Run-return — the case-level layer will
+		// annotate that.
+		return err
+	}
+	return fmt.Errorf("%w (judge timeout %ds via judge.timeout_seconds)", err, j.TimeoutSeconds)
 }
 
 func canRecoverAgentJudgeResult(err error, sessionResult *agent.SessionResult) bool {

--- a/internal/judge/agent_judge_test.go
+++ b/internal/judge/agent_judge_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/alibaba/skill-up/internal/agent"
 	"github.com/alibaba/skill-up/internal/logging"
@@ -29,7 +30,7 @@ func TestAgentJudge_AllPass(t *testing.T) {
 	ag := &mockJudgeTestAgent{output: output}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"output identifies the bug", "no false positives", "actionable suggestion"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"output identifies the bug", "no false positives", "actionable suggestion"}, nil, 0)
 	r, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	assertStatus(t, r, StatusPass)
@@ -61,14 +62,14 @@ func TestAgentJudge_PartialPass_AboveThreshold(t *testing.T) {
 	rt := &mockJudgeTestRuntime{}
 
 	// 2/3 = 0.667, threshold default 0.7 → FAIL
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2", "c3"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2", "c3"}, nil, 0)
 	r, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	assertStatus(t, r, StatusFail) // 0.667 < 0.7
 
 	// With lower threshold 0.6 → PASS
 	threshold := 0.6
-	j2 := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2", "c3"}, &threshold)
+	j2 := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2", "c3"}, &threshold, 0)
 	r2, err := j2.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	assertStatus(t, r2, StatusPass) // 0.667 >= 0.6
@@ -86,7 +87,7 @@ func TestAgentJudge_AllFail(t *testing.T) {
 	ag := &mockJudgeTestAgent{output: output}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2"}, nil, 0)
 	r, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	assertStatus(t, r, StatusFail)
@@ -109,7 +110,7 @@ func TestAgentJudge_ThresholdExactlyMet(t *testing.T) {
 
 	// 1/2 = 0.5, threshold = 0.5 → PASS (>=)
 	threshold := 0.5
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2"}, &threshold)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2"}, &threshold, 0)
 	r, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	assertStatus(t, r, StatusPass)
@@ -123,7 +124,7 @@ func TestAgentJudge_AgentError(t *testing.T) {
 	ag := &mockJudgeTestAgent{err: errors.New("API rate limit exceeded")}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil, 0)
 	_, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	if err == nil {
 		t.Fatal("expected error from agent")
@@ -146,7 +147,7 @@ func TestAgentJudge_AgentError_PreservesSession(t *testing.T) {
 	}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil, 0)
 	_, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	if err == nil {
 		t.Fatal("expected error from agent")
@@ -167,7 +168,7 @@ func TestAgentJudge_RecoversTimedOutSessionWithValidJSON(t *testing.T) {
 	}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil, 0)
 	r, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	assertStatus(t, r, StatusPass)
@@ -188,7 +189,7 @@ func TestAgentJudge_RecoveryLogsWarning(t *testing.T) {
 	rt := &mockJudgeTestRuntime{}
 
 	captured := captureLogOutput(t, func() {
-		j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil)
+		j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil, 0)
 		_, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 		assertNoError(t, err)
 	})
@@ -208,7 +209,7 @@ func TestAgentJudge_CanceledSessionDoesNotRecover(t *testing.T) {
 	}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil, 0)
 	_, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	if err == nil {
 		t.Fatal("expected error for canceled judge run")
@@ -233,7 +234,7 @@ func TestAgentJudge_RecoversNonZeroExitWithValidJSON(t *testing.T) {
 	}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil, 0)
 	r, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	assertStatus(t, r, StatusFail)
@@ -250,7 +251,7 @@ func TestAgentJudge_EmptyCriteria(t *testing.T) {
 	ag := &mockJudgeTestAgent{}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{}, nil, 0)
 	r, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	assertStatus(t, r, StatusPass)
@@ -267,7 +268,7 @@ func TestAgentJudge_EvidencePreserved(t *testing.T) {
 	ag := &mockJudgeTestAgent{output: output}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"identified the bug"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"identified the bug"}, nil, 0)
 	r, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	if len(r.AssertionResults) != 1 {
@@ -299,14 +300,14 @@ func TestAgentJudge_CustomThreshold(t *testing.T) {
 	// 3/4 = 0.75
 	// threshold 0.8 → FAIL
 	threshold := 0.8
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2", "c3", "c4"}, &threshold)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2", "c3", "c4"}, &threshold, 0)
 	r, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	assertStatus(t, r, StatusFail)
 
 	// threshold 0.75 → PASS
 	threshold2 := 0.75
-	j2 := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2", "c3", "c4"}, &threshold2)
+	j2 := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2", "c3", "c4"}, &threshold2, 0)
 	r2, err := j2.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	assertNoError(t, err)
 	assertStatus(t, r2, StatusPass)
@@ -402,7 +403,7 @@ func TestAgentJudge_PartialResults_ReturnsError(t *testing.T) {
 	ag := &mockJudgeTestAgent{output: output}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2", "c3"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2", "c3"}, nil, 0)
 	_, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	if err == nil {
 		t.Fatal("expected error for partial criterion results")
@@ -421,7 +422,7 @@ func TestAgentJudge_EmptyResults_ReturnsError(t *testing.T) {
 	ag := &mockJudgeTestAgent{output: output}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2"}, nil, 0)
 	_, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	if err == nil {
 		t.Fatal("expected error for empty criterion results")
@@ -443,7 +444,7 @@ func TestAgentJudge_EmptyEvidence_ReturnsError(t *testing.T) {
 	ag := &mockJudgeTestAgent{output: output}
 	rt := &mockJudgeTestRuntime{}
 
-	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2"}, nil)
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1", "c2"}, nil, 0)
 	_, err := j.Evaluate(context.Background(), Input{FinalMessage: "test"})
 	if err == nil {
 		t.Fatal("expected error for empty evidence")
@@ -451,6 +452,97 @@ func TestAgentJudge_EmptyEvidence_ReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "empty evidence") {
 		t.Fatalf("unexpected error message: %v", err)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// TimeoutSeconds wiring
+// ---------------------------------------------------------------------------
+
+func TestAgentJudge_TimeoutSeconds_AppliesDeadline(t *testing.T) {
+	ag := &mockJudgeTestAgent{
+		output:   buildMockAgentOutput([]CriterionResult{{Criterion: "c1", Passed: true, Evidence: "ok"}}),
+		runDelay: 500 * time.Millisecond,
+	}
+	rt := &mockJudgeTestRuntime{}
+
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil, 1) // 1s budget should beat the 500ms delay
+	deadline, ok := assertEvaluatesWithDeadline(t, j, ag)
+	if !ok {
+		t.Fatalf("expected agent ctx to have a deadline when TimeoutSeconds=1")
+	}
+	if d := time.Until(deadline); d <= 0 || d > time.Second {
+		t.Fatalf("deadline %v not within (0,1s] from now", d)
+	}
+}
+
+func TestAgentJudge_TimeoutSeconds_ZeroDoesNotShortenParentCtx(t *testing.T) {
+	ag := &mockJudgeTestAgent{output: buildMockAgentOutput([]CriterionResult{{Criterion: "c1", Passed: true, Evidence: "ok"}})}
+	rt := &mockJudgeTestRuntime{}
+
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil, 0)
+	if _, err := j.Evaluate(context.Background(), Input{FinalMessage: "x"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ag.observedDeadlineOK {
+		t.Fatalf("expected no deadline on inner ctx when TimeoutSeconds=0, got %v", ag.observedDeadline)
+	}
+}
+
+func TestAgentJudge_TimeoutSeconds_DeadlineKillsSlowAgent(t *testing.T) {
+	ag := &mockJudgeTestAgent{
+		output:   buildMockAgentOutput([]CriterionResult{{Criterion: "c1", Passed: true, Evidence: "ok"}}),
+		runDelay: 2 * time.Second,
+	}
+	rt := &mockJudgeTestRuntime{}
+
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil, 1) // 1s budget, agent takes 2s
+	start := time.Now()
+	_, err := j.Evaluate(context.Background(), Input{FinalMessage: "x"})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("expected error when agent exceeds judge timeout")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected wrapped context.DeadlineExceeded, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "judge timeout 1s via judge.timeout_seconds") {
+		t.Fatalf("expected judge timeout annotation in error, got %v", err)
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("Evaluate ran %v, expected to abort near the 1s deadline", elapsed)
+	}
+}
+
+func TestAgentJudge_TimeoutSeconds_ParentTimeoutNotAnnotatedAsJudgeTimeout(t *testing.T) {
+	ag := &mockJudgeTestAgent{
+		output:   buildMockAgentOutput([]CriterionResult{{Criterion: "c1", Passed: true, Evidence: "ok"}}),
+		runDelay: 2 * time.Second,
+	}
+	rt := &mockJudgeTestRuntime{}
+
+	// Judge has a generous 10s budget; the parent ctx is the binding deadline at 200ms.
+	j := NewAgentJudge(ag, rt, "test-model", []string{"c1"}, nil, 10)
+	parentCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err := j.Evaluate(parentCtx, Input{FinalMessage: "x"})
+	if err == nil {
+		t.Fatalf("expected error when parent ctx expires")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected wrapped context.DeadlineExceeded, got %v", err)
+	}
+	if strings.Contains(err.Error(), "judge.timeout_seconds") {
+		t.Fatalf("parent-ctx deadline must not be labelled as judge timeout, got %v", err)
+	}
+}
+
+func assertEvaluatesWithDeadline(t *testing.T, j *AgentJudge, ag *mockJudgeTestAgent) (time.Time, bool) {
+	t.Helper()
+	if _, err := j.Evaluate(context.Background(), Input{FinalMessage: "x"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return ag.observedDeadline, ag.observedDeadlineOK
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/judge/e2e_test.go
+++ b/internal/judge/e2e_test.go
@@ -437,7 +437,7 @@ func TestE2E_JudgePolymorphism_SameInputDifferentStrategies(t *testing.T) {
 	})
 	mockAg := &mockJudgeTestAgent{output: agentOutput}
 	mockRt := &mockJudgeTestRuntime{}
-	agentJudge := NewAgentJudge(mockAg, mockRt, "gpt-5.4", []string{"identified the bug", "provided fix suggestion"}, nil)
+	agentJudge := NewAgentJudge(mockAg, mockRt, "gpt-5.4", []string{"identified the bug", "provided fix suggestion"}, nil, 0)
 
 	ctx := context.Background()
 
@@ -715,7 +715,7 @@ func TestE2E_AgentJudge_WithExpect_ThresholdDecision(t *testing.T) {
 
 	// threshold 0.7 → 0.667 < 0.7 → FAIL.
 	judge1 := NewAgentJudge(mockAg, mockRt, "gpt-5.4",
-		[]string{"identified the bug type", "located the bug position", "provided fix suggestion"}, nil)
+		[]string{"identified the bug type", "located the bug position", "provided fix suggestion"}, nil, 0)
 	result1, err := runEvalPipeline(context.Background(), expectCfg, judge1, input)
 	assertNoError(t, err)
 	assertStatus(t, result1, StatusFail)
@@ -726,7 +726,7 @@ func TestE2E_AgentJudge_WithExpect_ThresholdDecision(t *testing.T) {
 	// threshold 0.6 → 0.667 >= 0.6 → PASS.
 	threshold := 0.6
 	judge2 := NewAgentJudge(mockAg, mockRt, "gpt-5.4",
-		[]string{"identified the bug type", "located the bug position", "provided fix suggestion"}, &threshold)
+		[]string{"identified the bug type", "located the bug position", "provided fix suggestion"}, &threshold, 0)
 	result2, err := runEvalPipeline(context.Background(), expectCfg, judge2, input)
 	assertNoError(t, err)
 	assertStatus(t, result2, StatusPass)

--- a/internal/judge/factory.go
+++ b/internal/judge/factory.go
@@ -38,7 +38,7 @@ func NewJudge(cfg config.JudgeConfig, ag agent.Agent, rt runtime.Runtime) (Judge
 		if ag == nil {
 			return nil, errors.New("agent_judge requires an Agent")
 		}
-		return NewAgentJudge(ag, rt, cfg.Model, cfg.Criteria, cfg.PassThreshold), nil
+		return NewAgentJudge(ag, rt, cfg.Model, cfg.Criteria, cfg.PassThreshold, derefInt(cfg.TimeoutSeconds)), nil
 
 	case "":
 		// No judge configured — return nil, caller should handle

--- a/internal/judge/factory_test.go
+++ b/internal/judge/factory_test.go
@@ -119,6 +119,45 @@ func TestNewJudge_AgentJudge_CustomThreshold(t *testing.T) {
 	}
 }
 
+// Regression: judge.timeout_seconds must reach AgentJudge through the factory.
+// Was silently dropped at one point when the parameter list was rewritten in
+// bulk and the factory call site got a hardcoded 0.
+func TestNewJudge_AgentJudge_PropagatesTimeoutSeconds(t *testing.T) {
+	cfg := config.JudgeConfig{
+		Type:           "agent_judge",
+		Model:          "test-model",
+		Criteria:       []string{"c1"},
+		TimeoutSeconds: intPtr(45),
+	}
+	j, err := NewJudge(cfg, &mockJudgeTestAgent{}, &mockJudgeTestRuntime{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	aj, ok := j.(*AgentJudge)
+	if !ok {
+		t.Fatalf("expected *AgentJudge, got %T", j)
+	}
+	if aj.TimeoutSeconds != 45 {
+		t.Errorf("expected TimeoutSeconds 45 from cfg, got %d", aj.TimeoutSeconds)
+	}
+}
+
+func TestNewJudge_AgentJudge_NilTimeoutSecondsDefaultsToZero(t *testing.T) {
+	cfg := config.JudgeConfig{
+		Type:     "agent_judge",
+		Model:    "test-model",
+		Criteria: []string{"c1"},
+	}
+	j, err := NewJudge(cfg, &mockJudgeTestAgent{}, &mockJudgeTestRuntime{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	aj := j.(*AgentJudge)
+	if aj.TimeoutSeconds != 0 {
+		t.Errorf("expected TimeoutSeconds 0 when unset, got %d", aj.TimeoutSeconds)
+	}
+}
+
 func TestNewJudge_AgentJudge_NilAgent(t *testing.T) {
 	cfg := config.JudgeConfig{Type: "agent_judge"}
 	_, err := NewJudge(cfg, nil, nil)

--- a/internal/judge/factory_test.go
+++ b/internal/judge/factory_test.go
@@ -152,7 +152,10 @@ func TestNewJudge_AgentJudge_NilTimeoutSecondsDefaultsToZero(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	aj := j.(*AgentJudge)
+	aj, ok := j.(*AgentJudge)
+	if !ok {
+		t.Fatalf("expected *AgentJudge, got %T", j)
+	}
 	if aj.TimeoutSeconds != 0 {
 		t.Errorf("expected TimeoutSeconds 0 when unset, got %d", aj.TimeoutSeconds)
 	}

--- a/internal/judge/helpers_test.go
+++ b/internal/judge/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/alibaba/skill-up/internal/agent"
 	"github.com/alibaba/skill-up/internal/runtime"
@@ -66,6 +67,17 @@ type mockJudgeTestAgent struct {
 	output    string
 	err       error
 	runResult *agent.SessionResult
+
+	// runDelay simulates a slow agent call by blocking on either the ctx
+	// deadline or the duration expiring, whichever happens first. Used by
+	// timeout tests; leave zero for the immediate-return default.
+	runDelay time.Duration
+
+	// observedDeadline captures whatever deadline the agent received on its
+	// last Run call, so tests can assert that AgentJudge applied
+	// TimeoutSeconds correctly. ok mirrors ctx.Deadline()'s second return.
+	observedDeadline   time.Time
+	observedDeadlineOK bool
 }
 
 func (m *mockJudgeTestAgent) Name() string { return "mock-judge-agent" }
@@ -86,7 +98,15 @@ func (m *mockJudgeTestAgent) Check(_ context.Context, _ runtime.Runtime) error {
 
 func (m *mockJudgeTestAgent) CheckCredentials(_ context.Context) error { return nil }
 
-func (m *mockJudgeTestAgent) Run(_ context.Context, _ runtime.Runtime, _ agent.ExecOptions, _ []transcript.Message) (*agent.SessionResult, error) {
+func (m *mockJudgeTestAgent) Run(ctx context.Context, _ runtime.Runtime, _ agent.ExecOptions, _ []transcript.Message) (*agent.SessionResult, error) {
+	m.observedDeadline, m.observedDeadlineOK = ctx.Deadline()
+	if m.runDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(m.runDelay):
+		}
+	}
 	if m.runResult != nil {
 		return m.runResult, m.err
 	}

--- a/internal/runtime/none.go
+++ b/internal/runtime/none.go
@@ -201,7 +201,17 @@ func (r *NoneRuntime) Exec(ctx context.Context, command string, opts ExecOptions
 		// hit its deadline. -1 is a sentinel, not a real exit code, and
 		// attaching the full command source ("exited with code -1: set
 		// -e ...") misleads readers into chasing a script-level failure.
-		logging.ErrorContextf(ctx, "command killed by context (%v); command: %s", ctx.Err(), maskCommand(command))
+		// When this was specifically a deadline (not a manual cancel),
+		// include "deadline elapsed by Xs" so the surrounding logs make
+		// the timeout obvious and the higher layer's error wrapper can be
+		// correlated with this line.
+		reason := ctx.Err().Error()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			if deadline, ok := ctx.Deadline(); ok {
+				reason = fmt.Sprintf("%s (deadline elapsed by %s)", reason, time.Since(deadline).Round(time.Millisecond))
+			}
+		}
+		logging.ErrorContextf(ctx, "command killed by context (%s); command: %s", reason, maskCommand(command))
 		if result.Stderr != "" {
 			logNonZeroStderr(ctx, result.ExitCode, result.Stderr)
 		}

--- a/internal/runtime/none_test.go
+++ b/internal/runtime/none_test.go
@@ -220,6 +220,53 @@ func TestNoneRuntime_ExecReturnsContextErrorOnTimeout(t *testing.T) {
 	}
 }
 
+func TestNoneRuntime_ExecLogsDeadlineDelta_OnTimeout(t *testing.T) {
+	rt := &NoneRuntime{}
+	if err := rt.Create(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close() }()
+
+	output := captureStdout(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		_, _ = rt.Exec(ctx, "sleep 1", ExecOptions{})
+	})
+
+	if !strings.Contains(output, "command killed by context (context deadline exceeded") {
+		t.Fatalf("expected timeout reason in log, got: %s", output)
+	}
+	if !strings.Contains(output, "deadline elapsed by") {
+		t.Fatalf("expected deadline-elapsed annotation in log, got: %s", output)
+	}
+}
+
+func TestNoneRuntime_ExecOmitsDeadlineDelta_OnManualCancel(t *testing.T) {
+	rt := &NoneRuntime{}
+	if err := rt.Create(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close() }()
+
+	output := captureStdout(t, func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+		_, _ = rt.Exec(ctx, "sleep 1", ExecOptions{})
+	})
+
+	if !strings.Contains(output, "command killed by context (context canceled") {
+		t.Fatalf("expected cancel reason in log, got: %s", output)
+	}
+	// A manual cancel has no deadline; the negative-elapsed annotation must
+	// not appear (it would read "deadline elapsed by -…").
+	if strings.Contains(output, "deadline elapsed by") {
+		t.Fatalf("must not annotate deadline on manual cancel, got: %s", output)
+	}
+}
+
 func TestNoneRuntime_ExecAddsSpanCommandAttrs(t *testing.T) {
 	rt := &NoneRuntime{}
 	if err := rt.Create(context.Background()); err != nil {


### PR DESCRIPTION
## Summary

Three related changes to the eval timeout model. The trigger was a CI run where an `agent_judge` case timed out but the failure log only said `context deadline exceeded` with no clue **which** timeout fired, **how long** it was, or **why** the judge ran at all after the agent had already been killed.

### A. \`judge.timeout_seconds\` now also bounds \`agent_judge\`

Previously only the script judge respected `judge.timeout_seconds` (see the prior comment in `internal/config/schema.go`, ``\"Only applicable when Type is \\\"script\\\"\"``); the agent_judge variant silently ignored it. `AgentJudge` gains a `TimeoutSeconds` field, `factory.NewJudge` passes `cfg.TimeoutSeconds` through. `0` keeps the old \"no judge-level deadline\" behaviour — the parent ctx still applies. A regression test (`TestNewJudge_AgentJudge_PropagatesTimeoutSeconds`) pins the factory wiring so it can't get silently dropped by a bulk rename.

### B. Strict case-timeout budget — drop the salvage detour

The evaluator used to re-run the judge with `context.WithoutCancel` when the agent run hit `context.DeadlineExceeded` but its `sessionResult` still had ≥16 chars of recoverable text. That quietly broke the contract that the case timeout bounds a case — a salvaged judge could spend minutes more on a case whose budget was already exhausted. Removed:

- `evaluator.evaluationContext` (the `WithoutCancel` rewrap)
- `canContinueAfterExecutionError` / `hasRecoverableSessionResult` / `hasRecoverableText` / `isInterruptedError`
- `minRecoverableSessionTextLen`

`handleExecutionResult` now ERRORs on any `execErr`; the case timeout strictly bounds agent + judge as a single budget. New regression test `TestExecuteCase_AgentTimeoutDoesNotInvokeAgentJudge` actually counts judge runs to make sure no one re-introduces the side door.

> **Kept on purpose:** `AgentJudge.canRecoverAgentJudgeResult` (a different salvage that reparses JSON from a failed agent's `FinalMessage`) — it has nothing to do with ctx cancellation.

### C. Timeout errors now name the knob and value

`evaluator.withCaseTimeout` returns `(ctx, cancel, source, seconds)`; `executeCase` annotates `DeadlineExceeded` errors with `(case timeout 300s via cases.defaults.timeout_seconds)` so users know exactly which YAML field to bump. `AgentJudge.annotateTimeoutError` does the same for `(judge timeout 60s via judge.timeout_seconds)`, but only when the judge's own ctx fired **AND** the parent ctx had not already expired at `Run` return — the `parentExpired` flag is snapshotted right after `Run` returns to avoid a race with the parent timer when the two budgets are close. `runtime/none.go`'s \"command killed by context\" log now also includes `(deadline elapsed by Xs)`, but only on a real deadline (gated on `errors.Is(ctx.Err(), context.DeadlineExceeded)` so a manual cancel doesn't print a negative delta).

### Docs

`docs/guide/writing-evals.md` and the zh mirror get the new `agent_judge` `timeout_seconds` knob in the example.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green
- [x] New tests:
  - `TestAgentJudge_TimeoutSeconds_AppliesDeadline` / `_ZeroDoesNotShortenParentCtx` / `_DeadlineKillsSlowAgent` / `_ParentTimeoutNotAnnotatedAsJudgeTimeout`
  - `TestNewJudge_AgentJudge_PropagatesTimeoutSeconds` / `_NilTimeoutSecondsDefaultsToZero`
  - `TestExecuteCase_TimeoutErrorNamesConfigKey` (table-driven: case-constraint vs eval-default)
  - `TestExecuteCase_AgentTimeoutDoesNotInvokeAgentJudge` (counts judge runs)
  - `TestExecuteCase_AgentTimeoutWithPartialResultStillErrors`
  - `TestNoneRuntime_ExecLogsDeadlineDelta_OnTimeout` / `_OmitsDeadlineDelta_OnManualCancel`
- [x] `gofmt`, `go vet` clean.

## Reviewer notes

- Branched from `main`, **independent of #60** (the two PRs touch different files and can land in either order).
- One commit with all three pieces because B and C share `evaluator.go`; commit message has the same three-part structure for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)