### PR TITLE
feat(engine): add engine.kwargs (--engine-kwarg/--ek); codex honors bypass_sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `engine.kwargs` (CLI: `--engine-kwarg key=value`, alias `--ek`): an
+  agent-specific switch map mirroring `environment.kwargs`/`--runtime-kwarg`.
+  Each agent reads only the keys it understands; unknown keys are silently
+  ignored. First key: `bypass_sandbox` — `codex` honours it by forcing
+  `--dangerously-bypass-approvals-and-sandbox` and skipping its Landlock-based
+  `linux-sandbox` wrapper, useful on CI runners whose kernel/seccomp profile
+  does not allow Landlock setup (typical Aone CI symptom:
+  `error running landlock: Sandbox(LandlockRestrict)`, exit 101 on every
+  shell call). `claude_code` and `qodercli` accept the key but no-op.
+
 ## [0.2.2] - 2026-05-26
 
 ### Added

--- a/docs/guide/writing-evals.md
+++ b/docs/guide/writing-evals.md
@@ -85,8 +85,7 @@ engine:
     provider: anthropic
     name: claude-sonnet-4-6
     base_url: ""                  # Custom API endpoint (optional)
-  kwargs:                         # Agent-specific switches (optional)
-    bypass_sandbox: "true"        # codex: skip its own process sandbox (host kernel lacks Landlock)
+  # kwargs: { ... }               # Agent-specific switches — see "Engine kwargs" below
 
 # ========== 6. Cases ==========
 cases:

--- a/docs/guide/writing-evals.md
+++ b/docs/guide/writing-evals.md
@@ -115,7 +115,7 @@ report:
 
 ### Engine kwargs (agent-specific switches)
 
-`engine.kwargs` is a free-form string map. Each agent reads only the keys it recognises; unknown keys are silently ignored. CLI override: `--engine-kwarg key=value` (alias `--ek`), repeatable. Precedence: `--engine-kwarg` > `engine.kwargs` > default.
+`engine.kwargs` is a free-form string map. Each agent reads only the keys it recognises; unknown keys are ignored. Unrecognised keys (typos like `bypas_sandbox`) emit a DEBUG log line — run with `-v` to surface them. CLI override: `--engine-kwarg key=value` (alias `--ek`), repeatable. Precedence: `--engine-kwarg` > `engine.kwargs` > default.
 
 | key | agent | `true` behaviour | unset / `false` |
 | :---: | :---: | :--- | :--- |

--- a/docs/guide/writing-evals.md
+++ b/docs/guide/writing-evals.md
@@ -85,6 +85,8 @@ engine:
     provider: anthropic
     name: claude-sonnet-4-6
     base_url: ""                  # Custom API endpoint (optional)
+  kwargs:                         # Agent-specific switches (optional)
+    bypass_sandbox: "true"        # codex: skip its own process sandbox (host kernel lacks Landlock)
 
 # ========== 6. Cases ==========
 cases:
@@ -110,6 +112,21 @@ report:
 ```
 
 `cases.parallelism` is the file-level default. To override it for a single run, use `skill-up run --parallelism N` without modifying `eval.yaml`. Allowed range: **1 to 256**.
+
+### Engine kwargs (agent-specific switches)
+
+`engine.kwargs` is a free-form string map. Each agent reads only the keys it recognises; unknown keys are silently ignored. CLI override: `--engine-kwarg key=value` (alias `--ek`), repeatable. Precedence: `--engine-kwarg` > `engine.kwargs` > default.
+
+| key | agent | `true` behaviour | unset / `false` |
+| :---: | :---: | :--- | :--- |
+| `bypass_sandbox` | `codex` | Forces `--dangerously-bypass-approvals-and-sandbox`; overrides the runtime-derived choice. Use when the host kernel lacks Landlock support (e.g. some CI containers) | Default: `none` runtime → `--sandbox workspace-write`; other runtimes already bypass |
+| `bypass_sandbox` | `claude_code` | No-op — claude already runs with `--permission-mode=bypassPermissions` | No-op |
+| `bypass_sandbox` | `qodercli` | No-op — no equivalent flag | No-op |
+
+```bash
+# One-off override at the call site
+skill-up run evals/eval.yaml --engine-kwarg bypass_sandbox=true
+```
 
 ### MCP configuration
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -65,6 +65,10 @@ type Config struct {
 	ModelProvider string
 	APIKey        string
 	BaseURL       string
+	// Kwargs carries agent-specific key/value options forwarded from
+	// EngineConfig.Kwargs. Each agent reads only the keys it understands;
+	// unknown keys are ignored. See agent kwargs helpers in kwargs.go.
+	Kwargs map[string]string
 }
 
 // Runtime is an alias for runtime.Runtime for agent package convenience.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -250,7 +250,7 @@ func TestDetectAgentWithInitParams_SetsTypedCredentialFields(t *testing.T) {
 		Model:    "gpt-5.4",
 		APIKey:   "openai-test-token",
 		BaseURL:  "https://openai.example.com/v1",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("DetectAgentWithInitParams failed: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestDetectAgentWithInitParams_QoderMapsAPIKeyToRuntimeEnv(t *testing.T) {
 	ag, err := DetectAgentWithInitParams("qoder-cli", credential.AgentInitParams{
 		Provider: "qoder",
 		Model:    "auto",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("DetectAgentWithInitParams failed: %v", err)
 	}
@@ -301,7 +301,7 @@ func TestDetectAgentWithInitParams_QoderIgnoresParamsAPIKey(t *testing.T) {
 		Provider: "anthropic",
 		Model:    "auto",
 		APIKey:   "sk-ant-should-not-appear",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("DetectAgentWithInitParams failed: %v", err)
 	}
@@ -343,7 +343,7 @@ func TestDetectAgentWithInitParams_StripsAutoForNonQoderEngines(t *testing.T) {
 
 	ag, err := DetectAgentWithInitParams("claude-code", credential.AgentInitParams{
 		Model: "auto",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("DetectAgentWithInitParams failed: %v", err)
 	}
@@ -362,7 +362,7 @@ func TestDetectAgentWithInitParams_PreservesAutoForQoderCLI(t *testing.T) {
 
 	ag, err := DetectAgentWithInitParams("qoder-cli", credential.AgentInitParams{
 		Model: "auto",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("DetectAgentWithInitParams failed: %v", err)
 	}
@@ -373,5 +373,29 @@ func TestDetectAgentWithInitParams_PreservesAutoForQoderCLI(t *testing.T) {
 	}
 	if got := qoderAgent.Cfg.ModelName; got != "auto" {
 		t.Fatalf("ModelName = %q, want auto (should be preserved for qoder-cli)", got)
+	}
+}
+
+func TestDetectAgentWithInitParams_ForwardsKwargs(t *testing.T) {
+	t.Parallel()
+
+	kwargs := map[string]string{KwargBypassSandbox: "true", "future_key": "x"}
+	ag, err := DetectAgentWithInitParams("codex", credential.AgentInitParams{
+		Provider: "openai",
+		Model:    "gpt-5.4",
+	}, kwargs)
+	if err != nil {
+		t.Fatalf("DetectAgentWithInitParams failed: %v", err)
+	}
+
+	codexAgent, ok := ag.(*CodexAgent)
+	if !ok {
+		t.Fatalf("expected *CodexAgent, got %T", ag)
+	}
+	if got := codexAgent.Cfg.Kwargs[KwargBypassSandbox]; got != "true" {
+		t.Fatalf("Cfg.Kwargs[%s] = %q, want true", KwargBypassSandbox, got)
+	}
+	if got := codexAgent.Cfg.Kwargs["future_key"]; got != "x" {
+		t.Fatalf("Cfg.Kwargs[future_key] = %q, want x", got)
 	}
 }

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -227,8 +227,11 @@ func (a *CodexAgent) Run(ctx context.Context, rt Runtime, opts ExecOptions, mess
 	start := time.Now()
 
 	instruction := BuildInstructionFromMessages(messages)
+	// bypass_sandbox kwarg overrides the runtime-derived choice; useful when
+	// the host kernel does not support codex's Landlock-based linux-sandbox
+	// (e.g. CI containers that block Landlock syscalls).
 	sandboxFlag := codexBypassSandbox
-	if rt.RequiresProcessSandbox() {
+	if rt.RequiresProcessSandbox() && !EngineKwargBool(a.Cfg.Kwargs, KwargBypassSandbox) {
 		sandboxFlag = codexProcessSandbox
 	}
 	lastMessagePath := filepath.Join(rt.Workspace(), ".skill-up", "codex-last-message.txt")

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -716,6 +716,76 @@ func TestCodexRun_MergesConfiguredEnvVars(t *testing.T) {
 	}
 }
 
+func TestCodexRun_SandboxFlagHonoursKwargAndRuntime(t *testing.T) {
+	t.Parallel()
+
+	stdout := `{"type":"thread.started","thread_id":"thread-123"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"done"}}
+{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}`
+
+	cases := []struct {
+		name        string
+		workspace   string // codexTestRuntime returns RequiresProcessSandbox() == (workspace != "opensandbox")
+		kwargs      map[string]string
+		wantFlag    string
+		notWantFlag string
+	}{
+		{
+			name:        "none runtime, no kwarg -> auto workspace-write",
+			workspace:   t.TempDir(),
+			kwargs:      nil,
+			wantFlag:    "--sandbox workspace-write",
+			notWantFlag: "--dangerously-bypass-approvals-and-sandbox",
+		},
+		{
+			name:        "none runtime, bypass_sandbox=true -> forced bypass",
+			workspace:   t.TempDir(),
+			kwargs:      map[string]string{KwargBypassSandbox: "true"},
+			wantFlag:    "--dangerously-bypass-approvals-and-sandbox",
+			notWantFlag: "--sandbox workspace-write",
+		},
+		{
+			name:        "opensandbox runtime, no kwarg -> bypass (unchanged)",
+			workspace:   "opensandbox",
+			kwargs:      nil,
+			wantFlag:    "--dangerously-bypass-approvals-and-sandbox",
+			notWantFlag: "--sandbox workspace-write",
+		},
+		{
+			name:        "none runtime, bypass_sandbox=garbage -> auto workspace-write (ParseBool fails)",
+			workspace:   t.TempDir(),
+			kwargs:      map[string]string{KwargBypassSandbox: "garbage"},
+			wantFlag:    "--sandbox workspace-write",
+			notWantFlag: "--dangerously-bypass-approvals-and-sandbox",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rt := &codexTestRuntime{
+				workspace:  tc.workspace,
+				execResult: runtime.ExecResult{Stdout: stdout, ExitCode: 0},
+			}
+			ag := NewCodexAgent(Config{Kwargs: tc.kwargs})
+			if _, err := ag.Run(context.Background(), rt, ExecOptions{}, []transcript.Message{{
+				Role:    transcript.RoleUser,
+				Content: "hi",
+				Turn:    1,
+			}}); err != nil {
+				t.Fatalf("Run failed: %v", err)
+			}
+			if !containsCommand(rt.commands, tc.wantFlag) {
+				t.Fatalf("no command contains %q; commands=%v", tc.wantFlag, rt.commands)
+			}
+			if containsCommand(rt.commands, tc.notWantFlag) {
+				t.Fatalf("commands unexpectedly contain %q; commands=%v", tc.notWantFlag, rt.commands)
+			}
+		})
+	}
+}
+
 func TestCodexRun_KeepsStreamFinalMessageWhenSessionHasNoFinalMessage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -53,6 +53,7 @@ func DetectAgentWithInitParams(engineName string, params credential.AgentInitPar
 		EnvVars:       make(map[string]string),
 		Kwargs:        kwargs,
 	}
+	logUnknownEngineKwargs(engineName, kwargs)
 
 	switch engineName {
 	case qoderCLIEngineAlias, qoderEngineAlias, qoderCLIEngineName:

--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -34,7 +34,9 @@ func DetectAgent(engineName string, cfg Config) (Agent, error) {
 }
 
 // DetectAgentWithInitParams maps resolved init params into an engine-specific agent config.
-func DetectAgentWithInitParams(engineName string, params credential.AgentInitParams) (Agent, error) {
+// kwargs carries engine.kwargs from eval.yaml (or --engine-kwarg overrides) and
+// is forwarded as-is to the agent; each agent reads only the keys it understands.
+func DetectAgentWithInitParams(engineName string, params credential.AgentInitParams, kwargs map[string]string) (Agent, error) {
 	model := params.Model
 	// "auto" is a QoderCLI-specific model tier; strip it for other engines
 	// so downstream agents don't need to hard-code awareness of it.
@@ -49,6 +51,7 @@ func DetectAgentWithInitParams(engineName string, params credential.AgentInitPar
 		APIKey:        params.APIKey,
 		BaseURL:       params.BaseURL,
 		EnvVars:       make(map[string]string),
+		Kwargs:        kwargs,
 	}
 
 	switch engineName {

--- a/internal/agent/kwargs.go
+++ b/internal/agent/kwargs.go
@@ -1,0 +1,29 @@
+package agent
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Recognised engine kwarg keys. Each agent reads only the keys it understands.
+const (
+	// KwargBypassSandbox asks the agent to skip its own process sandbox
+	// (e.g. codex's Landlock wrapper). Useful when the host runtime lacks
+	// the kernel features the agent's sandbox depends on.
+	KwargBypassSandbox = "bypass_sandbox"
+)
+
+// EngineKwargBool reads a boolean engine kwarg. Returns false when the key
+// is absent or the value cannot be parsed as a bool (per strconv.ParseBool:
+// "1", "t", "T", "true", "TRUE", "True" => true; "0", "f", "false" => false).
+func EngineKwargBool(kw map[string]string, key string) bool {
+	v, ok := kw[key]
+	if !ok {
+		return false
+	}
+	b, err := strconv.ParseBool(strings.TrimSpace(v))
+	if err != nil {
+		return false
+	}
+	return b
+}

--- a/internal/agent/kwargs.go
+++ b/internal/agent/kwargs.go
@@ -1,8 +1,11 @@
 package agent
 
 import (
+	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/alibaba/skill-up/internal/logging"
 )
 
 // Recognised engine kwarg keys. Each agent reads only the keys it understands.
@@ -12,6 +15,13 @@ const (
 	// the kernel features the agent's sandbox depends on.
 	KwargBypassSandbox = "bypass_sandbox"
 )
+
+// knownEngineKwargs is the project-wide set of recognised engine kwarg keys.
+// At least one agent in the project must honour or knowingly no-op on each
+// key listed here. Keys not in this set are likely typos.
+var knownEngineKwargs = map[string]struct{}{
+	KwargBypassSandbox: {},
+}
 
 // EngineKwargBool reads a boolean engine kwarg. Returns false when the key
 // is absent or the value cannot be parsed as a bool (per strconv.ParseBool:
@@ -26,4 +36,28 @@ func EngineKwargBool(kw map[string]string, key string) bool {
 		return false
 	}
 	return b
+}
+
+// logUnknownEngineKwargs emits a DEBUG line for each key in kwargs that is
+// not in knownEngineKwargs. Helps catch typos like "bypas_sandbox" (missing s)
+// or "bypass-sandbox" (wrong separator). Per-agent semantics (which agent
+// actually honours a key) are documented separately; this only flags keys
+// no agent in the project recognises.
+func logUnknownEngineKwargs(engineName string, kwargs map[string]string) {
+	if len(kwargs) == 0 {
+		return
+	}
+	unknown := make([]string, 0)
+	for key := range kwargs {
+		if _, ok := knownEngineKwargs[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) == 0 {
+		return
+	}
+	sort.Strings(unknown)
+	for _, key := range unknown {
+		logging.Debugf("engine kwarg %q is not a recognised key for agent %q; check spelling or see docs", key, engineName)
+	}
 }

--- a/internal/agent/kwargs_test.go
+++ b/internal/agent/kwargs_test.go
@@ -1,6 +1,11 @@
 package agent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/alibaba/skill-up/internal/logging"
+)
 
 func TestEngineKwargBool(t *testing.T) {
 	t.Parallel()
@@ -31,6 +36,72 @@ func TestEngineKwargBool(t *testing.T) {
 			t.Parallel()
 			if got := EngineKwargBool(tc.kw, tc.key); got != tc.want {
 				t.Errorf("EngineKwargBool(%v, %q) = %v, want %v", tc.kw, tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLogUnknownEngineKwargs(t *testing.T) {
+	// Not parallel: captureStdout redirects package-level log output, and
+	// logging verbosity is a process-global setting.
+	logging.SetVerbosity(1)
+	defer logging.SetVerbosity(0)
+
+	cases := []struct {
+		name       string
+		engineName string
+		kwargs     map[string]string
+		wantLogs   []string // substrings that must appear
+		notLogs    []string // substrings that must NOT appear
+	}{
+		{
+			name:       "nil kwargs emits nothing",
+			engineName: "codex",
+			kwargs:     nil,
+		},
+		{
+			name:       "empty kwargs emits nothing",
+			engineName: "codex",
+			kwargs:     map[string]string{},
+		},
+		{
+			name:       "all known keys emit nothing",
+			engineName: "codex",
+			kwargs:     map[string]string{KwargBypassSandbox: "true"},
+			notLogs:    []string{"not a recognised"},
+		},
+		{
+			name:       "unknown key triggers DEBUG",
+			engineName: "codex",
+			kwargs:     map[string]string{"bypas_sandbox": "true"}, // typo: missing s
+			wantLogs:   []string{`bypas_sandbox`, `codex`, "not a recognised"},
+		},
+		{
+			name:       "mixed: known stays quiet, unknown logs",
+			engineName: "claude_code",
+			kwargs:     map[string]string{KwargBypassSandbox: "true", "extra_args": "--foo"},
+			wantLogs:   []string{`extra_args`, `claude_code`, "not a recognised"},
+			notLogs:    []string{`bypass_sandbox`},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				logUnknownEngineKwargs(tc.engineName, tc.kwargs)
+			})
+			for _, want := range tc.wantLogs {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected log to contain %q, got: %s", want, out)
+				}
+			}
+			for _, no := range tc.notLogs {
+				if strings.Contains(out, no) {
+					t.Errorf("expected log NOT to contain %q, got: %s", no, out)
+				}
+			}
+			if len(tc.wantLogs) == 0 && len(tc.notLogs) == 0 && out != "" {
+				t.Errorf("expected no log output, got: %s", out)
 			}
 		})
 	}

--- a/internal/agent/kwargs_test.go
+++ b/internal/agent/kwargs_test.go
@@ -1,0 +1,37 @@
+package agent
+
+import "testing"
+
+func TestEngineKwargBool(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		kw   map[string]string
+		key  string
+		want bool
+	}{
+		{name: "nil map", kw: nil, key: KwargBypassSandbox, want: false},
+		{name: "missing key", kw: map[string]string{"other": "true"}, key: KwargBypassSandbox, want: false},
+		{name: "true lowercase", kw: map[string]string{KwargBypassSandbox: "true"}, key: KwargBypassSandbox, want: true},
+		{name: "True mixed case", kw: map[string]string{KwargBypassSandbox: "True"}, key: KwargBypassSandbox, want: true},
+		{name: "TRUE upper", kw: map[string]string{KwargBypassSandbox: "TRUE"}, key: KwargBypassSandbox, want: true},
+		{name: "numeric one", kw: map[string]string{KwargBypassSandbox: "1"}, key: KwargBypassSandbox, want: true},
+		{name: "t short", kw: map[string]string{KwargBypassSandbox: "t"}, key: KwargBypassSandbox, want: true},
+		{name: "false", kw: map[string]string{KwargBypassSandbox: "false"}, key: KwargBypassSandbox, want: false},
+		{name: "zero", kw: map[string]string{KwargBypassSandbox: "0"}, key: KwargBypassSandbox, want: false},
+		{name: "empty string", kw: map[string]string{KwargBypassSandbox: ""}, key: KwargBypassSandbox, want: false},
+		{name: "whitespace trimmed", kw: map[string]string{KwargBypassSandbox: "  true  "}, key: KwargBypassSandbox, want: true},
+		{name: "garbage", kw: map[string]string{KwargBypassSandbox: "garbage"}, key: KwargBypassSandbox, want: false},
+		{name: "yes not accepted", kw: map[string]string{KwargBypassSandbox: "yes"}, key: KwargBypassSandbox, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := EngineKwargBool(tc.kw, tc.key); got != tc.want {
+				t.Errorf("EngineKwargBool(%v, %q) = %v, want %v", tc.kw, tc.key, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -36,6 +36,8 @@ const (
 	runtimeKwargFlagName   = "runtime-kwarg"
 	runtimeKwargAlias      = "rk"
 	runtimeFlagName        = "runtime"
+	engineKwargFlagName    = "engine-kwarg"
+	engineKwargAlias       = "ek"
 )
 
 // validRuntimeTypes lists the environment.type values accepted by --runtime.
@@ -105,6 +107,7 @@ func init() {
 	runCmd.Flags().Int("parallelism", 0, "Override cases.parallelism. Must be between 1 and 256 when specified")
 	runCmd.Flags().SetNormalizeFunc(normalizeRunFlagName)
 	runCmd.Flags().StringArray(runtimeKwargFlagName, nil, "Environment kwarg in key=value format (can be used multiple times; --rk is accepted as an alias)")
+	runCmd.Flags().StringArray(engineKwargFlagName, nil, "Engine kwarg in key=value format (can be used multiple times; --ek is accepted as an alias). Recognised keys are per-agent (e.g. codex honours bypass_sandbox=true)")
 	runCmd.Flags().VarP(&verbose, "verbose", "v", "Increase log verbosity (-v or --verbose for debug, -vv or --verbose=2 for trace; --verbose=true/false is also supported)")
 	runCmd.Flags().Lookup("verbose").NoOptDefVal = "true"
 	runCmd.Flags().Int("iteration", 0, "Total number of evaluation runs. Each run writes artifacts to iteration-<N>. 0 = auto (appends after the last existing iteration). Default: auto")
@@ -242,7 +245,7 @@ func loadCredentialsAndAgent(cmd *cobra.Command, evalCfg *config.EvalConfig) (ag
 		cliAPIKey,
 	)
 
-	ag, err := agent.DetectAgentWithInitParams(evalCfg.Engine.Name, runnerParams)
+	ag, err := agent.DetectAgentWithInitParams(evalCfg.Engine.Name, runnerParams, evalCfg.Engine.Kwargs)
 	if err != nil {
 		return nil, nil, credential.AgentInitParams{}, fmt.Errorf("failed to create agent: %w", err)
 	}
@@ -495,6 +498,9 @@ func applyRunConfigOverrides(evalCfg *config.EvalConfig, cmd *cobra.Command) err
 	if err := applyRuntimeKwargOverrides(evalCfg, cmd); err != nil {
 		return err
 	}
+	if err := applyEngineKwargOverrides(evalCfg, cmd); err != nil {
+		return err
+	}
 	if err := applyRuntimeTypeOverride(evalCfg, cmd); err != nil {
 		return err
 	}
@@ -537,27 +543,39 @@ func applyUserConfigKwargs(ctx context.Context, evalCfg *config.EvalConfig) {
 }
 
 func applyRuntimeKwargOverrides(evalCfg *config.EvalConfig, cmd *cobra.Command) error {
-	runtimeKwargFlag := cmd.Flags().Lookup(runtimeKwargFlagName)
-	if runtimeKwargFlag == nil || !runtimeKwargFlag.Changed {
+	return applyMapKwargFlag(cmd, runtimeKwargFlagName, &evalCfg.Environment.Kwargs)
+}
+
+func applyEngineKwargOverrides(evalCfg *config.EvalConfig, cmd *cobra.Command) error {
+	return applyMapKwargFlag(cmd, engineKwargFlagName, &evalCfg.Engine.Kwargs)
+}
+
+// applyMapKwargFlag reads a repeatable key=value StringArray flag and merges
+// its values into the destination map (initialising it if nil). It is shared
+// by --runtime-kwarg and --engine-kwarg; both wrappers exist so callers and
+// error messages stay specific to their respective surfaces.
+func applyMapKwargFlag(cmd *cobra.Command, flagName string, dest *map[string]string) error {
+	flag := cmd.Flags().Lookup(flagName)
+	if flag == nil || !flag.Changed {
 		return nil
 	}
-	values, err := cmd.Flags().GetStringArray(runtimeKwargFlagName)
+	values, err := cmd.Flags().GetStringArray(flagName)
 	if err != nil {
-		return fmt.Errorf("read --runtime-kwarg: %w", err)
+		return fmt.Errorf("read --%s: %w", flagName, err)
 	}
 	if len(values) == 0 {
 		return nil
 	}
-	if evalCfg.Environment.Kwargs == nil {
-		evalCfg.Environment.Kwargs = map[string]string{}
+	if *dest == nil {
+		*dest = map[string]string{}
 	}
 	for _, value := range values {
 		key, val, ok := strings.Cut(value, "=")
 		key = strings.TrimSpace(key)
 		if !ok || key == "" {
-			return fmt.Errorf("invalid --runtime-kwarg %q: expected key=value", value)
+			return fmt.Errorf("invalid --%s %q: expected key=value", flagName, value)
 		}
-		evalCfg.Environment.Kwargs[key] = val
+		(*dest)[key] = val
 	}
 	return nil
 }
@@ -594,8 +612,11 @@ func applyRuntimeTypeOverride(evalCfg *config.EvalConfig, cmd *cobra.Command) er
 }
 
 func normalizeRunFlagName(_ *pflag.FlagSet, name string) pflag.NormalizedName {
-	if name == runtimeKwargAlias {
+	switch name {
+	case runtimeKwargAlias:
 		return pflag.NormalizedName(runtimeKwargFlagName)
+	case engineKwargAlias:
+		return pflag.NormalizedName(engineKwargFlagName)
 	}
 	return pflag.NormalizedName(name)
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -968,6 +968,50 @@ func TestApplyRunConfigOverrides_RuntimeKwargs(t *testing.T) {
 	}
 }
 
+func TestApplyRunConfigOverrides_EngineKwargs(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().SetNormalizeFunc(normalizeRunFlagName)
+	cmd.Flags().StringArray(runtimeKwargFlagName, nil, "")
+	cmd.Flags().StringArray(engineKwargFlagName, nil, "")
+	if err := cmd.Flags().Set("engine-kwarg", "bypass_sandbox=1"); err != nil {
+		t.Fatalf("set engine-kwarg: %v", err)
+	}
+	if err := cmd.Flags().Set("ek", "future_key=abc"); err != nil {
+		t.Fatalf("set ek: %v", err)
+	}
+
+	cfg := config.DefaultEvalConfig()
+	cfg.Engine.Kwargs = map[string]string{"bypass_sandbox": "0"}
+	if err := applyRunConfigOverrides(cfg, cmd); err != nil {
+		t.Fatalf("applyRunConfigOverrides: %v", err)
+	}
+	if got := cfg.Engine.Kwargs["bypass_sandbox"]; got != "1" {
+		t.Fatalf("bypass_sandbox kwarg = %q, want CLI override %q", got, "1")
+	}
+	if got := cfg.Engine.Kwargs["future_key"]; got != "abc" {
+		t.Fatalf("future_key kwarg = %q, want CLI value abc", got)
+	}
+}
+
+func TestApplyRunConfigOverrides_EngineKwargInvalid(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().SetNormalizeFunc(normalizeRunFlagName)
+	cmd.Flags().StringArray(runtimeKwargFlagName, nil, "")
+	cmd.Flags().StringArray(engineKwargFlagName, nil, "")
+	if err := cmd.Flags().Set("engine-kwarg", "no_equals_sign"); err != nil {
+		t.Fatalf("set engine-kwarg: %v", err)
+	}
+
+	cfg := config.DefaultEvalConfig()
+	if err := applyRunConfigOverrides(cfg, cmd); err == nil {
+		t.Fatal("expected error for malformed --engine-kwarg")
+	}
+}
+
 func TestApplyRunConfigOverrides_RuntimeType(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -125,6 +125,39 @@ report:
 	}
 }
 
+func TestLoader_LoadEvalConfig_EngineKwargs(t *testing.T) {
+	t.Parallel()
+
+	content := `schema_version: v1alpha1
+environment:
+  type: none
+engine:
+  name: codex
+  kwargs:
+    bypass_sandbox: "1"
+    future_key: ok
+cases:
+  files: []
+`
+
+	tmpDir := t.TempDir()
+	evalPath := filepath.Join(tmpDir, "eval.yaml")
+	if err := os.WriteFile(evalPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write temp eval.yaml: %v", err)
+	}
+
+	cfg, err := NewLoader(evalPath).LoadEvalConfig()
+	if err != nil {
+		t.Fatalf("LoadEvalConfig failed: %v", err)
+	}
+	if got := cfg.Engine.Kwargs["bypass_sandbox"]; got != "1" {
+		t.Errorf("engine.kwargs.bypass_sandbox = %q, want %q", got, "1")
+	}
+	if got := cfg.Engine.Kwargs["future_key"]; got != "ok" {
+		t.Errorf("engine.kwargs.future_key = %q, want %q", got, "ok")
+	}
+}
+
 // nolint:funlen // table-driven test cases drive the line count; splitting hurts readability.
 func TestLoader_LoadEvalConfig_PassThreshold(t *testing.T) {
 	t.Parallel()

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -97,6 +97,10 @@ type EngineConfig struct {
 	Version string      `yaml:"version,omitempty"`
 	Entry   string      `yaml:"entry,omitempty"`
 	Model   ModelConfig `yaml:"model"`
+	// Kwargs carries agent-specific key/value options. Each agent reads only
+	// the keys it understands; unknown keys are ignored. Recognised keys are
+	// documented per agent (e.g. codex honours "bypass_sandbox").
+	Kwargs map[string]string `yaml:"kwargs,omitempty"`
 }
 
 // ModelConfig describes the model to use.

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -627,7 +627,7 @@ func (e *defaultEvaluator) resolveJudgeAgent(ctx context.Context, judgeCfg confi
 	if e.evalCfg.Engine.Name != "" {
 		judgeParams := credential.ResolveJudgeInitParams(e.evalCfg.Engine.Name, judgeCfg, e.runnerParams, e.resolver)
 		var err error
-		judgeAgent, err = agentDetectWithInitParams(e.evalCfg.Engine.Name, judgeParams)
+		judgeAgent, err = agentDetectWithInitParams(e.evalCfg.Engine.Name, judgeParams, e.evalCfg.Engine.Kwargs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create judge agent: %w", err)
 		}

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -660,7 +660,7 @@ func TestExecuteCase_AgentTimeoutDoesNotInvokeAgentJudge(t *testing.T) {
 	})
 
 	origDetect := agentDetectWithInitParams
-	agentDetectWithInitParams = func(_ string, _ credential.AgentInitParams) (agent.Agent, error) {
+	agentDetectWithInitParams = func(_ string, _ credential.AgentInitParams, _ map[string]string) (agent.Agent, error) {
 		return judgeAgent, nil
 	}
 	defer func() { agentDetectWithInitParams = origDetect }()

--- a/skills/skill-upper/assets/eval.yaml.tmpl
+++ b/skills/skill-upper/assets/eval.yaml.tmpl
@@ -24,6 +24,8 @@ engine:
   #   provider: anthropic
   #   name: claude-sonnet-4-6
   #   base_url: ""
+  # kwargs:                         # agent-specific switches; see references/eval-yaml.md
+  #   bypass_sandbox: "true"        # codex: skip its own process sandbox (host kernel lacks Landlock)
 
 # mcp:
 #   servers:

--- a/skills/skill-upper/references/eval-yaml.md
+++ b/skills/skill-upper/references/eval-yaml.md
@@ -106,7 +106,7 @@ environment:
 
 ### `engine.kwargs` —— agent 私有开关
 
-`engine.kwargs` 是字符串键值对，每个 agent 只读取自己关心的 key，未知 key 静默忽略。CLI 等价开关：`--engine-kwarg key=value`（别名 `--ek`），可重复。优先级 `--engine-kwarg` > `engine.kwargs` > 缺省。
+`engine.kwargs` 是字符串键值对，每个 agent 只读取自己关心的 key，未知 key 被忽略。无人认识的 key（拼写错误，如 `bypas_sandbox`）会在 verbose 日志里打 DEBUG，`-v` 可见。CLI 等价开关：`--engine-kwarg key=value`（别名 `--ek`），可重复。优先级 `--engine-kwarg` > `engine.kwargs` > 缺省。
 
 ```yaml
 engine:

--- a/skills/skill-upper/references/eval-yaml.md
+++ b/skills/skill-upper/references/eval-yaml.md
@@ -104,6 +104,23 @@ environment:
 - `provider` / `name` 组合在 CLI 中形如 `anthropic/claude-sonnet-4-6`、`openai/gpt-4` 等。
 - `qodercli` 通常无需配置 `model`。
 
+### `engine.kwargs` —— agent 私有开关
+
+`engine.kwargs` 是字符串键值对，每个 agent 只读取自己关心的 key，未知 key 静默忽略。CLI 等价开关：`--engine-kwarg key=value`（别名 `--ek`），可重复。优先级 `--engine-kwarg` > `engine.kwargs` > 缺省。
+
+```yaml
+engine:
+  name: codex
+  kwargs:
+    bypass_sandbox: "true"
+```
+
+| key | agent | true 时行为 | 缺省 / false |
+|---|---|---|---|
+| `bypass_sandbox` | `codex` | 命令行强制 `--dangerously-bypass-approvals-and-sandbox`，覆盖根据 runtime 自动决定的 sandbox flag。用于宿主内核不支持 Landlock 的场景（典型：部分 CI 容器） | 维持现状：`none` runtime 用 `--sandbox workspace-write`，其它 runtime 已是 bypass |
+| `bypass_sandbox` | `claude_code` | no-op（claude 现有命令已固定 `--permission-mode=bypassPermissions`） | no-op |
+| `bypass_sandbox` | `qodercli` | no-op（qoder CLI 无对应 flag） | no-op |
+
 ## 常见错误
 
 - `opensandbox` 但未配置鉴权或 `base_url` → 运行时失败


### PR DESCRIPTION
## Summary

- Adds `engine.kwargs` (a `map[string]string`) and `--engine-kwarg key=value` / `--ek` CLI flags — agent-specific switch surface mirroring the existing `environment.kwargs` / `--runtime-kwarg`. Each agent reads only the keys it understands; unknown keys are silently ignored.
- First recognised key: **`bypass_sandbox`**. When true, the `codex` agent forces `--dangerously-bypass-approvals-and-sandbox` and skips its Rust `linux-sandbox` wrapper, regardless of what the runtime's `RequiresProcessSandbox()` reports. `claude_code` and `qodercli` accept the key but no-op.
- New shared helper `applyMapKwargFlag` backs both `--runtime-kwarg` and `--engine-kwarg` so parsing/error semantics stay in lockstep.

## Motivation

On Aone CI runners (and any host whose kernel/seccomp profile rejects Landlock setup), codex 0.80.0 panics on every shell call:

```
thread 'main' panicked at linux-sandbox/src/linux_run_main.rs:30:9:
error running landlock: Sandbox(LandlockRestrict)
```

Exit code 101 → all cases fail without ever touching the workspace. With `none` runtime, skill-up auto-picks `--sandbox workspace-write` based on `rt.RequiresProcessSandbox()`, and there was no way to override.

OpenSandbox / Docker runtimes already sidestep this (their `RequiresProcessSandbox()` returns `false`), but they require a remote service or local daemon. The kwarg path gives a third escape: keep `none` runtime, just tell codex to skip its own sandbox.

## Usage

```yaml
# evals/eval.yaml
engine:
  name: codex
  kwargs:
    bypass_sandbox: \"true\"
```

```bash
# Or as a one-off override
skill-up run evals/eval.yaml --engine-kwarg bypass_sandbox=true
# Alias
skill-up run evals/eval.yaml --ek bypass_sandbox=true
```

## Test plan

- [x] `make fmt && make verify && make test` all green locally
- [x] New unit tests:
  - `internal/agent/kwargs_test.go` — `EngineKwargBool` nil map / missing / true / 1 / TRUE / whitespace / garbage / yes / empty
  - `internal/agent/codex_test.go::TestCodexRun_SandboxFlagHonoursKwargAndRuntime` — 4 cases covering `none` runtime + no kwarg (→ workspace-write), `none` + bypass=true (→ bypass), opensandbox + no kwarg (→ bypass), `none` + garbage (→ workspace-write fallback)
  - `internal/agent/agent_test.go::TestDetectAgentWithInitParams_ForwardsKwargs` — factory plumbs kwargs into agent Config
  - `internal/config/loader_test.go::TestLoader_LoadEvalConfig_EngineKwargs` — YAML round-trip
  - `internal/cli/run_test.go::TestApplyRunConfigOverrides_EngineKwargs` + `_EngineKwargInvalid` — flag override + alias + malformed value
- [ ] Maintainers may want to verify on a real Landlock-blocked CI runner that `--engine-kwarg bypass_sandbox=true` unblocks codex (cannot reproduce in unit test sandbox)

## Notes

- `--runtime-kwarg`'s pairing with `userconfig.MergeKwargs` (per-runtime defaults from `~/.skill-up/config.yaml`) is **not** mirrored for `engine.kwargs` in this PR — it's a deliberate scope cut. Easy to add later if needed.
- Help text for `--engine-kwarg` mentions the example key. Docs updated: `docs/guide/writing-evals.md`, `skills/skill-upper/references/eval-yaml.md`, `skills/skill-upper/assets/eval.yaml.tmpl`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)