### PR TITLE
docs(changelog): record 0.2.3 engine.kwargs / bypass_sandbox release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.3] - 2026-05-27
 
 ### Added
 - `engine.kwargs` (CLI: `--engine-kwarg key=value`, alias `--ek`): an


### PR DESCRIPTION
## Summary

- Renames `## [Unreleased]` → `## [0.2.3] - 2026-05-27` in CHANGELOG.md.
- Single-line release header bump, no other content change.

## Why patch (0.2.3) and not minor (0.3.0)

The merged change set since v0.2.2 is one user-visible feat (#73 — `engine.kwargs` / `bypass_sandbox`), strictly additive and backward-compatible. Per project preference, treat as patch; keep 0.3.0 in reserve for a larger surface change.

## After merge

Maintainer tags `v0.2.3` on the merge commit; GoReleaser triggers on the tag.

## Test plan

- [x] CHANGELOG renders correctly (header is the only edit)
- [x] `make verify` passes (pre-commit hook ran golangci-lint, 0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)