### PR TITLE
fix(ci): publish coverage badge from badges branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: badges
 
       - name: Download coverage badge artifact
         uses: actions/download-artifact@v5
@@ -117,7 +119,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .github/badges/coverage.json
           git commit -m "chore(ci): update coverage badge to ${pct} [skip ci]"
-          git push
+          git push origin badges
 
   e2e:
     name: E2E (none runtime)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
       <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" />
     </a>
     <a href="./.github/badges/coverage.json">
-      <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/alibaba/skill-up/main/.github/badges/coverage.json" alt="Coverage" />
+      <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/alibaba/skill-up/badges/.github/badges/coverage.json" alt="Coverage" />
     </a>
     <a href="https://go.dev/">
       <img src="https://img.shields.io/badge/go-%3E%3D1.25-blue" alt="Go Version" />

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
       <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" />
     </a>
     <a href="./.github/badges/coverage.json">
-      <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/alibaba/skill-up/main/.github/badges/coverage.json" alt="Coverage" />
+      <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/alibaba/skill-up/badges/.github/badges/coverage.json" alt="Coverage" />
     </a>
     <a href="https://go.dev/">
       <img src="https://img.shields.io/badge/go-%3E%3D1.25-blue" alt="Go Version" />


### PR DESCRIPTION
## Summary
- publish the coverage badge artifact from the unprotected badges branch
- point English and Chinese README coverage badge URLs at the badges branch
- initialized origin/badges with .github/badges/coverage.json so checkout succeeds after merge

Fixes #59

## Verification
- make fmt
- make verify
- make test