### PR TITLE
ci+meta: prevent PR #62-style lint slip-through (revive exit code + CLAUDE.md symlink)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/revive.toml
+++ b/revive.toml
@@ -1,8 +1,12 @@
 ignoreGeneratedHeader = false
 severity = "warning"
 confidence = 0.8
-errorCode = 0
-warningCode = 0
+# Non-zero exit codes make CI's `revive` step actually fail on violations.
+# With both at 0 (revive's defaults), warnings become GitHub inline
+# annotations but the Lint job stays green — issues silently pass review,
+# as happened on PR #62 with flag-parameter and context-as-argument hits.
+errorCode = 1
+warningCode = 1
 
 [rule.context-keys-type]
 [rule.time-equal]


### PR DESCRIPTION
Two complementary fixes for the root causes that let PR #62 ship 3 revive violations as inline annotations without anyone noticing.

## Why both in one PR

The slip-through had two contributing causes — fix only one and it can happen again:

| Cause | What lets it slip | Fix here |
|---|---|---|
| **revive exits 0 on violations** → `Lint` job stays green, GitHub only paints inline annotations | author + reviewers don't notice | `revive.toml`: `warningCode = 1` so violations actually fail the job |
| **`CLAUDE.md` not in repo root** → Claude Code (the author of #62) doesn't auto-load `AGENTS.md`, never sees the documented `make verify` / `make hooks` gates, runs ad-hoc `golangci-lint` instead | author runs the wrong local checks | `ln -s AGENTS.md CLAUDE.md` so Claude Code picks up the same conventions Qoder / Codex / Cursor already do |

Either one alone fixes the regression class; both together is belt + suspenders. Kept as two atomic commits so each can be reverted independently.

## Commits

- `94c651b ci: make revive violations actually fail the Lint job`
- `4c7e98e docs: symlink CLAUDE.md -> AGENTS.md so Claude Code auto-loads conventions`

## Verification

```
# revive change — main is clean
$ revive -config revive.toml ./...
$ echo $?
0

# revive change — injected violation now fails
$ revive -config revive.toml ./...   # ... flag-parameter violation ...
$ echo $?
1

# symlink — both names resolve to identical content
$ readlink CLAUDE.md
AGENTS.md
$ head -1 CLAUDE.md
# AGENTS.md

# full project gate passes
$ make verify
0 issues.
```

## Risk

- `warningCode = 1`: zero risk on current main — it's already clean. Future PRs with new revive violations will see the Lint job fail (intended).
- Symlink: zero risk to non-Claude tools (they still read AGENTS.md as before). On Windows, symlinks need Administrator / Developer Mode; if that's a blocker we can switch to a `CLAUDE.md` that contains `@AGENTS.md` (also officially supported), but symlink is simpler and the repo's pre-commit hook + Makefile already assume a Unix-like environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)