### PR TITLE
test: improve unit coverage

### DIFF
--- a/internal/agent/claude_code_test.go
+++ b/internal/agent/claude_code_test.go
@@ -297,6 +297,120 @@ func TestParseStreamOutput_JSONEventArray(t *testing.T) {
 	}
 }
 
+func TestParseStreamOutput_NDJSONWithTurnsAndTools(t *testing.T) {
+	t.Parallel()
+
+	output := strings.Join([]string{
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Prompt"}]}}`,
+		`{"type":"tool_call","tool_call":{"id":"tool-1","name":"read_file","input":{"path":"README.md"}}}`,
+		`{"type":"tool_result","tool_result":{"call_id":"tool-1","status":"success","content":"contents"}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Answer"}],"usage":{"input_tokens":3,"cache_read_input_tokens":2,"output_tokens":5}}}`,
+		`{"type":"result","result":"Final answer","usage":{"input_tokens":4,"cache_creation_input_tokens":1,"output_tokens":6}}`,
+		`not-json`,
+		`{}`,
+	}, "\n")
+
+	trans, finalMsg, inputTokens, outputTokens := parseStreamOutput(output)
+	assertClaudeStreamParseResult(t, trans, finalMsg, inputTokens, outputTokens)
+}
+
+func assertClaudeStreamParseResult(t *testing.T, trans transcript.Transcript, finalMsg string, inputTokens, outputTokens int) {
+	t.Helper()
+	if finalMsg != "Final answer" {
+		t.Fatalf("finalMsg = %q, want Final answer", finalMsg)
+	}
+	if inputTokens != 5 || outputTokens != 6 {
+		t.Fatalf("tokens = %d/%d, want 5/6", inputTokens, outputTokens)
+	}
+	if len(trans) != 4 {
+		t.Fatalf("transcript length = %d, want 4: %#v", len(trans), trans)
+	}
+	assertClaudeStreamUserMessage(t, trans[0])
+	assertClaudeStreamToolCall(t, trans[1])
+	assertClaudeStreamToolResult(t, trans[2])
+	assertClaudeStreamAssistantMessage(t, trans[3])
+}
+
+func assertClaudeStreamUserMessage(t *testing.T, msg transcript.Message) {
+	t.Helper()
+	if msg.Role != transcript.RoleUser || msg.Content != "Prompt" || msg.Turn != 1 {
+		t.Fatalf("user message = %#v", msg)
+	}
+}
+
+func assertClaudeStreamToolCall(t *testing.T, msg transcript.Message) {
+	t.Helper()
+	if msg.ToolCall == nil || msg.ToolCall.Name != "read_file" || msg.Turn != 1 {
+		t.Fatalf("tool call = %#v", msg)
+	}
+}
+
+func assertClaudeStreamToolResult(t *testing.T, msg transcript.Message) {
+	t.Helper()
+	if msg.ToolResult == nil || msg.ToolResult.CallID != "tool-1" || msg.Turn != 1 {
+		t.Fatalf("tool result = %#v", msg)
+	}
+}
+
+func assertClaudeStreamAssistantMessage(t *testing.T, msg transcript.Message) {
+	t.Helper()
+	if msg.Role != transcript.RoleAssistant || msg.Content != "Answer" {
+		t.Fatalf("assistant message = %#v", msg)
+	}
+}
+
+func TestStreamEventNilPayloadsStillMaintainTurnState(t *testing.T) {
+	t.Parallel()
+
+	var state streamParseState
+	applyStreamUserEvent(&state, &streamEvent{})
+	if state.currentTurn != 1 || len(state.messages) != 0 {
+		t.Fatalf("nil user event state = %+v, want turn advanced without message", state)
+	}
+	applyStreamToolCallEvent(&state, &streamEvent{})
+	applyStreamToolResultEvent(&state, &streamEvent{})
+	applyStreamAssistantEvent(&state, &streamEvent{})
+	applyStreamResultEvent(&state, &streamEvent{Usage: &streamUsage{OutputTokens: 2}})
+	if len(state.messages) != 0 {
+		t.Fatalf("nil payload events appended messages: %#v", state.messages)
+	}
+	if state.totalOutputTokens != 2 {
+		t.Fatalf("result usage output tokens = %d, want 2", state.totalOutputTokens)
+	}
+}
+
+func TestClaudeInputContentJSONAndContentBlockToString(t *testing.T) {
+	t.Parallel()
+
+	data, err := claudeInputContentJSON("hello")
+	if err != nil {
+		t.Fatalf("claudeInputContentJSON string error: %v", err)
+	}
+	if !strings.Contains(string(data), `"text":"hello"`) {
+		t.Fatalf("string content JSON = %s", data)
+	}
+	data, err = claudeInputContentJSON([]map[string]string{{"type": "text", "text": "custom"}})
+	if err != nil {
+		t.Fatalf("claudeInputContentJSON custom error: %v", err)
+	}
+	if !strings.Contains(string(data), `"custom"`) {
+		t.Fatalf("custom content JSON = %s", data)
+	}
+
+	if got := contentBlockToString(nil); got != "" {
+		t.Fatalf("contentBlockToString(nil) = %q, want empty", got)
+	}
+	if got := contentBlockToString("plain"); got != "plain" {
+		t.Fatalf("contentBlockToString(string) = %q, want plain", got)
+	}
+	if got := contentBlockToString(map[string]string{"b": "2", "a": "1"}); got != `{"a":"1","b":"2"}` {
+		t.Fatalf("contentBlockToString(map) = %q", got)
+	}
+	if got := contentBlockToString(func() {}); got == "" {
+		t.Fatalf("contentBlockToString(unmarshalable) = %q, want fmt fallback", got)
+	}
+}
+
 func TestProviderAuthFailureSignal(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/mcp_test.go
+++ b/internal/agent/mcp_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -173,5 +175,74 @@ func TestBuildCodexMCPInstallCmd_RejectsInvalidHeaderEnvName(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "BAD-NAME") {
 		t.Fatalf("expected invalid env name in error, got %v", err)
+	}
+}
+
+func TestInstallMCPServersExecutesInstallCommandsWithServerEnv(t *testing.T) {
+	t.Parallel()
+
+	rt := &qoderTestRuntime{}
+	err := installMCPServers(context.Background(), rt, runtime.MCPConfig{
+		Servers: []runtime.MCPServerConfig{{
+			Name: "marker",
+			Env:  map[string]string{"MCP_TOKEN": "secret"},
+		}},
+	}, func(server runtime.MCPServerConfig) (string, error) {
+		if server.Name != "marker" {
+			t.Fatalf("server = %+v", server)
+		}
+		return "qodercli -p mcp-add-marker", nil
+	})
+	if err != nil {
+		t.Fatalf("installMCPServers returned error: %v", err)
+	}
+	if rt.lastCommand != "qodercli -p mcp-add-marker" {
+		t.Fatalf("last command = %q", rt.lastCommand)
+	}
+	if rt.lastExecEnv["MCP_TOKEN"] != "secret" {
+		t.Fatalf("exec env = %#v, want MCP_TOKEN", rt.lastExecEnv)
+	}
+}
+
+func TestInstallMCPServersReportsBuilderAndExitErrors(t *testing.T) {
+	t.Parallel()
+
+	err := installMCPServers(context.Background(), &qoderTestRuntime{}, runtime.MCPConfig{
+		Servers: []runtime.MCPServerConfig{{Name: "bad"}},
+	}, func(runtime.MCPServerConfig) (string, error) {
+		return "", errors.New("boom")
+	})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("builder error = %v, want boom", err)
+	}
+
+	rt := &qoderTestRuntime{execResult: runtime.ExecResult{ExitCode: 2, Stderr: "install failed"}}
+	err = installMCPServers(context.Background(), rt, runtime.MCPConfig{
+		Servers: []runtime.MCPServerConfig{{Name: "bad"}},
+	}, func(runtime.MCPServerConfig) (string, error) {
+		return "qodercli mcp add bad", nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "install failed") {
+		t.Fatalf("exit error = %v, want stderr", err)
+	}
+}
+
+func TestMCPCommandValidationHelpers(t *testing.T) {
+	t.Parallel()
+
+	if _, err := shellEnvAssignment("BAD-NAME"); err == nil {
+		t.Fatal("shellEnvAssignment accepted invalid name")
+	}
+	if got, err := shellExpandedValue("https://${HOST}/mcp/${TOKEN}"); err != nil || !strings.Contains(got, `"${HOST}"`) || !strings.Contains(got, `"${TOKEN}"`) {
+		t.Fatalf("shellExpandedValue interpolation = %q, %v", got, err)
+	}
+	if got, err := shellExpandedValue("$TOKEN"); err != nil || got != `"${TOKEN}"` {
+		t.Fatalf("shellExpandedValue whole ref = %q, %v", got, err)
+	}
+	if _, err := shellExpandedValue("$TOKEN-suffix"); err == nil {
+		t.Fatal("shellExpandedValue accepted invalid bare ref")
+	}
+	if name, ok := wholeShellEnvRef("${TOKEN}"); !ok || name != "TOKEN" {
+		t.Fatalf("wholeShellEnvRef = %q/%v, want TOKEN true", name, ok)
 	}
 }

--- a/internal/cli/command_integration_test.go
+++ b/internal/cli/command_integration_test.go
@@ -28,6 +28,16 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 		done <- copyErr
 	}()
 
+	cleaned := false
+	defer func() {
+		if cleaned {
+			return
+		}
+		_ = w.Close()
+		os.Stdout = orig
+		_ = r.Close()
+	}()
+
 	runErr := fn()
 	_ = w.Close()
 	os.Stdout = orig
@@ -35,6 +45,7 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 		t.Fatalf("copy stdout: %v", copyErr)
 	}
 	_ = r.Close()
+	cleaned = true
 
 	return buf.String(), runErr
 }

--- a/internal/cli/command_integration_test.go
+++ b/internal/cli/command_integration_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = w
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(&buf, r)
+		done <- copyErr
+	}()
+
+	runErr := fn()
+	_ = w.Close()
+	os.Stdout = orig
+	if copyErr := <-done; copyErr != nil {
+		t.Fatalf("copy stdout: %v", copyErr)
+	}
+	_ = r.Close()
+
+	return buf.String(), runErr
+}
+
+func TestValidateCommandRunEReportsLoadedCases(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	output, err := captureStdout(t, func() error {
+		return validateCmd.RunE(cmd, []string{testEvalPath})
+	})
+	if err != nil {
+		t.Fatalf("validate RunE returned error: %v", err)
+	}
+	if !strings.Contains(output, "eval.yaml is valid") || !strings.Contains(output, "loaded 3 case(s)") {
+		t.Fatalf("validate output = %q, want success with case count", output)
+	}
+}
+
+func TestValidateCommandRunEWrapsLoadErrors(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	_, err := captureStdout(t, func() error {
+		return validateCmd.RunE(cmd, []string{"/does/not/exist/eval.yaml"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed to load config") {
+		t.Fatalf("validate error = %v, want failed to load config", err)
+	}
+}
+
+func TestListCasesCommandRunEPrintsDefaultsAndTruncatesPrompt(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	output, err := captureStdout(t, func() error {
+		return listCasesCmd.RunE(cmd, []string{testEvalPath})
+	})
+	if err != nil {
+		t.Fatalf("list-cases RunE returned error: %v", err)
+	}
+	for _, want := range []string{
+		"ID",
+		"Title",
+		"Tag",
+		"analyze-directory",
+		"functional_test",
+		"Analyze the current directory using the code-st...",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("list-cases output missing %q:\n%s", want, output)
+		}
+	}
+}

--- a/internal/cli/import_test.go
+++ b/internal/cli/import_test.go
@@ -99,7 +99,7 @@ func TestGenerateEvalConfig(t *testing.T) {
 		t.Errorf("expected Skill Path '.', got '%s'", result.Skills[0].Path)
 	}
 
-	if result.Engine.Name != "claude_code" {
+	if result.Engine.Name != testEngineClaudeCode {
 		t.Errorf("expected Engine.Name 'claude_code', got '%s'", result.Engine.Name)
 	}
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -32,6 +32,21 @@ func TestUsageOnError_PrintsUsageForParseErrors(t *testing.T) {
 	}
 }
 
+func TestExecuteArgsVersionInitializesRoot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	output, err := captureStdout(t, func() error {
+		return ExecuteArgs("test-version", []string{"--version"})
+	})
+	if err != nil {
+		t.Fatalf("ExecuteArgs --version returned error: %v", err)
+	}
+	if !strings.Contains(output, "test-version") {
+		t.Fatalf("version output = %q, want test-version", output)
+	}
+}
+
 func TestIsInitInvocation(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,12 +17,16 @@ import (
 	"github.com/alibaba/skill-up/internal/credential"
 	"github.com/alibaba/skill-up/internal/evaluator"
 	"github.com/alibaba/skill-up/internal/judge"
+	"github.com/alibaba/skill-up/internal/ui"
 	"github.com/alibaba/skill-up/internal/userconfig"
 )
 
-const agentJudgeType = "agent_judge"
-
-const testRuntimeOpenSandbox = "opensandbox"
+const (
+	agentJudgeType         = "agent_judge"
+	testEngineClaudeCode   = "claude_code"
+	testRuntimeOpenSandbox = "opensandbox"
+	testFlagBoolTrue       = "true"
+)
 
 // Test fixtures for the provider/model split disambiguation suite.
 const (
@@ -35,6 +40,168 @@ func TestRunCommand_UsesUsageAwareArgs(t *testing.T) {
 
 	if runCmd.Args == nil {
 		t.Fatal("expected run command args validator to be configured")
+	}
+}
+
+func newRunPhaseTestCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "run"}
+	cmd.SetContext(userconfig.WithContext(context.Background(), userconfig.Config{}, nil))
+	cmd.Flags().StringArray("include-case-name", nil, "")
+	cmd.Flags().StringArray("exclude-case-name", nil, "")
+	cmd.Flags().Bool("auto", false, "")
+	cmd.Flags().StringArray("format", nil, "")
+	cmd.Flags().String("output-dir", "", "")
+	cmd.Flags().String("engine", "", "")
+	cmd.Flags().String(runtimeFlagName, "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("api-key", "", "")
+	cmd.Flags().Int("parallelism", 0, "")
+	cmd.Flags().SetNormalizeFunc(normalizeRunFlagName)
+	cmd.Flags().StringArray(runtimeKwargFlagName, nil, "")
+	var verbose verbosityValue
+	cmd.Flags().VarP(&verbose, "verbose", "v", "")
+	cmd.Flags().Lookup("verbose").NoOptDefVal = testFlagBoolTrue
+	cmd.Flags().Int("iteration", 0, "")
+	cmd.Flags().Bool("no-delete", false, "")
+	cmd.Flags().Bool("dry-run", false, "")
+	return cmd
+}
+
+func TestRunEvalDryRunLoadsFiltersAndSkipsAgentSetup(t *testing.T) {
+	cmd := newRunPhaseTestCommand(t)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Flags().Set("dry-run", testFlagBoolTrue); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("include-case-name", "analyze-*"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("engine", "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("model", "openai/gpt-5"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("parallelism", "1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set(runtimeFlagName, "none"); err != nil {
+		t.Fatal(err)
+	}
+
+	var uiOut bytes.Buffer
+	origUIOutput := ui.Output
+	ui.Output = &uiOut
+	t.Cleanup(func() { ui.Output = origUIOutput })
+
+	stdout, err := captureStdout(t, func() error {
+		return runEval(cmd, []string{testEvalPath})
+	})
+	if err != nil {
+		t.Fatalf("runEval dry-run returned error: %v", err)
+	}
+	if !strings.Contains(uiOut.String(), "Loaded 1 case(s) | engine: codex | model: openai/gpt-5") {
+		t.Fatalf("UI output = %q, want loaded dry-run summary", uiOut.String())
+	}
+	if !strings.Contains(stdout, "Would run 1 case(s) with agent codex") ||
+		!strings.Contains(stdout, "  - analyze-directory") {
+		t.Fatalf("stdout = %q, want dry-run case list", stdout)
+	}
+}
+
+func TestRunPhaseHelpers(t *testing.T) {
+	var out bytes.Buffer
+	observer := &uiProgressObserver{}
+	origUIOutput := ui.Output
+	ui.Output = &out
+	t.Cleanup(func() { ui.Output = origUIOutput })
+
+	observer.OnCaseStart(1, 2, "case-a", "Case A")
+	observer.OnCaseComplete(1, 2, "case-a", judge.StatusPass, 1)
+	if got := out.String(); !strings.Contains(got, "case-a: Case A") || !strings.Contains(got, "PASS (100.0%)") {
+		t.Fatalf("observer output = %q", got)
+	}
+
+	results := []evaluator.EvalResult{
+		{Status: judge.StatusPass},
+		{Status: judge.StatusFail},
+		{Status: judge.StatusError},
+		{Status: judge.StatusSkip},
+	}
+	passed, failed, errored := countResultStatus(results)
+	if passed != 1 || failed != 1 || errored != 1 {
+		t.Fatalf("countResultStatus = %d/%d/%d, want 1/1/1", passed, failed, errored)
+	}
+
+	if got := formatModelRef("openai", "gpt-5"); got != "openai/gpt-5" {
+		t.Fatalf("formatModelRef provider/name = %q", got)
+	}
+	if got := formatModelRef("", "gpt-5"); got != "gpt-5" {
+		t.Fatalf("formatModelRef name = %q", got)
+	}
+	if got := formatModelRef("openai", ""); got != "openai" {
+		t.Fatalf("formatModelRef provider = %q", got)
+	}
+	if got := formatModelRef("", ""); got != "<unset>" {
+		t.Fatalf("formatModelRef empty = %q", got)
+	}
+
+	var verbose verbosityValue
+	if verbose.Type() != "verbosity" {
+		t.Fatalf("verbosity Type() = %q, want verbosity", verbose.Type())
+	}
+}
+
+func TestLoadCredentialsAndAgentAppliesCLIModelAndAPIKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cmd := newRunPhaseTestCommand(t)
+	if err := cmd.Flags().Set("model", "openai/gpt-5"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("api-key", "sk-test"); err != nil {
+		t.Fatal(err)
+	}
+	evalCfg := &config.EvalConfig{Engine: config.EngineConfig{Name: "codex"}}
+	ag, resolver, params, err := loadCredentialsAndAgent(cmd, evalCfg)
+	if err != nil {
+		t.Fatalf("loadCredentialsAndAgent returned error: %v", err)
+	}
+	if ag == nil || resolver == nil {
+		t.Fatalf("agent/resolver = %v/%v, want non-nil", ag, resolver)
+	}
+	if params.Model != "gpt-5" || params.Provider != "" || params.APIKey != "sk-test" {
+		t.Fatalf("runner params = %+v, want literal gpt-5 with cli API key", params)
+	}
+}
+
+func TestLoadUserConfigHonorsInitAndExplicitFailures(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	badPath := filepath.Join(t.TempDir(), "bad.yaml")
+	if err := os.WriteFile(badPath, []byte("telemetry: : :\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := loadUserConfig([]string{"--config", badPath, "run"})
+	if err == nil {
+		t.Fatal("loadUserConfig for run with corrupt explicit config returned nil error")
+	}
+
+	cfg, sources, err := loadUserConfig([]string{"--config", badPath, "init"})
+	if err != nil {
+		t.Fatalf("loadUserConfig for init should ignore explicit load path, got %v", err)
+	}
+	if cfg.Kind != "" {
+		t.Fatalf("config = %+v, want empty", cfg)
+	}
+	for _, source := range sources {
+		if source.Kind == "explicit" {
+			t.Fatalf("init load should not include explicit source: %+v", sources)
+		}
 	}
 }
 
@@ -61,7 +228,7 @@ func TestGetVerbosity(t *testing.T) {
 			cmd := &cobra.Command{Use: "test"}
 			var verbose verbosityValue
 			cmd.Flags().VarP(&verbose, "verbose", "v", "")
-			cmd.Flags().Lookup("verbose").NoOptDefVal = "true"
+			cmd.Flags().Lookup("verbose").NoOptDefVal = testFlagBoolTrue
 
 			if err := cmd.Flags().Parse(tt.args); err != nil {
 				t.Fatalf("parse flags: %v", err)
@@ -355,6 +522,57 @@ func TestLoadAutoModeEvaluation_FallsBackToEvalsJSON(t *testing.T) {
 	}
 }
 
+func TestLoadManualModeEvaluationAcceptsSkillRootOrEvalFile(t *testing.T) {
+	root := t.TempDir()
+	writeAutoModeSkill(t, root)
+	writeAutoModeEvalYAML(t, root, "manual-case")
+	evalPath := filepath.Join(root, "evals", "eval.yaml")
+
+	gotPath, cases, evalCfg, loader, err := loadManualModeEvaluation(t.Context(), root)
+	if err != nil {
+		t.Fatalf("loadManualModeEvaluation(root) returned error: %v", err)
+	}
+	if gotPath != evalPath || len(cases) != 1 || cases[0].ID != "manual-case" {
+		t.Fatalf("root load path/cases = %q/%#v, want manual-case", gotPath, cases)
+	}
+	if evalCfg.Engine.Name != testEngineClaudeCode || loader.SkillDir() != root {
+		t.Fatalf("root eval/loader = %+v/%s", evalCfg.Engine, loader.SkillDir())
+	}
+
+	gotPath, cases, _, _, err = loadManualModeEvaluation(t.Context(), evalPath)
+	if err != nil {
+		t.Fatalf("loadManualModeEvaluation(file) returned error: %v", err)
+	}
+	if gotPath != evalPath || len(cases) != 1 {
+		t.Fatalf("file load path/cases = %q/%d", gotPath, len(cases))
+	}
+
+	if _, _, _, _, err := loadManualModeEvaluation(t.Context(), filepath.Join(root, "missing")); err == nil {
+		t.Fatal("expected error for missing eval.yaml")
+	}
+}
+
+func TestLoadRunInputsManualMode(t *testing.T) {
+	root := t.TempDir()
+	writeAutoModeSkill(t, root)
+	writeAutoModeEvalYAML(t, root, "manual-input")
+
+	cmd := newRunPhaseTestCommand(t)
+	cases, evalCfg, loader, err := loadRunInputs(t.Context(), cmd, []string{root})
+	if err != nil {
+		t.Fatalf("loadRunInputs manual returned error: %v", err)
+	}
+	if len(cases) != 1 || cases[0].ID != "manual-input" {
+		t.Fatalf("cases = %#v, want manual-input", cases)
+	}
+	if evalCfg.Engine.Name != testEngineClaudeCode {
+		t.Fatalf("engine = %q, want claude_code", evalCfg.Engine.Name)
+	}
+	if loader.SkillDir() != root {
+		t.Fatalf("loader.SkillDir() = %q, want %q", loader.SkillDir(), root)
+	}
+}
+
 func writeAutoModeSkill(t *testing.T, root string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(root, "SKILL.md"), []byte("# test skill\n"), 0o600); err != nil {
@@ -547,6 +765,54 @@ func TestNormalizeAutoEvalRoot(t *testing.T) {
 	_, err = normalizeAutoEvalRoot(looseFile)
 	if err == nil {
 		t.Fatal("expected error for file outside evals directory")
+	}
+}
+
+func TestResolveAutoEvalRootUsesExplicitPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	got, err := resolveAutoEvalRoot(t.Context(), []string{root})
+	if err != nil {
+		t.Fatalf("resolveAutoEvalRoot returned error: %v", err)
+	}
+	if got != root {
+		t.Fatalf("resolveAutoEvalRoot = %q, want %q", got, root)
+	}
+
+	if _, err := resolveAutoEvalRoot(t.Context(), []string{filepath.Join(root, "missing")}); err == nil {
+		t.Fatal("expected error for missing explicit auto root")
+	}
+}
+
+func TestResolveAutoEvalRootDiscoversFromWorkingTree(t *testing.T) {
+	root := t.TempDir()
+	writeAutoModeSkill(t, root)
+	writeAutoModeEvalsJSON(t, root)
+	deep := filepath.Join(root, "nested", "deep")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(deep)
+
+	got, err := resolveAutoEvalRoot(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("resolveAutoEvalRoot discovery returned error: %v", err)
+	}
+	if got != root {
+		t.Fatalf("resolveAutoEvalRoot discovery = %q, want %q", got, root)
+	}
+}
+
+func TestResolveEvalPathUsesExplicitArg(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveEvalPath(t.Context(), []string{testEvalPath})
+	if err != nil {
+		t.Fatalf("resolveEvalPath returned error: %v", err)
+	}
+	if got != testEvalPath {
+		t.Fatalf("resolveEvalPath = %q, want %q", got, testEvalPath)
 	}
 }
 
@@ -827,7 +1093,7 @@ func TestEvaluateOptionsFromFlags(t *testing.T) {
 	cmd.Flags().Int("iteration", 1, "")
 	cmd.Flags().StringArray("format", nil, "")
 
-	if err := cmd.Flags().Set("no-delete", "true"); err != nil {
+	if err := cmd.Flags().Set("no-delete", testFlagBoolTrue); err != nil {
 		t.Fatalf("set no-delete: %v", err)
 	}
 	if err := cmd.Flags().Set("output-dir", "/tmp/custom-output"); err != nil {
@@ -904,7 +1170,7 @@ func TestResolveEvalConfig_AllowsRawModelOverrideForAnyEngine(t *testing.T) {
 
 func TestResolveEvalConfig_ParsesProviderQualifiedModel(t *testing.T) {
 	t.Parallel()
-	runResolveEvalConfigCase(t, "anthropic/auto", "claude_code", "anthropic", "auto")
+	runResolveEvalConfigCase(t, "anthropic/auto", testEngineClaudeCode, "anthropic", "auto")
 }
 
 func TestApplyRunConfigOverrides_Parallelism(t *testing.T) {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -43,6 +43,21 @@ cases:
 	}
 }
 
+func TestStripExt(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"case.yaml":        "case",
+		"case.with.dots":   "case.with",
+		"case-without-ext": "case-without-ext",
+	}
+	for input, want := range tests {
+		if got := stripExt(input); got != want {
+			t.Fatalf("stripExt(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
 func TestLoader_LoadEvalConfig(t *testing.T) {
 	t.Parallel()
 	content := `schema_version: v1alpha1

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -477,6 +477,8 @@ func TestSerializeTranscriptWritesJSONAndCleanupRemovesFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("serializeTranscript returned error: %v", err)
 	}
+	t.Cleanup(cleanup)
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read transcript: %v", err)

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -39,8 +39,11 @@ type mockAgent struct {
 	runCall      atomic.Int32
 	credCall     atomic.Int32
 	installCall  atomic.Int32
+	mcpCall      atomic.Int32
+	skillCall    atomic.Int32
 	mu           sync.Mutex
 	lastMessages []transcript.Message
+	lastSkill    runtime.SkillConfig
 }
 
 func (m *mockAgent) Name() string { return m.name }
@@ -50,10 +53,15 @@ func (m *mockAgent) Install(_ context.Context, _ runtime.Runtime) error {
 }
 
 func (m *mockAgent) InstallMCP(_ context.Context, _ runtime.Runtime, _ runtime.MCPConfig) error {
+	m.mcpCall.Add(1)
 	return nil
 }
 
-func (m *mockAgent) InstallSkill(_ context.Context, _ runtime.Runtime, _ runtime.SkillConfig) error {
+func (m *mockAgent) InstallSkill(_ context.Context, _ runtime.Runtime, cfg runtime.SkillConfig) error {
+	m.skillCall.Add(1)
+	m.mu.Lock()
+	m.lastSkill = cfg
+	m.mu.Unlock()
 	return nil
 }
 func (m *mockAgent) Check(_ context.Context, _ runtime.Runtime) error { return nil }
@@ -233,6 +241,299 @@ func TestProvisionMCPConfigCachesResolvedConfig(t *testing.T) {
 	}
 	if got := secondEnv["MCP_TOKEN"]; got != "first-token" {
 		t.Fatalf("cached env = %q", got)
+	}
+}
+
+func TestEvaluatorInputHelpers(t *testing.T) {
+	t.Parallel()
+
+	promptCfg := &config.CaseConfig{Input: config.Input{Prompt: "single prompt"}}
+	prompt, turns := casePromptAndTurnsTotal(promptCfg)
+	if prompt != "single prompt" || turns != 1 {
+		t.Fatalf("prompt case = %q/%d, want single prompt/1", prompt, turns)
+	}
+	if messages := buildCaseMessages(promptCfg); len(messages) != 1 || messages[0].Role != transcript.RoleUser || messages[0].Turn != 1 {
+		t.Fatalf("prompt messages = %#v, want one user message", messages)
+	}
+
+	turnCfg := &config.CaseConfig{Input: config.Input{Turns: []config.Turn{
+		{Role: "user", Content: "first"},
+		{Role: "assistant", Content: "second"},
+		{Content: "third defaults to user"},
+	}}}
+	prompt, turns = casePromptAndTurnsTotal(turnCfg)
+	if prompt != "first" || turns != 3 {
+		t.Fatalf("turn case = %q/%d, want first/3", prompt, turns)
+	}
+	messages := buildCaseMessages(turnCfg)
+	if len(messages) != 3 || messages[1].Role != transcript.RoleAssistant || messages[2].Role != transcript.RoleUser || messages[2].Turn != 3 {
+		t.Fatalf("turn messages = %#v, want preserved roles and turn numbers", messages)
+	}
+}
+
+func TestEvaluatorRetryAndRecoveryHelpers(t *testing.T) {
+	t.Parallel()
+
+	policy := config.RetryPolicy{MaxRetries: 2, RetryOn: []string{"timeout"}}
+	if !retryAllowed(policy, "TIMEOUT") {
+		t.Fatal("retryAllowed should match retry reasons case-insensitively")
+	}
+	if retryAllowed(policy, "error") {
+		t.Fatal("retryAllowed unexpectedly allowed unconfigured error reason")
+	}
+	if retryBackoffDelay(0) != 2*time.Second || retryBackoffDelay(2) != 4*time.Second {
+		t.Fatalf("retryBackoffDelay produced unexpected values")
+	}
+
+	result := EvalResult{Status: judge.StatusError, Error: context.DeadlineExceeded}
+	if reason, ok := retryReasonForResult(result); !ok || reason != "timeout" {
+		t.Fatalf("retryReasonForResult(timeout) = %q/%v, want timeout true", reason, ok)
+	}
+	result.Error = errors.New("boom")
+	if reason, ok := retryReasonForResult(result); !ok || reason != "error" {
+		t.Fatalf("retryReasonForResult(error) = %q/%v, want error true", reason, ok)
+	}
+	result.Status = judge.StatusFail
+	if _, ok := retryReasonForResult(result); ok {
+		t.Fatal("retryReasonForResult should ignore non-error statuses")
+	}
+
+	timeoutResult := &EvalResult{Error: fmt.Errorf("agent failed: %w", context.DeadlineExceeded)}
+	annotateCaseTimeoutError(timeoutResult, "cases.defaults.timeout_seconds", 30)
+	if !strings.Contains(timeoutResult.Error.Error(), "case timeout 30s via cases.defaults.timeout_seconds") {
+		t.Fatalf("annotated timeout error = %v", timeoutResult.Error)
+	}
+	if !errors.Is(timeoutResult.Error, context.DeadlineExceeded) {
+		t.Fatalf("annotation lost DeadlineExceeded in error chain: %v", timeoutResult.Error)
+	}
+
+	nonTimeoutResult := &EvalResult{Error: errors.New("boom")}
+	annotateCaseTimeoutError(nonTimeoutResult, "cases.defaults.timeout_seconds", 30)
+	if nonTimeoutResult.Error.Error() != "boom" {
+		t.Fatalf("non-timeout error was annotated: %v", nonTimeoutResult.Error)
+	}
+}
+
+func TestEvaluatorSessionHelpers(t *testing.T) {
+	t.Parallel()
+
+	original := &agent.SessionResult{
+		FinalMessage: "stale",
+		Transcript: transcript.Transcript{
+			{Role: transcript.RoleAssistant, Content: "fresh"},
+			{Role: transcript.RoleToolCall, Content: "tool"},
+		},
+		Artifacts: &agent.SessionArtifacts{
+			WorkspaceDiff:  "diff",
+			GeneratedFiles: []string{"a.txt"},
+		},
+	}
+	normalized := normalizeSessionResult(original)
+	if normalized.FinalMessage != "fresh" {
+		t.Fatalf("normalized FinalMessage = %q, want fresh", normalized.FinalMessage)
+	}
+	if original.FinalMessage != "stale" {
+		t.Fatalf("normalizeSessionResult mutated original final message to %q", original.FinalMessage)
+	}
+	if sessionTranscript(original).FinalAssistantMessage() != "fresh" {
+		t.Fatal("sessionTranscript did not return transcript")
+	}
+	if sessionWorkspaceDiff(original) != "diff" {
+		t.Fatal("sessionWorkspaceDiff did not return diff")
+	}
+	if got := sessionGeneratedFiles(original); len(got) != 1 || got[0] != "a.txt" {
+		t.Fatalf("sessionGeneratedFiles = %#v, want a.txt", got)
+	}
+	if normalizeSessionResult(nil) == nil {
+		t.Fatal("normalizeSessionResult(nil) returned nil")
+	}
+	if sessionTranscript(nil) != nil || sessionWorkspaceDiff(nil) != "" || sessionGeneratedFiles(nil) != nil {
+		t.Fatal("nil session helpers should return empty values")
+	}
+}
+
+func TestEvaluatorConfigHelpers(t *testing.T) {
+	t.Parallel()
+
+	e := newTestEvaluator(EvalOptions{})
+	if e.judgeScriptBaseDir() != "" {
+		t.Fatalf("judgeScriptBaseDir without loader = %q, want empty", e.judgeScriptBaseDir())
+	}
+
+	skillDir := t.TempDir()
+	rel := resolveJudgeScriptPath(skillDir, config.JudgeConfig{Type: "script", ScriptPath: "checks/pass.sh"})
+	want := filepath.Join(skillDir, "checks", "pass.sh")
+	if rel.ScriptPath != want {
+		t.Fatalf("resolveJudgeScriptPath relative = %q, want %q", rel.ScriptPath, want)
+	}
+	abs := resolveJudgeScriptPath(skillDir, config.JudgeConfig{Type: "script", ScriptPath: want})
+	if abs.ScriptPath != want {
+		t.Fatalf("resolveJudgeScriptPath absolute = %q, want unchanged", abs.ScriptPath)
+	}
+	unchanged := resolveJudgeScriptPath(skillDir, config.JudgeConfig{Type: "rule_based", ScriptPath: "checks/pass.sh"})
+	if unchanged.ScriptPath != "checks/pass.sh" {
+		t.Fatalf("non-script path changed to %q", unchanged.ScriptPath)
+	}
+
+	if resolveExpectConfig(&config.Expect{}) != nil {
+		t.Fatal("empty expect config should resolve to nil")
+	}
+	exitCode := 0
+	if resolveExpectConfig(&config.Expect{ExitCode: &exitCode}) == nil {
+		t.Fatal("expect config with exit_code should be active")
+	}
+	if judgeLabel(config.JudgeConfig{}) != "no_judge" || judgeLabel(config.JudgeConfig{Type: "rule_based"}) != "rule_based" {
+		t.Fatal("judgeLabel returned unexpected values")
+	}
+}
+
+func TestSetupCaseEnvironmentRunsSetupAndInstallsAgentMCPAndSkill(t *testing.T) {
+	skillDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Skill\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	evalsDir := filepath.Join(skillDir, "evals")
+	if err := os.MkdirAll(evalsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	evalPath := filepath.Join(evalsDir, "eval.yaml")
+	if err := os.WriteFile(evalPath, []byte("schema_version: v1alpha1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := &mockRuntime{workspace: t.TempDir()}
+	ag := &mockAgent{name: "agent"}
+	e := newTestEvaluator(EvalOptions{
+		SkillDir: skillDir,
+		Loader:   config.NewLoader(evalPath),
+		EvalCfg: &config.EvalConfig{
+			Environment: config.Environment{
+				Type:       "opensandbox",
+				SetupSteps: []config.SetupStep{{Run: "printf setup > marker.txt"}},
+			},
+			Skills: []config.SkillRef{{Path: ".", Target: "custom-target"}},
+		},
+	})
+
+	err := e.setupCaseEnvironment(context.Background(), rt, &config.CaseConfig{ID: "case-a"}, "with_skill", ag, runtime.MCPConfig{})
+	if err != nil {
+		t.Fatalf("setupCaseEnvironment returned error: %v", err)
+	}
+	if rt.execCall.Load() != 1 {
+		t.Fatalf("setup exec calls = %d, want 1", rt.execCall.Load())
+	}
+	if ag.installCall.Load() != 1 || ag.mcpCall.Load() != 1 || ag.skillCall.Load() != 1 {
+		t.Fatalf("agent install calls install/mcp/skill = %d/%d/%d, want 1/1/1", ag.installCall.Load(), ag.mcpCall.Load(), ag.skillCall.Load())
+	}
+	ag.mu.Lock()
+	lastSkill := ag.lastSkill
+	ag.mu.Unlock()
+	if lastSkill.Source != skillDir || lastSkill.Target != "custom-target" {
+		t.Fatalf("last skill config = %+v, want source skill dir and custom target", lastSkill)
+	}
+
+	withoutSkillAgent := &mockAgent{name: "agent"}
+	if err := e.setupCaseEnvironment(context.Background(), rt, &config.CaseConfig{ID: "case-a"}, "without_skill", withoutSkillAgent, runtime.MCPConfig{}); err != nil {
+		t.Fatalf("setup without_skill returned error: %v", err)
+	}
+	if withoutSkillAgent.skillCall.Load() != 0 {
+		t.Fatalf("without_skill installed skill %d time(s), want 0", withoutSkillAgent.skillCall.Load())
+	}
+}
+
+func TestSetupCaseEnvironmentReportsSetupFailures(t *testing.T) {
+	t.Parallel()
+
+	e := newTestEvaluator(EvalOptions{EvalCfg: &config.EvalConfig{
+		Environment: config.Environment{SetupSteps: []config.SetupStep{{Run: "exit 2"}}},
+	}})
+	rt := &mockRuntime{
+		workspace: t.TempDir(),
+		execFunc: func(context.Context, string, runtime.ExecOptions) (runtime.ExecResult, error) {
+			return runtime.ExecResult{ExitCode: 2, Stderr: "bad setup"}, nil
+		},
+	}
+	err := e.setupCaseEnvironment(context.Background(), rt, &config.CaseConfig{ID: "case-a"}, "with_skill", &mockAgent{name: "agent"}, runtime.MCPConfig{})
+	if err == nil || !strings.Contains(err.Error(), "bad setup") {
+		t.Fatalf("setup error = %v, want stderr", err)
+	}
+
+	rt.execFunc = func(context.Context, string, runtime.ExecOptions) (runtime.ExecResult, error) {
+		return runtime.ExecResult{}, errors.New("boom")
+	}
+	err = e.setupCaseEnvironment(context.Background(), rt, &config.CaseConfig{ID: "case-a"}, "with_skill", &mockAgent{name: "agent"}, runtime.MCPConfig{})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("setup exec error = %v, want boom", err)
+	}
+}
+
+func TestSerializeTranscriptWritesJSONAndCleanupRemovesFile(t *testing.T) {
+	t.Parallel()
+
+	path, cleanup, err := serializeTranscript(transcript.Transcript{
+		{Role: transcript.RoleUser, Content: "hello", Turn: 1},
+		{Role: transcript.RoleAssistant, Content: "hi", Turn: 1},
+	})
+	if err != nil {
+		t.Fatalf("serializeTranscript returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if !strings.Contains(string(data), `"role":"assistant"`) || !strings.Contains(string(data), `"content":"hi"`) {
+		t.Fatalf("serialized transcript = %s", data)
+	}
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("cleanup did not remove transcript file, stat err=%v", err)
+	}
+}
+
+func TestArtifactOutputHelpersDownloadOnlyMissingFiles(t *testing.T) {
+	t.Parallel()
+
+	outputDir := t.TempDir()
+	e := newTestEvaluator(EvalOptions{OutputDir: outputDir})
+	prepared := e.prepareOutputDir(context.Background(), "with_skill", "case-a", "agent/run")
+	if prepared == "" {
+		t.Fatal("prepareOutputDir returned empty path")
+	}
+	inside := filepath.Join(prepared, "already.txt")
+	if err := os.WriteFile(inside, []byte("already"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !artifactsInDir([]string{inside}, prepared) {
+		t.Fatal("artifactsInDir should accept files already in prepared directory")
+	}
+	if artifactInCleanDir("relative.txt", filepath.Clean(prepared)) {
+		t.Fatal("relative artifact should not be treated as already copied")
+	}
+
+	rt := &mockRuntime{
+		workspace: t.TempDir(),
+		downloadFileFunc: func(_ context.Context, sourcePath, targetPath string) error {
+			return os.WriteFile(targetPath, []byte(filepath.Base(sourcePath)), 0o600)
+		},
+	}
+	session := &agent.SessionResult{Artifacts: &agent.SessionArtifacts{GeneratedFiles: []string{inside, "/remote/new.txt"}}}
+	e.ensureArtifactsInOutputDir(context.Background(), rt, "with_skill", "case-a", "agent/run", prepared, session)
+	if rt.downloadFileCall.Load() != 1 {
+		t.Fatalf("download calls = %d, want only missing remote artifact", rt.downloadFileCall.Load())
+	}
+	data, err := os.ReadFile(filepath.Join(prepared, "new.txt"))
+	if err != nil {
+		t.Fatalf("downloaded artifact missing: %v", err)
+	}
+	if string(data) != "new.txt" {
+		t.Fatalf("downloaded artifact data = %q", data)
+	}
+
+	e.downloadArtifacts(context.Background(), rt, "with_skill", "case-b", "judge/run", &agent.SessionResult{
+		Artifacts: &agent.SessionArtifacts{GeneratedFiles: []string{"/remote/judge.txt"}},
+	})
+	if _, err := os.Stat(filepath.Join(outputDir, "case-b", "with_skill", "outputs", "judge", "run", "judge.txt")); err != nil {
+		t.Fatalf("downloadArtifacts did not write judge artifact: %v", err)
 	}
 }
 

--- a/internal/mcp/provisioner_test.go
+++ b/internal/mcp/provisioner_test.go
@@ -279,3 +279,130 @@ func TestProvisioner_MockedServerFromConfigRefUsesToolResponses(t *testing.T) {
 		t.Fatalf("mock script missing fixture tool: %#v", server.Args)
 	}
 }
+
+func TestProvisionerValidationAndTransportErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		server  config.MCPServer
+		wantErr string
+	}{
+		{
+			name:    "missing mode",
+			server:  config.MCPServer{Name: "missing"},
+			wantErr: "mode is required",
+		},
+		{
+			name:    "unknown mode",
+			server:  config.MCPServer{Name: "bad", Mode: "proxy"},
+			wantErr: "mode must be one of",
+		},
+		{
+			name:    "http missing endpoint",
+			server:  config.MCPServer{Name: "http", Mode: "real", Transport: "http"},
+			wantErr: "requires endpoint",
+		},
+		{
+			name:    "stdio missing command",
+			server:  config.MCPServer{Name: "stdio", Mode: "real", Transport: "stdio"},
+			wantErr: "requires command",
+		},
+		{
+			name:    "unknown transport",
+			server:  config.MCPServer{Name: "bad-transport", Mode: "real", Transport: "sse", Endpoint: "https://example.test"},
+			wantErr: "transport must be one of",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := (Provisioner{}).Provision(config.MCPConfig{Servers: []config.MCPServer{tt.server}})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Provision error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestProvisionerServerOverridesConfigRefFields(t *testing.T) {
+	t.Parallel()
+
+	skillDir := t.TempDir()
+	configPath := filepath.Join(skillDir, "mcp.yaml")
+	if err := os.WriteFile(configPath, []byte("transport: stdio\ncommand: node\nargs: [from-file]\nendpoint: https://file.example.test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, _, err := (Provisioner{SkillDir: skillDir}).Provision(config.MCPConfig{
+		Servers: []config.MCPServer{{
+			Name:      "override",
+			Mode:      "real",
+			ConfigRef: "mcp.yaml",
+			Transport: "streamable-http",
+			Endpoint:  "https://server.example.test",
+			Command:   "ignored-because-http",
+			Args:      []string{"from-server"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Provision returned error: %v", err)
+	}
+	server := resolved.Servers[0]
+	if server.Transport != transportHTTP {
+		t.Fatalf("Transport = %q, want http", server.Transport)
+	}
+	if server.Endpoint != "https://server.example.test" {
+		t.Fatalf("Endpoint = %q, want server override", server.Endpoint)
+	}
+	if server.Command != "ignored-because-http" {
+		t.Fatalf("Command = %q, want explicit command preserved", server.Command)
+	}
+	if len(server.Args) != 1 || server.Args[0] != "from-server" {
+		t.Fatalf("Args = %#v, want server override", server.Args)
+	}
+}
+
+func TestResolveEnvReferences(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(name string) (string, bool) {
+		values := map[string]string{
+			"TOKEN": "secret",
+			"HOST":  "example.test",
+		}
+		value, ok := values[name]
+		return value, ok
+	}
+
+	value, err := resolveEnvValue("https://${HOST}/mcp?token=${TOKEN}", lookup)
+	if err != nil {
+		t.Fatalf("resolveEnvValue returned error: %v", err)
+	}
+	if value != "https://example.test/mcp?token=secret" {
+		t.Fatalf("resolved value = %q", value)
+	}
+
+	refs, err := resolveReferencedEnv("Bearer ${TOKEN}", lookup)
+	if err != nil {
+		t.Fatalf("resolveReferencedEnv returned error: %v", err)
+	}
+	if refs["TOKEN"] != "secret" {
+		t.Fatalf("refs = %#v, want TOKEN", refs)
+	}
+
+	if _, err := resolveEnvValue("$TOKEN-suffix", lookup); err == nil || !strings.Contains(err.Error(), "invalid environment variable reference") {
+		t.Fatalf("resolveEnvValue invalid ref error = %v", err)
+	}
+	if _, err := resolveReferencedEnv("${MISSING}", lookup); err == nil || !strings.Contains(err.Error(), "MISSING") {
+		t.Fatalf("resolveReferencedEnv missing error = %v", err)
+	}
+	if name, ok := wholeEnvRef("$TOKEN"); !ok || name != "TOKEN" {
+		t.Fatalf("wholeEnvRef($TOKEN) = %q/%v, want TOKEN true", name, ok)
+	}
+	if _, ok := wholeEnvRef("$TOKEN-suffix"); ok {
+		t.Fatal("wholeEnvRef should reject invalid bare refs")
+	}
+}

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -11,6 +12,20 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
+
+func resetEnvConfigCache(t *testing.T) {
+	t.Helper()
+	envConfigCache.Lock()
+	envConfigCache.initialized = false
+	envConfigCache.config = envConfig{}
+	envConfigCache.Unlock()
+	t.Cleanup(func() {
+		envConfigCache.Lock()
+		envConfigCache.initialized = false
+		envConfigCache.config = envConfig{}
+		envConfigCache.Unlock()
+	})
+}
 
 func TestTracingEnabledFromEnv(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
@@ -45,6 +60,90 @@ func TestMetricsEnabledFromEnv(t *testing.T) {
 	t.Setenv("OTEL_METRICS_EXPORTER", "otlp")
 	if !metricsEnabledFromEnv() {
 		t.Fatal("expected metrics enabled with OTEL_METRICS_EXPORTER=otlp")
+	}
+}
+
+func TestInitWithoutExportersIsNoopAndCachesEnvironment(t *testing.T) {
+	resetEnvConfigCache(t)
+	t.Setenv(envOtelEndpoint, "")
+	t.Setenv(envOtelTracesEndpoint, "")
+	t.Setenv(envOtelTracesExporter, "")
+	t.Setenv(envOtelMetricsExporter, "")
+	t.Setenv(envTraceTopology, "single")
+
+	ctx, shutdown, err := Init(context.Background(), "dev")
+	if err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if ctx == nil || shutdown == nil {
+		t.Fatalf("Init returned nil ctx or shutdown: ctx=%v shutdown=%v", ctx, shutdown)
+	}
+	if err := shutdown(context.Background()); err != nil {
+		t.Fatalf("noop shutdown returned error: %v", err)
+	}
+	if TracingEnabled() {
+		t.Fatal("TracingEnabled() = true, want false after cached no-exporter init")
+	}
+	if LinkedTraceTopologyEnabled() {
+		t.Fatal("LinkedTraceTopologyEnabled() = true, want false for SKILL_UP_TRACE_TOPOLOGY=single")
+	}
+}
+
+func TestInitReturnsUnsupportedTraceProtocolError(t *testing.T) {
+	resetEnvConfigCache(t)
+	t.Setenv(envOtelTracesExporter, "otlp")
+	t.Setenv(envOtelTracesProtocol, "ftp")
+
+	_, shutdown, err := Init(context.Background(), "dev")
+	if err == nil || !strings.Contains(err.Error(), "unsupported OTLP trace protocol") {
+		t.Fatalf("Init error = %v, want unsupported trace protocol", err)
+	}
+	if shutdown != nil {
+		t.Fatalf("shutdown = %v, want nil on init failure", shutdown)
+	}
+}
+
+func TestInitWithConsoleMetricsExporterInstallsShutdown(t *testing.T) {
+	resetEnvConfigCache(t)
+	t.Setenv(envOtelEndpoint, "")
+	t.Setenv(envOtelTracesEndpoint, "")
+	t.Setenv(envOtelTracesExporter, "none")
+	t.Setenv(envOtelMetricsExporter, "console")
+
+	ctx, shutdown, err := Init(context.Background(), "dev")
+	if err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if ctx == nil || shutdown == nil {
+		t.Fatalf("Init returned nil ctx or shutdown: ctx=%v shutdown=%v", ctx, shutdown)
+	}
+	if !metricsEnabledFromEnv() {
+		t.Fatal("metricsEnabledFromEnv() = false, want cached true")
+	}
+	if err := shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown returned error: %v", err)
+	}
+}
+
+func TestMetricExporterValidation(t *testing.T) {
+	t.Setenv(envOtelMetricsExporter, "console")
+	exp, err := newMetricExporter(context.Background())
+	if err != nil {
+		t.Fatalf("console metric exporter returned error: %v", err)
+	}
+	if exp == nil {
+		t.Fatal("console metric exporter is nil")
+	}
+
+	t.Setenv(envOtelMetricsExporter, "custom")
+	if _, err := newMetricExporter(context.Background()); err == nil || !strings.Contains(err.Error(), "unsupported OTEL_METRICS_EXPORTER") {
+		t.Fatalf("newMetricExporter error = %v, want unsupported exporter", err)
+	}
+
+	t.Setenv(envOtelMetricsExporter, "otlp")
+	t.Setenv(envOtelMetricsProtocol, "ftp")
+	if _, err := newMetricExporter(context.Background()); err == nil || !strings.Contains(err.Error(), "unsupported OTLP metrics protocol") {
+		t.Fatalf("newMetricExporter error = %v, want unsupported metrics protocol", err)
 	}
 }
 
@@ -193,6 +292,46 @@ func TestAgentEnvInjectsConfiguredAgentSpanAttributesAsBaggage(t *testing.T) {
 	}
 }
 
+func TestAgentEnvUsesCurrentEnvForEnablementAndAllowlist(t *testing.T) {
+	t.Setenv(envOtelEndpoint, "http://parent-collector:4318")
+
+	if env := AgentEnv(context.Background(), map[string]string{envOtelTracesExporter: "none"}, nil); env != nil {
+		t.Fatalf("AgentEnv with current OTEL_TRACES_EXPORTER=none = %v, want nil", env)
+	}
+
+	env := AgentEnv(context.Background(), map[string]string{
+		envOtelEndpoint:       "http://child-collector:4318",
+		envOtelTracesExporter: "otlp",
+	}, map[string]string{"skill_up.engine": "codex"})
+	if env[envOtelEndpoint] != "http://child-collector:4318" {
+		t.Fatalf("endpoint = %q, want current env override", env[envOtelEndpoint])
+	}
+	if !strings.Contains(env[envOtelResourceAttrs], "skill_up.engine=codex") {
+		t.Fatalf("resource attrs = %q, want engine attr", env[envOtelResourceAttrs])
+	}
+}
+
+func TestContextAttributeAccessorsReturnCopies(t *testing.T) {
+	agentAttrs := map[string]string{"skill_up.case.id": "case-a"}
+	ctx := ContextWithAgentAttributes(context.Background(), agentAttrs)
+	agentAttrs["skill_up.case.id"] = "mutated"
+
+	gotAgent := AgentAttributesFromContext(ctx)
+	gotAgent["skill_up.case.id"] = "changed"
+	if again := AgentAttributesFromContext(ctx); again["skill_up.case.id"] != "case-a" {
+		t.Fatalf("agent attrs were mutable through accessor: %v", again)
+	}
+
+	spanAttrs := map[string]string{"telemetry.component": "cli"}
+	ctx = ContextWithSpanAttributes(ctx, spanAttrs)
+	spanAttrs["telemetry.component"] = "mutated"
+	gotSpan := SpanAttributesFromContext(ctx)
+	gotSpan["telemetry.component"] = "changed"
+	if again := SpanAttributesFromContext(ctx); again["telemetry.component"] != "cli" {
+		t.Fatalf("span attrs were mutable through accessor: %v", again)
+	}
+}
+
 func TestSpanAttributeProcessorAddsConfiguredAndContextAttributes(t *testing.T) {
 	recorder := tracetest.NewSpanRecorder()
 	provider := sdktrace.NewTracerProvider(
@@ -220,6 +359,50 @@ func TestSpanAttributeProcessorAddsConfiguredAndContextAttributes(t *testing.T) 
 	}
 	if attrs["telemetry.project.id"] != "745" {
 		t.Fatalf("expected context span attribute, got %q", attrs["telemetry.project.id"])
+	}
+}
+
+func TestSpanAttributeProcessorLifecycleMethods(t *testing.T) {
+	processor := newSpanAttributeProcessor(nil)
+	processor.OnEnd(nil)
+	if err := processor.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+	if err := processor.ForceFlush(context.Background()); err != nil {
+		t.Fatalf("ForceFlush returned error: %v", err)
+	}
+}
+
+func TestShutdownAllJoinsErrors(t *testing.T) {
+	errOne := errors.New("one")
+	errTwo := errors.New("two")
+	err := shutdownAll(
+		context.Background(),
+		func(context.Context) error { return nil },
+		func(context.Context) error { return errOne },
+		func(context.Context) error { return errTwo },
+	)
+	if !errors.Is(err, errOne) || !errors.Is(err, errTwo) {
+		t.Fatalf("shutdownAll error = %v, want joined one and two", err)
+	}
+}
+
+func TestMetricRecordingHelpersUseInitializedInstruments(t *testing.T) {
+	orig := instruments
+	instruments = newMetricInstruments()
+	t.Cleanup(func() { instruments = orig })
+
+	ctx := context.Background()
+	RecordRunStarted(ctx, "codex", "gpt-5", 2)
+	RecordCaseCompleted(ctx, "codex", "PASS", 123)
+	RecordRuntimeExec(ctx, 0, 45)
+	if !instruments.ensure() {
+		t.Fatal("metric instruments failed to initialize")
+	}
+	if instruments.runCount() == nil || instruments.caseRunCount() == nil ||
+		instruments.caseCount() == nil || instruments.caseDuration() == nil ||
+		instruments.runtimeExecCount() == nil || instruments.runtimeExecDuration() == nil {
+		t.Fatal("expected all metric instruments to be initialized")
 	}
 }
 

--- a/internal/report/template_helpers_test.go
+++ b/internal/report/template_helpers_test.go
@@ -1,0 +1,85 @@
+package report
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/alibaba/skill-up/internal/judge"
+)
+
+func TestSharedTemplateFuncs(t *testing.T) {
+	funcs := SharedTemplateFuncs()
+
+	fmtDuration := requireTemplateFunc[func(int64) string](t, funcs, "fmtDuration")
+	fmtPercent := requireTemplateFunc[func(float64) string](t, funcs, "fmtPercent")
+	fmtPercentSigned := requireTemplateFunc[func(float64) string](t, funcs, "fmtPercentSigned")
+	passFailClass := requireTemplateFunc[func(bool) string](t, funcs, "passFailClass")
+	passFailIcon := requireTemplateFunc[func(bool) template.HTML](t, funcs, "passFailIcon")
+	notNil := requireTemplateFunc[func(any) bool](t, funcs, "notNil")
+	derefFloat := requireTemplateFunc[func(*float64) float64](t, funcs, "derefFloat")
+
+	if got := fmtDuration(1234); got != "1.2s" {
+		t.Fatalf("fmtDuration = %q, want 1.2s", got)
+	}
+	if got := fmtPercent(0.875); got != "88%" {
+		t.Fatalf("fmtPercent = %q, want 88%%", got)
+	}
+	if got := fmtPercentSigned(-0.125); got != "-12%" {
+		t.Fatalf("fmtPercentSigned = %q, want -12%%", got)
+	}
+	if got := passFailClass(true); got != "pass" {
+		t.Fatalf("passFailClass(true) = %q, want pass", got)
+	}
+	if got := passFailClass(false); got != "fail" {
+		t.Fatalf("passFailClass(false) = %q, want fail", got)
+	}
+	if got := passFailIcon(true); got != template.HTML("&#x2705;") {
+		t.Fatalf("passFailIcon(true) = %q, want check mark entity", got)
+	}
+	if got := passFailIcon(false); got != template.HTML("&#x274C;") {
+		t.Fatalf("passFailIcon(false) = %q, want cross mark entity", got)
+	}
+
+	if notNil(nil) {
+		t.Fatal("notNil(nil) = true, want false")
+	}
+	var ptr *int
+	if notNil(ptr) {
+		t.Fatal("notNil(nil pointer) = true, want false")
+	}
+	if !notNil(0) || !notNil([]string{"x"}) {
+		t.Fatal("notNil should treat non-nil scalar and slice as true")
+	}
+
+	if got := derefFloat(nil); got != 0 {
+		t.Fatalf("derefFloat(nil) = %f, want 0", got)
+	}
+	value := 0.42
+	if got := derefFloat(&value); got != value {
+		t.Fatalf("derefFloat(&value) = %f, want %f", got, value)
+	}
+}
+
+func requireTemplateFunc[T any](t *testing.T, funcs template.FuncMap, name string) T {
+	t.Helper()
+	fn, ok := funcs[name].(T)
+	if !ok {
+		t.Fatalf("template func %s has unexpected type %T", name, funcs[name])
+	}
+	return fn
+}
+
+func TestStatusIcon(t *testing.T) {
+	tests := map[judge.Status]template.HTML{
+		judge.StatusPass:  "&#x2705;",
+		judge.StatusFail:  "&#x274C;",
+		judge.StatusSkip:  "&#x23ED;",
+		judge.StatusError: "&#x26A0;",
+		judge.Status("x"): "?",
+	}
+	for status, want := range tests {
+		if got := statusIcon(status); got != want {
+			t.Fatalf("statusIcon(%q) = %q, want %q", status, got, want)
+		}
+	}
+}

--- a/internal/report/workspace_test.go
+++ b/internal/report/workspace_test.go
@@ -25,6 +25,25 @@ func TestNewIterationWorkspace_FirstIteration(t *testing.T) {
 	}
 }
 
+func TestNewIterationWorkspace_DefaultAndInvalidIteration(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	ws, err := NewIterationWorkspace("", "demo", 1)
+	if err != nil {
+		t.Fatalf("NewIterationWorkspace default returned error: %v", err)
+	}
+	if ws.RootDir != "demo-workspace" {
+		t.Fatalf("RootDir = %q, want demo-workspace", ws.RootDir)
+	}
+	if _, err := os.Stat("demo-workspace"); err != nil {
+		t.Fatalf("expected default workspace dir: %v", err)
+	}
+
+	if _, err := NewIterationWorkspace("bad", "demo", 0); err == nil {
+		t.Fatal("expected invalid iteration error")
+	}
+}
+
 func TestIterationWorkspace_Paths(t *testing.T) {
 	t.Parallel()
 	ws, err := NewIterationWorkspace("/tmp/test-workspace", "test-skill", 1)
@@ -214,5 +233,52 @@ func TestIterationWorkspace_WriteBenchmark(t *testing.T) {
 	path := filepath.Join(ws.IterationDir(), "benchmark.json")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		t.Error("expected benchmark.json to exist")
+	}
+}
+
+func TestIterationWorkspace_WriteFile(t *testing.T) {
+	t.Parallel()
+
+	ws, err := NewIterationWorkspace(t.TempDir(), "test-skill", 1)
+	if err != nil {
+		t.Fatalf("NewIterationWorkspace error: %v", err)
+	}
+
+	if err := ws.WriteFile("nested/artifact.txt", []byte("artifact")); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(ws.IterationDir(), "nested", "artifact.txt"))
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+	if string(data) != "artifact" {
+		t.Fatalf("artifact data = %q, want artifact", data)
+	}
+
+	for _, rel := range []string{"../escape.txt", "/abs.txt"} {
+		if err := ws.WriteFile(rel, []byte("nope")); err == nil {
+			t.Fatalf("WriteFile(%q) returned nil error", rel)
+		}
+	}
+}
+
+func TestIterationWorkspaceRejectsUnsafeCaseIDs(t *testing.T) {
+	t.Parallel()
+
+	ws, err := NewIterationWorkspace(t.TempDir(), "test-skill", 1)
+	if err != nil {
+		t.Fatalf("NewIterationWorkspace error: %v", err)
+	}
+
+	for _, caseID := range []string{"../escape", "nested/case", `nested\case`, "/abs"} {
+		if err := ws.EnsureDirs([]string{caseID}); err == nil {
+			t.Fatalf("EnsureDirs(%q) returned nil error", caseID)
+		}
+		if err := ws.WriteResponse(caseID, "with_skill", "content"); err == nil {
+			t.Fatalf("WriteResponse(%q) returned nil error", caseID)
+		}
+	}
+	if err := validateCaseID("case-ok"); err != nil {
+		t.Fatalf("validateCaseID(case-ok) returned error: %v", err)
 	}
 }

--- a/internal/runtime/none_test.go
+++ b/internal/runtime/none_test.go
@@ -58,6 +58,20 @@ func TestNoneRuntime_StartStop(t *testing.T) {
 	if err := rt.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop should be no-op: %v", err)
 	}
+	if !rt.RequiresProcessSandbox() {
+		t.Fatal("NoneRuntime should require process sandboxing")
+	}
+}
+
+func TestNewRuntimeErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewRuntime(Config{Type: "unknown"}); err == nil || !strings.Contains(err.Error(), "unknown runtime type") {
+		t.Fatalf("NewRuntime unknown error = %v", err)
+	}
+	if _, err := NewRuntime(Config{Type: "docker"}); err == nil || !strings.Contains(err.Error(), "requires environment.image") {
+		t.Fatalf("NewRuntime docker validation error = %v", err)
+	}
 }
 
 func TestNoneRuntime_UploadDownloadFile(t *testing.T) {

--- a/internal/runtime/opensandbox_test.go
+++ b/internal/runtime/opensandbox_test.go
@@ -18,11 +18,13 @@ import (
 	opensandbox "github.com/alibaba/OpenSandbox/sdks/sandbox/go"
 )
 
+const testWorkspaceMount = "/work"
+
 func TestNewRuntimeAcceptsOpenSandbox(t *testing.T) {
 	rt, err := NewRuntime(Config{
 		Type:           "opensandbox",
 		Image:          "ubuntu:24.04",
-		WorkspaceMount: "/work",
+		WorkspaceMount: testWorkspaceMount,
 		SandboxTimeout: 2 * time.Minute,
 		ReadyTimeout:   time.Second,
 		UseServerProxy: true,
@@ -41,7 +43,7 @@ func TestNewRuntimeAcceptsOpenSandbox(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRuntime returned error: %v", err)
 	}
-	if rt.Workspace() != "/work" {
+	if rt.Workspace() != testWorkspaceMount {
 		t.Fatalf("Workspace() = %q, want /work", rt.Workspace())
 	}
 }
@@ -66,7 +68,7 @@ func TestOpenSandboxCreateUsesSDKOptions(t *testing.T) {
 	}
 
 	rt, err := NewOpenSandboxRuntime(Config{
-		WorkspaceMount: "/work",
+		WorkspaceMount: testWorkspaceMount,
 		Image:          "ubuntu:24.04",
 		UseServerProxy: true,
 		ReadyTimeout:   3 * time.Second,
@@ -103,7 +105,7 @@ func TestOpenSandboxCreateUsesSDKOptions(t *testing.T) {
 	if gotOpts.Extensions["template"] != "basic" {
 		t.Fatalf("Extensions = %#v, want kwargs extensions", gotOpts.Extensions)
 	}
-	if fake.createdDirs[0] != "/work" {
+	if fake.createdDirs[0] != testWorkspaceMount {
 		t.Fatalf("created workspace = %q, want /work", fake.createdDirs[0])
 	}
 }
@@ -237,6 +239,241 @@ func TestOpenSandboxCreateSnapshotsKwargs(t *testing.T) {
 	}
 	if rt.fileParallelism != 3 {
 		t.Fatalf("fileParallelism = %d, want snapshot value 3", rt.fileParallelism)
+	}
+}
+
+func TestOpenSandboxLocalHelpersRejectUnsafePathsAndPreserveRemoteScope(t *testing.T) {
+	t.Parallel()
+
+	rel, err := remoteRelativePath("/workspace/src", "/workspace/src/a/b.txt")
+	if err != nil {
+		t.Fatalf("remoteRelativePath returned error: %v", err)
+	}
+	if rel != "a/b.txt" {
+		t.Fatalf("remoteRelativePath = %q, want a/b.txt", rel)
+	}
+	if rel, err := remoteRelativePath("/workspace/src", "/workspace/src"); err != nil || rel != "." {
+		t.Fatalf("remoteRelativePath root = %q, %v; want . nil", rel, err)
+	}
+	if _, err := remoteRelativePath("/workspace/src", "/workspace/other.txt"); err == nil {
+		t.Fatal("remoteRelativePath outside root returned nil error")
+	}
+
+	root := t.TempDir()
+	target, err := safeLocalTarget(root, "nested/file.txt")
+	if err != nil {
+		t.Fatalf("safeLocalTarget returned error: %v", err)
+	}
+	if target != filepath.Join(root, "nested", "file.txt") {
+		t.Fatalf("safeLocalTarget = %q, want nested target", target)
+	}
+	if target, err := safeLocalTarget(root, "."); err != nil || target != root {
+		t.Fatalf("safeLocalTarget dot = %q, %v; want root nil", target, err)
+	}
+	for _, rel := range []string{"../escape", "/absolute", "nested/../../escape"} {
+		if _, err := safeLocalTarget(root, rel); err == nil {
+			t.Fatalf("safeLocalTarget(%q) returned nil error", rel)
+		}
+	}
+}
+
+func TestOpenSandboxCommandHelpers(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		"PATH":  "$PATH:/custom/bin",
+		"PLAIN": "value",
+	}
+	literal := literalRemoteEnv(env)
+	if _, ok := literal["PATH"]; ok {
+		t.Fatalf("literalRemoteEnv kept expandable PATH: %v", literal)
+	}
+	if literal["PLAIN"] != "value" {
+		t.Fatalf("literalRemoteEnv dropped PLAIN: %v", literal)
+	}
+
+	command := withRemoteEnvExpansion("echo ok", env)
+	if !strings.HasPrefix(command, `export PATH="$PATH:/custom/bin"`+"\n") {
+		t.Fatalf("withRemoteEnvExpansion = %q", command)
+	}
+	if got := withRemoteEnvExpansion("echo ok", map[string]string{"PATH": "/usr/bin"}); got != "echo ok" {
+		t.Fatalf("withRemoteEnvExpansion without expansion = %q, want original command", got)
+	}
+	if got := shellDoubleQuote(`a"b\c` + "`d"); got != `"a\"b\\c\`+"`"+`d"` {
+		t.Fatalf("shellDoubleQuote returned %q", got)
+	}
+}
+
+func TestOpenSandboxExecutionToResult(t *testing.T) {
+	t.Parallel()
+
+	exitCode := 7
+	result := executionToResult(&opensandbox.Execution{
+		Stdout:   []opensandbox.OutputMessage{{Text: "out"}, {Text: "put"}},
+		Stderr:   []opensandbox.OutputMessage{{Text: "err"}},
+		ExitCode: &exitCode,
+	})
+	if result.Stdout != "output" || result.Stderr != "err" || result.ExitCode != 7 {
+		t.Fatalf("executionToResult = %+v, want combined stdout/stderr and exit 7", result)
+	}
+
+	result = executionToResult(&opensandbox.Execution{
+		Error: &opensandbox.ExecutionError{Traceback: []string{"line1", "line2"}, Value: "fallback"},
+	})
+	if result.Stderr != "line1\nline2" || result.ExitCode != 0 {
+		t.Fatalf("executionToResult traceback = %+v", result)
+	}
+
+	result = executionToResult(&opensandbox.Execution{
+		Error: &opensandbox.ExecutionError{Value: "fallback"},
+	})
+	if result.Stderr != "fallback" {
+		t.Fatalf("executionToResult fallback stderr = %q, want fallback", result.Stderr)
+	}
+
+	if result := executionToResult(nil); result.ExitCode != -1 {
+		t.Fatalf("executionToResult(nil).ExitCode = %d, want -1", result.ExitCode)
+	}
+}
+
+func TestOpenSandboxRuntimeStateAndPathHelpers(t *testing.T) {
+	t.Parallel()
+
+	rt, err := NewOpenSandboxRuntime(Config{WorkspaceMount: testWorkspaceMount})
+	if err != nil {
+		t.Fatalf("NewOpenSandboxRuntime returned error: %v", err)
+	}
+	if rt.RequiresProcessSandbox() {
+		t.Fatal("OpenSandbox runtime should report no additional process sandbox required")
+	}
+	if err := rt.ensureCreated(); err == nil {
+		t.Fatal("ensureCreated before Create returned nil error")
+	}
+	if got := rt.Workspace(); got != testWorkspaceMount {
+		t.Fatalf("Workspace() = %q, want /work", got)
+	}
+	if got := rt.execCwd(""); got != testWorkspaceMount {
+		t.Fatalf("execCwd empty = %q, want /work", got)
+	}
+	if got := rt.execCwd("nested"); got != "/work/nested" {
+		t.Fatalf("execCwd nested = %q, want /work/nested", got)
+	}
+	if got := rt.remotePath("/abs/path"); got != "/abs/path" {
+		t.Fatalf("remotePath absolute = %q, want /abs/path", got)
+	}
+	if got := rt.remotePath("../escape"); got != "/escape" {
+		t.Fatalf("remotePath cleans traversal relative to workspace, got %q", got)
+	}
+	if got := cleanRemotePath("./nested/../file.txt"); got != "file.txt" {
+		t.Fatalf("cleanRemotePath = %q, want file.txt", got)
+	}
+}
+
+func TestOpenSandboxRuntimeLifecycleMethods(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeOpenSandbox{}
+	rt := &OpenSandboxRuntime{sandbox: fake, cfg: Config{Delete: true}}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	if err := rt.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if !fake.killed {
+		t.Fatal("Close with Delete=true did not kill sandbox")
+	}
+
+	keep := &fakeOpenSandbox{}
+	rt = &OpenSandboxRuntime{sandbox: keep, cfg: Config{Delete: false}}
+	if err := rt.Close(); err != nil {
+		t.Fatalf("Close keep-alive returned error: %v", err)
+	}
+	if keep.killed {
+		t.Fatal("Close with Delete=false should not kill sandbox")
+	}
+}
+
+func TestOpenSandboxConfigParsingHelpers(t *testing.T) {
+	t.Parallel()
+
+	rt := &OpenSandboxRuntime{cfg: Config{Kwargs: map[string]string{
+		openSandboxKwargReqTimeout:  "5",
+		openSandboxKwargParallelism: "128",
+	}}}
+	if got := rt.resolveRequestTimeout(); got != 5*time.Second {
+		t.Fatalf("resolveRequestTimeout = %s, want 5s", got)
+	}
+	if got := rt.resolveFileTransferParallelism(); got != 64 {
+		t.Fatalf("resolveFileTransferParallelism clamps to %d, want 64", got)
+	}
+
+	rt.cfg.Kwargs[openSandboxKwargReqTimeout] = "-1"
+	rt.cfg.Kwargs[openSandboxKwargParallelism] = "0"
+	if got := rt.resolveRequestTimeout(); got != 0 {
+		t.Fatalf("invalid request timeout = %s, want 0", got)
+	}
+	if got := rt.resolveFileTransferParallelism(); got != openSandboxDefaultFileTransferParallelism {
+		t.Fatalf("invalid parallelism = %d, want default", got)
+	}
+
+	if got := durationSecondsPtr(1500 * time.Millisecond); got == nil || *got != 1 {
+		t.Fatalf("durationSecondsPtr(1.5s) = %v, want 1", got)
+	}
+	if got := durationSecondsPtr(0); got != nil {
+		t.Fatalf("durationSecondsPtr(0) = %v, want nil", got)
+	}
+	if got := (&OpenSandboxRuntime{}).entrypoint(); len(got) != 1 || got[0] != "tail -F /dev/null" {
+		t.Fatalf("default entrypoint = %#v", got)
+	}
+	if got := (&OpenSandboxRuntime{cfg: Config{Entrypoint: []string{"sleep", "infinity"}}}).entrypoint(); len(got) != 2 || got[0] != "sleep" {
+		t.Fatalf("configured entrypoint = %#v", got)
+	}
+
+	parsed := parseExtensions(context.Background(), "test", `{"template":"basic"}`)
+	if parsed["template"] != "basic" {
+		t.Fatalf("parseExtensions valid = %#v", parsed)
+	}
+	if got := parseExtensions(context.Background(), "test", `{bad json`); got != nil {
+		t.Fatalf("parseExtensions invalid = %#v, want nil", got)
+	}
+	if got := parseExtensions(context.Background(), "test", `{}`); got != nil {
+		t.Fatalf("parseExtensions empty = %#v, want nil", got)
+	}
+}
+
+func TestOpenSandboxDirectoryFallbacks(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeOpenSandbox{createDirErr: errors.New("api unavailable")}
+	rt := &OpenSandboxRuntime{sandbox: fake}
+	if err := rt.ensureDirectory(context.Background(), "/work/a b", 0o755); err != nil {
+		t.Fatalf("ensureDirectory should accept shell-verified directory: %v", err)
+	}
+	if len(fake.execs) != 1 || !strings.Contains(fake.execs[0].Command, "mkdir -p '/work/a b'") {
+		t.Fatalf("fallback command = %#v", fake.execs)
+	}
+
+	exit := 2
+	fake = &fakeOpenSandbox{
+		createDirErr: errors.New("api unavailable"),
+		execResult:   &opensandbox.Execution{ExitCode: &exit, Stderr: []opensandbox.OutputMessage{{Text: "denied"}}},
+	}
+	rt = &OpenSandboxRuntime{sandbox: fake}
+	if err := rt.ensureDirectory(context.Background(), "/work/nope", 0o755); err == nil || !strings.Contains(err.Error(), "denied") {
+		t.Fatalf("ensureDirectory error = %v, want shell stderr", err)
+	}
+
+	fake = &fakeOpenSandbox{execResult: &opensandbox.Execution{ExitCode: &exit}}
+	rt = &OpenSandboxRuntime{sandbox: fake}
+	if err := rt.ensureDirectories(context.Background(), []string{"/work/a", "/work/b"}); err == nil || !strings.Contains(err.Error(), "exit code 2") {
+		t.Fatalf("ensureDirectories error = %v, want exit code", err)
+	}
+	if err := rt.ensureDirectories(context.Background(), nil); err != nil {
+		t.Fatalf("ensureDirectories(nil) = %v, want nil", err)
 	}
 }
 

--- a/internal/shellquote/shellquote_test.go
+++ b/internal/shellquote/shellquote_test.go
@@ -1,0 +1,24 @@
+package shellquote
+
+import "testing"
+
+func TestQuote(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "plain", input: "hello", want: "'hello'"},
+		{name: "spaces", input: "hello world", want: "'hello world'"},
+		{name: "single quote", input: "can't", want: "'can'\\''t'"},
+		{name: "empty", input: "", want: "''"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Quote(tt.input); got != tt.want {
+				t.Fatalf("Quote(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -1,0 +1,57 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestProgressOutputFormatting(t *testing.T) {
+	var out bytes.Buffer
+	orig := Output
+	Output = &out
+	t.Cleanup(func() { Output = orig })
+
+	Step(">", "Loading")
+	Stepf(">", "Loaded %d", 2)
+	Status("*", "Ready")
+	Statusf("*", "Case %s", "ok")
+	CaseStart(1, 3, "case-a", "Does work")
+	CaseComplete(1, 3, "case-a", "PASS", 1)
+	CaseComplete(2, 3, "case-b", "SKIP", -1)
+	Summary(1, 0, 0)
+	Separator()
+	Blank()
+
+	got := out.String()
+	for _, want := range []string{
+		"> Loading\n",
+		"> Loaded 2\n",
+		"* Ready\n",
+		"* Case ok\n",
+		"[1/3] case-a: Does work",
+		"case-a: PASS (100.0%)",
+		"case-b: SKIP\n",
+		"Results: 1 passed, 0 failed, 0 errors",
+		strings.Repeat("─", 40),
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStatusEmoji(t *testing.T) {
+	tests := map[string]string{
+		"pass":    "✅",
+		"FAIL":    "❌",
+		"Error":   "⚠️",
+		"skip":    "⏭️",
+		"unknown": "❓",
+	}
+	for status, want := range tests {
+		if got := statusEmoji(status); got != want {
+			t.Fatalf("statusEmoji(%q) = %q, want %q", status, got, want)
+		}
+	}
+}

--- a/internal/userconfig/apply_test.go
+++ b/internal/userconfig/apply_test.go
@@ -1,6 +1,7 @@
 package userconfig
 
 import (
+	"context"
 	"os"
 	"slices"
 	"testing"
@@ -95,6 +96,28 @@ func TestMergeKwargs_NilEval(t *testing.T) {
 	merged := MergeKwargs(c, "opensandbox", nil)
 	if merged["base_url"] != "u" {
 		t.Errorf("user kwarg should fill: %+v", merged)
+	}
+}
+
+func TestConfigContextRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{Env: map[string]string{"A": "B"}}
+	sources := []Source{{Kind: "project", Path: ".skill-up.yaml"}}
+	ctx := WithContext(context.Background(), cfg, sources)
+
+	gotCfg, gotSources, ok := FromContext(ctx)
+	if !ok {
+		t.Fatal("FromContext ok = false, want true")
+	}
+	if gotCfg.Env["A"] != "B" {
+		t.Fatalf("config from context = %#v", gotCfg)
+	}
+	if len(gotSources) != 1 || gotSources[0].Kind != "project" {
+		t.Fatalf("sources from context = %#v", gotSources)
+	}
+	if _, _, ok := FromContext(context.Background()); ok {
+		t.Fatal("FromContext on empty context = true, want false")
 	}
 }
 

--- a/internal/userconfig/loader_test.go
+++ b/internal/userconfig/loader_test.go
@@ -196,3 +196,48 @@ func TestLoadEffective_ValidateErrorIncludesSources(t *testing.T) {
 		t.Errorf("validate error should mention source path; got %v", err)
 	}
 }
+
+func TestLoadFile(t *testing.T) {
+	tmp := t.TempDir()
+	valid := filepath.Join(tmp, "config.yaml")
+	writeFile(t, valid, "telemetry:\n  service_name: cli\n")
+
+	cfg, err := LoadFile(valid)
+	if err != nil {
+		t.Fatalf("LoadFile valid returned error: %v", err)
+	}
+	if cfg.Telemetry.ServiceName != "cli" {
+		t.Fatalf("service name = %q, want cli", cfg.Telemetry.ServiceName)
+	}
+
+	if _, err := LoadFile(filepath.Join(tmp, "missing.yaml")); err == nil || !strings.Contains(err.Error(), "config file not found") {
+		t.Fatalf("LoadFile missing error = %v", err)
+	}
+
+	invalid := filepath.Join(tmp, "invalid.yaml")
+	writeFile(t, invalid, "telemetry:\n  traces:\n    protocol: tcp\n")
+	if _, err := LoadFile(invalid); err == nil || !strings.Contains(err.Error(), "validate") {
+		t.Fatalf("LoadFile invalid error = %v", err)
+	}
+}
+
+func TestResolveConfigPaths(t *testing.T) {
+	t.Parallel()
+
+	xdg := t.TempDir()
+	env := func(key string) string {
+		if key == "XDG_CONFIG_HOME" {
+			return xdg
+		}
+		return ""
+	}
+	if got := resolveUserConfigPath(LoadOptions{HomeDir: "/home/test"}, env); got != filepath.Join(xdg, UserConfigDir, UserConfigFile) {
+		t.Fatalf("resolveUserConfigPath XDG = %q", got)
+	}
+	if got := resolveUserConfigPath(LoadOptions{HomeDir: "/home/test"}, emptyEnv); got != filepath.Join("/home/test", ".config", UserConfigDir, UserConfigFile) {
+		t.Fatalf("resolveUserConfigPath home = %q", got)
+	}
+	if got := resolveProjectConfigPath(LoadOptions{WorkingDir: "/repo"}); got != filepath.Join("/repo", ProjectConfigFile) {
+		t.Fatalf("resolveProjectConfigPath = %q", got)
+	}
+}

--- a/pkg/skillup/skillup_test.go
+++ b/pkg/skillup/skillup_test.go
@@ -1,0 +1,11 @@
+package skillup
+
+import "testing"
+
+func TestExecuteDelegatesToCLI(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := Execute("test-version", []string{"--version"}); err != nil {
+		t.Fatalf("Execute --version returned error: %v", err)
+	}
+}

--- a/pkg/transcript/transcript_test.go
+++ b/pkg/transcript/transcript_test.go
@@ -1,0 +1,53 @@
+package transcript
+
+import "testing"
+
+func TestTranscriptQueries(t *testing.T) {
+	t.Parallel()
+
+	tr := Transcript{
+		{Role: RoleUser, Content: "first prompt", Turn: 1},
+		{Role: RoleToolCall, Content: "call one", Turn: 1, ToolCall: &ToolCallInfo{Name: "read_file"}},
+		{Role: RoleAssistant, Content: "draft", Turn: 1},
+		{Role: RoleToolResult, Content: "result", Turn: 1, ToolResult: &ToolResultInfo{Status: "ok"}},
+		{Role: RoleUser, Content: "follow up", Turn: 2},
+		{Role: RoleAssistant, Content: "final", Turn: 2},
+	}
+
+	if got := tr.FinalAssistantMessage(); got != "final" {
+		t.Fatalf("FinalAssistantMessage() = %q, want final", got)
+	}
+
+	calls := tr.ToolCalls()
+	if len(calls) != 1 || calls[0].ToolCall == nil || calls[0].ToolCall.Name != "read_file" {
+		t.Fatalf("ToolCalls() = %#v, want read_file call", calls)
+	}
+
+	turnOne := tr.MessagesForTurn(1)
+	if len(turnOne) != 4 {
+		t.Fatalf("MessagesForTurn(1) returned %d message(s), want 4", len(turnOne))
+	}
+
+	assistantTurnOne := tr.AssistantMessagesForTurn(1)
+	if len(assistantTurnOne) != 1 || assistantTurnOne[0].Content != "draft" {
+		t.Fatalf("AssistantMessagesForTurn(1) = %#v, want draft", assistantTurnOne)
+	}
+}
+
+func TestTranscriptQueriesReturnEmptyWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	tr := Transcript{{Role: RoleUser, Content: "prompt", Turn: 1}}
+	if got := tr.FinalAssistantMessage(); got != "" {
+		t.Fatalf("FinalAssistantMessage() = %q, want empty", got)
+	}
+	if got := tr.ToolCalls(); got != nil {
+		t.Fatalf("ToolCalls() = %#v, want nil", got)
+	}
+	if got := tr.MessagesForTurn(99); got != nil {
+		t.Fatalf("MessagesForTurn(99) = %#v, want nil", got)
+	}
+	if got := tr.AssistantMessagesForTurn(1); got != nil {
+		t.Fatalf("AssistantMessagesForTurn(1) = %#v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add meaningful unit coverage across CLI command paths, evaluator lifecycle helpers, MCP provisioning/install behavior, OpenSandbox helpers, observability, reporting, user config, UI, shell quoting, and public wrapper/transcript APIs
- Cover dry-run/config loading, artifact download behavior, environment/reference validation, metrics initialization, and path-safety boundaries
- Raise aggregate unit coverage above 85%

## Verification
- GOCACHE=/private/tmp/skill-up-gocache make fmt
- GOCACHE=/private/tmp/skill-up-gocache make verify
- GOCACHE=/private/tmp/skill-up-gocache make test
- GOCACHE=/private/tmp/skill-up-gocache go test -coverprofile=/tmp/skill-up-cover-final.out ./... -> 85.02%