### PR TITLE
fix(codex): synthesize provider override when ModelProvider is empty but BaseURL is set

### DIFF
--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -288,17 +288,24 @@ type codexProviderConfig struct {
 }
 
 func (a *CodexAgent) runProviderConfig(ctx context.Context) codexProviderConfig {
-	if a.Cfg.ModelProvider == "" {
-		return codexProviderConfig{BaseURL: a.Cfg.BaseURL}
-	}
-	// When OPENAI_BASE_URL (or DASHSCOPE_BASE_URL routed via provider env)
-	// resolves to a non-default endpoint, route codex to it via a *distinct*
-	// provider entry. We can't reuse the literal "openai" name because codex
-	// ships a built-in provider config under that key and merging the override
-	// onto it is unreliable across codex versions — codex keeps using its
-	// bundled api.openai.com endpoint. A unique key forces codex to construct
-	// a brand-new provider definition from the -c flags alone.
-	if a.Cfg.ModelProvider == agentProviderOpenAI {
+	// Empty provider + non-empty BaseURL is the same situation as
+	// provider="openai" + non-empty BaseURL: the caller pointed codex at a
+	// non-default endpoint without naming a distinct provider. Both cases
+	// must synthesise the "skill-up-openai" override so codex emits a full
+	// `model_providers.skill-up-openai.{base_url,env_key,wire_api}` config —
+	// the legacy single `-c openai_base_url=...` fallback below is silently
+	// ignored by codex (it keeps using its bundled api.openai.com endpoint
+	// with wire_api="responses"), which makes any /chat/completions-only
+	// upstream (idealab, dashscope OpenAI-compat, …) return 400 from
+	// `codex_api::endpoint::responses`. wire_api="chat" forces codex onto
+	// /chat/completions instead.
+	//
+	// We can't reuse the literal "openai" name because codex ships a
+	// built-in provider config under that key and merging the override
+	// onto it is unreliable across codex versions. A unique key forces
+	// codex to construct a brand-new provider definition from the -c
+	// flags alone.
+	if a.Cfg.ModelProvider == "" || a.Cfg.ModelProvider == agentProviderOpenAI {
 		if a.Cfg.BaseURL == "" {
 			return codexProviderConfig{}
 		}
@@ -436,26 +443,23 @@ func buildCodexRunCmdWithLastMessage(instruction, model string, provider codexPr
 }
 
 func codexProviderFlags(provider codexProviderConfig) string {
-	if provider.Name != "" {
-		flags := " -c " + shellQuote("model_provider="+strconv.Quote(provider.Name))
-		if provider.Label != "" {
-			flags += " -c " + shellQuote("model_providers."+provider.Name+".name="+strconv.Quote(provider.Label))
-		}
-		if provider.BaseURL != "" {
-			flags += " -c " + shellQuote("model_providers."+provider.Name+".base_url="+strconv.Quote(provider.BaseURL))
-		}
-		if provider.EnvKey != "" {
-			flags += " -c " + shellQuote("model_providers."+provider.Name+".env_key="+strconv.Quote(provider.EnvKey))
-		}
-		if provider.WireAPI != "" {
-			flags += " -c " + shellQuote("model_providers."+provider.Name+".wire_api="+strconv.Quote(provider.WireAPI))
-		}
-		return flags
+	if provider.Name == "" {
+		return ""
+	}
+	flags := " -c " + shellQuote("model_provider="+strconv.Quote(provider.Name))
+	if provider.Label != "" {
+		flags += " -c " + shellQuote("model_providers."+provider.Name+".name="+strconv.Quote(provider.Label))
 	}
 	if provider.BaseURL != "" {
-		return " -c " + shellQuote("openai_base_url="+strconv.Quote(provider.BaseURL))
+		flags += " -c " + shellQuote("model_providers."+provider.Name+".base_url="+strconv.Quote(provider.BaseURL))
 	}
-	return ""
+	if provider.EnvKey != "" {
+		flags += " -c " + shellQuote("model_providers."+provider.Name+".env_key="+strconv.Quote(provider.EnvKey))
+	}
+	if provider.WireAPI != "" {
+		flags += " -c " + shellQuote("model_providers."+provider.Name+".wire_api="+strconv.Quote(provider.WireAPI))
+	}
+	return flags
 }
 
 func codexCustomProviderUnavailableReason(provider, baseURL string) string {

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -130,13 +130,50 @@ func TestBuildCodexRunCmd(t *testing.T) {
 	}
 }
 
-func TestBuildCodexRunCmdWithBaseURL(t *testing.T) {
+// TestCodexRunProviderConfig_EmptyProviderWithBaseURLOverridesBuiltin pins the
+// post-fix behavior for `ModelProvider="" + BaseURL=<non-default>`: same as the
+// `ModelProvider="openai"` case, route through the synthetic "skill-up-openai"
+// override so codex emits a full `model_providers.skill-up-openai.{base_url,
+// env_key,wire_api=chat}` block. Regression guard for the prior buggy fallback
+// that emitted only `-c openai_base_url=...` (silently ignored by codex →
+// upstream got hit on /responses with the bundled provider's wire_api,
+// returning 400 against /chat/completions-only endpoints like idealab).
+func TestCodexRunProviderConfig_EmptyProviderWithBaseURLOverridesBuiltin(t *testing.T) {
 	t.Parallel()
 
-	cmd := buildCodexRunCmd("say hi", "gpt-5.4", codexProviderConfig{BaseURL: "https://openai.example.com/v1"}, codexProcessSandbox)
-	want := `codex exec --json --skip-git-repo-check --sandbox workspace-write -c 'openai_base_url="https://openai.example.com/v1"' -m 'gpt-5.4' 'say hi'`
-	if cmd != want {
-		t.Fatalf("unexpected command:\nwant: %s\ngot:  %s", want, cmd)
+	ag := NewCodexAgent(Config{
+		ModelName: "gpt-5.2-1211-global",
+		BaseURL:   "https://idealab.alibaba-inc.com/api/openai/v1",
+	})
+
+	got := ag.runProviderConfig(context.Background())
+	if got.Name != codexOpenAIOverrideProvider {
+		t.Fatalf("provider name = %q, want %q", got.Name, codexOpenAIOverrideProvider)
+	}
+	if got.Label != codexOpenAIOverrideProvider {
+		t.Fatalf("provider label = %q, want %q", got.Label, codexOpenAIOverrideProvider)
+	}
+	if got.BaseURL != "https://idealab.alibaba-inc.com/api/openai/v1" {
+		t.Fatalf("base URL = %q, want idealab endpoint", got.BaseURL)
+	}
+	if got.EnvKey != credential.EnvOpenAIAPIKey {
+		t.Fatalf("env key = %q, want %q", got.EnvKey, credential.EnvOpenAIAPIKey)
+	}
+	if got.WireAPI != codexCustomWireAPI {
+		t.Fatalf("wire API = %q, want %q", got.WireAPI, codexCustomWireAPI)
+	}
+}
+
+// TestCodexRunProviderConfig_EmptyProviderEmptyBaseURL keeps the no-config
+// case explicit: when neither provider nor base URL is set, runProviderConfig
+// returns the zero value so codex falls back to its bundled defaults.
+func TestCodexRunProviderConfig_EmptyProviderEmptyBaseURL(t *testing.T) {
+	t.Parallel()
+
+	ag := NewCodexAgent(Config{ModelName: "gpt-5.2-1211-global"})
+
+	if got := ag.runProviderConfig(context.Background()); got.Name != "" || got.BaseURL != "" {
+		t.Fatalf("runProviderConfig() = %+v, want empty when both ModelProvider and BaseURL are unset", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

`runProviderConfig` previously emitted only `-c openai_base_url=\"...\"` when `ModelProvider == \"\"` even though `BaseURL` was set. codex silently ignores that flag and keeps talking to `api.openai.com` under the bundled provider with `wire_api=\"responses\"`, so any `/chat/completions`-only OpenAI-compat upstream (idealab, dashscope-compat, …) returns `400 Bad Request` from `codex_api::endpoint::responses`.

This left a leaky CLI abstraction: `--model idealab/<name>` worked (populates `ModelProvider` via `resolveEvalConfig`'s `provider/name` split), but the equivalent `engine.model.name: <name>` in `eval.yaml` plus an `OPENAI_BASE_URL` pointing at idealab did not — same intent, divergent runtime behavior depending solely on whether the caller happened to encode the provider in the model string.

This PR treats empty `ModelProvider` the same as `ModelProvider == \"openai\"`: when `BaseURL` is set, route through the synthetic `\"skill-up-openai\"` override so codex emits a self-contained
`model_providers.skill-up-openai.{base_url, env_key, wire_api=chat}` config block. The legacy single-flag fallback in `codexProviderFlags` becomes unreachable from `runProviderConfig` and is removed.

### Behavior change to call out

Any non-default `BaseURL` now lands on `wire_api=\"chat\"` regardless of provider naming. Previously `ModelProvider=\"\"` + `BaseURL=https://api.openai.com/v1` would have stayed on codex's default `wire_api=\"responses\"`. For genuine OpenAI endpoints `/chat/completions` is a stable, public-stable-API surface, so this is a behavior tightening rather than a regression — but worth flagging.

`effectiveModelName` already collapses `ModelProvider==\"\"` and `ModelProvider==\"openai\"` to the same branch (codex.go:264-266), so this PR brings `runProviderConfig` in line with that.

## Repro & verification

Triggered downstream of skill-up-component PipelineRun [42750873](https://code.alibaba-inc.com/aone-ci-component/skill-up/ci/jobs?pipelineId=189925&pipelineRunId=42750873&createType=yaml):

```
engine=codex, OPENAI_BASE_URL=https://idealab.alibaba-inc.com/api/openai/v1
eval.yaml: engine.name=codex, engine.model.name=gpt-5.2-1211-global  (no provider prefix)
→ skill-up run --engine codex   (no --model, no --provider)
→ codex_api::endpoint::responses error=http 400 Bad Request
```

After this PR, the empty-provider + non-empty-BaseURL path emits the same `-c model_providers.skill-up-openai.*` block previously reserved for `provider=\"openai\" + BaseURL`, so codex hits `/chat/completions` and idealab returns 200.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`, `gofmt -l`
- [x] New regression test `TestCodexRunProviderConfig_EmptyProviderWithBaseURLOverridesBuiltin` pins the post-fix behavior
- [x] New `TestCodexRunProviderConfig_EmptyProviderEmptyBaseURL` keeps the no-config fallthrough explicit
- [x] Existing `TestCodexRunProviderConfig_OpenAIWithBaseURLOverridesBuiltin` still passes (path unchanged, just merged with the empty-provider branch)
- [x] Removed `TestBuildCodexRunCmdWithBaseURL` — it asserted the buggy fallback that this PR removes; coverage is now via the agent-level regression test above