### PR TITLE
refactor(agent): decouple nvm bootstrap from agent Run/InstallMCP commands

### DIFF
--- a/internal/agent/README.md
+++ b/internal/agent/README.md
@@ -79,6 +79,8 @@ export NVM_NODEJS_ORG_MIRROR=https://mirrors.aliyun.com/nodejs-release
 export NPM_CONFIG_REGISTRY=https://registry.npmmirror.com
 ```
 
+The bootstrap is invoked from `ensureNodeRuntime`, which runs as its **own** `rt.Exec` call before the agent invocation (or MCP install). The script's first line short-circuits with `exit 0` when the CLI binary (`claude`, `codex`) is already on `PATH`, so the happy-path cost is one `command -v` check. Splitting the bootstrap into a separate Exec keeps the agent run's stdout/stderr clean of nvm/curl noise and makes bootstrap failures distinguishable in errors (`node bootstrap failed: ...`) and traces.
+
 ## Agent Interface
 
 ```go

--- a/internal/agent/claude_code.go
+++ b/internal/agent/claude_code.go
@@ -71,15 +71,17 @@ func (a *ClaudeCodeAgent) Install(ctx context.Context, rt Runtime) error {
 
 // InstallMCP installs MCP servers with the Claude Code CLI.
 func (a *ClaudeCodeAgent) InstallMCP(ctx context.Context, rt Runtime, mcpCfg runtime.MCPConfig) error {
+	if len(mcpCfg.Servers) == 0 {
+		return nil
+	}
+	if err := ensureNodeRuntime(ctx, rt, "claude", ExecOptions{}); err != nil {
+		return err
+	}
 	return installMCPServers(ctx, rt, mcpCfg, buildClaudeMCPInstallCmd)
 }
 
 func buildClaudeMCPInstallCmd(server runtime.MCPServerConfig) (string, error) {
-	cmd, err := buildClaudeCompatibleMCPInstallCmd("claude", "claude-code", server)
-	if err != nil {
-		return "", err
-	}
-	return nodeRuntimeCommandWithGuard("claude", cmd), nil
+	return buildClaudeCompatibleMCPInstallCmd("claude", "claude-code", server)
 }
 
 func defaultClaudeCodeInstallCmd() string {
@@ -134,7 +136,10 @@ func (a *ClaudeCodeAgent) Run(ctx context.Context, rt Runtime, opts ExecOptions,
 	ctx = observability.ContextWithConfiguredAgentSpanAttributes(ctx, opts.Env)
 
 	instruction := BuildInstructionFromMessages(messages)
-	cmd := nodeRuntimeCommandWithGuard("claude", buildClaudePrintCmd(sessionID, a.effectiveModelName(ctx), instruction))
+	if err := ensureNodeRuntime(ctx, rt, "claude", opts); err != nil {
+		return nil, err
+	}
+	cmd := buildClaudePrintCmd(sessionID, a.effectiveModelName(ctx), instruction)
 
 	result, err := rt.Exec(ctx, cmd, opts)
 	sessionResult := a.buildSessionResult(ctx, rt, opts, instruction, start, result)

--- a/internal/agent/claude_code.go
+++ b/internal/agent/claude_code.go
@@ -137,7 +137,12 @@ func (a *ClaudeCodeAgent) Run(ctx context.Context, rt Runtime, opts ExecOptions,
 
 	instruction := BuildInstructionFromMessages(messages)
 	if err := ensureNodeRuntime(ctx, rt, "claude", opts); err != nil {
-		return nil, err
+		return &SessionResult{
+			Engine:     a.Name(),
+			ExitCode:   1,
+			DurationMs: time.Since(start).Milliseconds(),
+			Artifacts:  &SessionArtifacts{},
+		}, err
 	}
 	cmd := buildClaudePrintCmd(sessionID, a.effectiveModelName(ctx), instruction)
 

--- a/internal/agent/claude_code_test.go
+++ b/internal/agent/claude_code_test.go
@@ -746,6 +746,12 @@ func (r *claudeCodeTestRuntime) Exec(_ context.Context, command string, opts run
 		}
 		return runtime.ExecResult{Stdout: stdout}, nil
 	}
+	// ensureNodeRuntime emits a script whose first conditional short-circuits
+	// when claude is already on PATH. Treat it as a no-op success so the
+	// subsequent agent-command Exec is what tests observe via lastCommand.
+	if strings.Contains(command, "if command -v 'claude' >/dev/null 2>&1; then exit 0; fi") {
+		return runtime.ExecResult{ExitCode: 0}, nil
+	}
 	r.lastCommand = command
 	r.execCount++
 	if r.execCount == 1 {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -256,7 +256,12 @@ func (a *CodexAgent) Run(ctx context.Context, rt Runtime, opts ExecOptions, mess
 	ctx = observability.ContextWithConfiguredAgentSpanAttributes(ctx, opts.Env)
 
 	if err := ensureNodeRuntime(ctx, rt, codexEngineName, opts); err != nil {
-		return nil, err
+		return &SessionResult{
+			Engine:     a.Name(),
+			ExitCode:   1,
+			DurationMs: time.Since(start).Milliseconds(),
+			Artifacts:  &SessionArtifacts{},
+		}, err
 	}
 	cmd := "mkdir -p " + shellQuote(filepath.Dir(lastMessagePath)) + "\n" +
 		buildCodexRunCmdWithLastMessage(instruction, a.effectiveModelName(ctx), a.runProviderConfig(ctx), sandboxFlag, lastMessagePath)

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -97,6 +97,12 @@ func (a *CodexAgent) Install(ctx context.Context, rt Runtime) error {
 
 // InstallMCP installs MCP servers with the Codex CLI.
 func (a *CodexAgent) InstallMCP(ctx context.Context, rt Runtime, mcpCfg runtime.MCPConfig) error {
+	if len(mcpCfg.Servers) == 0 {
+		return nil
+	}
+	if err := ensureNodeRuntime(ctx, rt, codexEngineName, ExecOptions{}); err != nil {
+		return err
+	}
 	return installMCPServers(ctx, rt, mcpCfg, buildCodexMCPInstallCmd)
 }
 
@@ -142,7 +148,7 @@ func buildCodexMCPInstallCmd(server runtime.MCPServerConfig) (string, error) {
 	default:
 		return "", fmt.Errorf("mcp server %q transport %q is not supported by codex", server.Name, server.Transport)
 	}
-	return nodeRuntimeCommandWithGuard("codex", cmd.String()), nil
+	return cmd.String(), nil
 }
 
 func buildCodexMCPRemoteInstallCmd(server runtime.MCPServerConfig) (string, error) {
@@ -177,7 +183,7 @@ func buildCodexMCPRemoteInstallCmd(server runtime.MCPServerConfig) (string, erro
 		return "", fmt.Errorf("mcp server %q endpoint is invalid: %w", server.Name, err)
 	}
 	cmd.WriteString(endpoint)
-	return nodeRuntimeCommandWithGuard("codex", cmd.String()), nil
+	return cmd.String(), nil
 }
 
 func buildCodexMCPRemoteBridgeScript(server runtime.MCPServerConfig) (string, error) {
@@ -244,12 +250,16 @@ func (a *CodexAgent) Run(ctx context.Context, rt Runtime, opts ExecOptions, mess
 		sandboxFlag = codexProcessSandbox
 	}
 	lastMessagePath := filepath.Join(rt.Workspace(), ".skill-up", "codex-last-message.txt")
-	cmd := "mkdir -p " + shellQuote(filepath.Dir(lastMessagePath)) + "\n" +
-		nodeRuntimeCommandWithGuard("codex", buildCodexRunCmdWithLastMessage(instruction, a.effectiveModelName(ctx), a.runProviderConfig(ctx), sandboxFlag, lastMessagePath))
 
 	envVars := a.credentialEnvVars(credential.EnvOpenAIAPIKey, credential.EnvOpenAIBaseURL)
 	opts = a.mergeExecOptionsEnv(ctx, opts, envVars, a.buildAgentObservabilityAttrs(nil))
 	ctx = observability.ContextWithConfiguredAgentSpanAttributes(ctx, opts.Env)
+
+	if err := ensureNodeRuntime(ctx, rt, codexEngineName, opts); err != nil {
+		return nil, err
+	}
+	cmd := "mkdir -p " + shellQuote(filepath.Dir(lastMessagePath)) + "\n" +
+		buildCodexRunCmdWithLastMessage(instruction, a.effectiveModelName(ctx), a.runProviderConfig(ctx), sandboxFlag, lastMessagePath)
 
 	result, err := rt.Exec(ctx, cmd, opts)
 	sessionResult := a.buildSessionResult(ctx, rt, opts, instruction, start, result, lastMessagePath)

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -999,6 +999,14 @@ func (r *codexTestRuntime) Exec(_ context.Context, command string, opts runtime.
 		}
 		return runtime.ExecResult{Stdout: stdout}, nil
 	}
+	// ensureNodeRuntime emits a script whose first conditional short-circuits
+	// when codex is already on PATH. Treat it as a no-op success so the
+	// subsequent agent-command Exec is what tests observe via lastCommand /
+	// execResult — otherwise the bootstrap call would consume the configured
+	// non-zero exit codes meant for the codex invocation.
+	if strings.Contains(command, "if command -v 'codex' >/dev/null 2>&1; then exit 0; fi") {
+		return runtime.ExecResult{ExitCode: 0}, nil
+	}
 	r.commands = append(r.commands, command)
 	r.lastCommand = command
 	if strings.Contains(command, "SKILL_UP_CODEX_THREAD_ID") {

--- a/internal/agent/mcp.go
+++ b/internal/agent/mcp.go
@@ -30,7 +30,9 @@ func installMCPServers(ctx context.Context, rt Runtime, mcpCfg runtime.MCPConfig
 		}
 		// ExecOptions.Env exposes auth values to the one-shot install process.
 		// Agent CLI --env flags persist selected variables into the registered
-		// MCP server config so future tool calls can read them.
+		// MCP server config so future tool calls can read them. PATH flows
+		// from the runtime baseline (populated by Install's probeAndMergePATH)
+		// rather than being injected here.
 		result, err := rt.Exec(ctx, cmd, ExecOptions{Env: server.Env})
 		if err != nil {
 			return fmt.Errorf("failed to install MCP server %s: %w", server.Name, err)

--- a/internal/agent/node_install.go
+++ b/internal/agent/node_install.go
@@ -1,6 +1,15 @@
 package agent
 
-import "strings"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// errEnsureNodeRuntimeNoCLI is returned when ensureNodeRuntime is called
+// without a CLI binary name to guard against — a programming error.
+var errEnsureNodeRuntimeNoCLI = errors.New("ensureNodeRuntime: cliBin must not be empty")
 
 const (
 	agentNodeDefaultVersion = "22"
@@ -61,26 +70,29 @@ func nodeBootstrapLines(nodeVersion string) []string {
 	}
 }
 
-func nodeRuntimeCommand(command string) string {
-	return nodeRuntimeCommandWithGuard("", command)
-}
-
-// nodeRuntimeCommandWithGuard wraps command with the Node/nvm bootstrap,
-// but skips the bootstrap entirely when cliBin is already on PATH. This lets
-// host-style runtimes (environment.type: none) reuse a locally-installed
-// claude / codex without forcing an nvm switch.
-func nodeRuntimeCommandWithGuard(cliBin, command string) string {
-	lines := []string{"set -e"}
-	bootstrap := nodeBootstrapLines(agentNodeDefaultVersion)
+// ensureNodeRuntime runs the nvm/Node bootstrap as a standalone Exec call,
+// separate from the agent invocation that follows. When cliBin is already on
+// PATH the script short-circuits with `exit 0` and produces no output, so the
+// happy-path cost is one extra `command -v` check. Errors are wrapped with a
+// `node bootstrap failed` prefix so they're distinguishable from agent run
+// failures in result handling and signal detectors.
+func ensureNodeRuntime(ctx context.Context, rt Runtime, cliBin string, opts ExecOptions) error {
 	if cliBin == "" {
-		lines = append(lines, bootstrap...)
-	} else {
-		lines = append(lines, "if ! command -v "+shellQuote(cliBin)+" >/dev/null 2>&1; then")
-		for _, l := range bootstrap {
-			lines = append(lines, "  "+l)
-		}
-		lines = append(lines, "fi")
+		return errEnsureNodeRuntimeNoCLI
 	}
-	lines = append(lines, command)
-	return strings.Join(lines, "\n")
+	lines := []string{
+		"set -e",
+		"if command -v " + shellQuote(cliBin) + " >/dev/null 2>&1; then exit 0; fi",
+	}
+	lines = append(lines, nodeBootstrapLines(agentNodeDefaultVersion)...)
+	script := strings.Join(lines, "\n")
+
+	result, err := rt.Exec(ctx, script, opts)
+	if err != nil {
+		return fmt.Errorf("node bootstrap failed: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("node bootstrap failed (exit %d): %s", result.ExitCode, result.Stderr)
+	}
+	return nil
 }

--- a/internal/agent/node_install_test.go
+++ b/internal/agent/node_install_test.go
@@ -1,8 +1,12 @@
 package agent
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/alibaba/skill-up/internal/runtime"
 )
 
 func TestNodeBootstrapLines(t *testing.T) {
@@ -44,30 +48,94 @@ func TestNodeBootstrapLinesUsesDefaultVersion(t *testing.T) {
 	}
 }
 
-func TestNodeRuntimeCommandGuardSkipsBootstrapWhenCLIPresent(t *testing.T) {
+func TestEnsureNodeRuntime_ScriptShape(t *testing.T) {
 	t.Parallel()
 
-	cmd := nodeRuntimeCommandWithGuard("claude", "claude --help")
-	if !strings.Contains(cmd, "if ! command -v 'claude' >/dev/null 2>&1; then") {
-		t.Fatalf("guarded runtime command missing CLI guard:\n%s", cmd)
+	rt := &nodeBootstrapTestRuntime{result: runtime.ExecResult{ExitCode: 0}}
+	if err := ensureNodeRuntime(context.Background(), rt, "claude", ExecOptions{}); err != nil {
+		t.Fatalf("ensureNodeRuntime returned error: %v", err)
 	}
-	// Bootstrap must live inside the guarded block, not at top level — verify
-	// the trailing `fi` precedes the actual command invocation.
-	guardClose := strings.Index(cmd, "\nfi\n")
-	cmdIdx := strings.Index(cmd, "claude --help")
-	if guardClose < 0 || cmdIdx < guardClose {
-		t.Fatalf("guarded runtime command should run cli after closing the guard block:\n%s", cmd)
+	if len(rt.commands) != 1 {
+		t.Fatalf("expected 1 Exec call, got %d: %v", len(rt.commands), rt.commands)
 	}
-}
-
-func TestNodeRuntimeCommandWithoutGuardKeepsBootstrap(t *testing.T) {
-	t.Parallel()
-
-	cmd := nodeRuntimeCommand("echo hi")
-	if strings.Contains(cmd, "if ! command -v") && strings.Contains(cmd, ">/dev/null 2>&1; then\n  export NVM_DIR") {
-		t.Fatalf("unguarded runtime command should not wrap bootstrap in a CLI guard:\n%s", cmd)
+	cmd := rt.commands[0]
+	// The guard short-circuit must precede the bootstrap so it never executes
+	// when the CLI is already on PATH.
+	if !strings.HasPrefix(cmd, "set -e\nif command -v 'claude' >/dev/null 2>&1; then exit 0; fi\n") {
+		t.Fatalf("bootstrap script missing CLI short-circuit at top:\n%s", cmd)
 	}
 	if !strings.Contains(cmd, "nvm install '"+agentNodeDefaultVersion+"'") {
-		t.Fatalf("unguarded runtime command should still emit bootstrap:\n%s", cmd)
+		t.Fatalf("bootstrap script missing nvm install:\n%s", cmd)
 	}
 }
+
+func TestEnsureNodeRuntime_WrapsExecError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("network down")
+	rt := &nodeBootstrapTestRuntime{err: sentinel}
+	err := ensureNodeRuntime(context.Background(), rt, "claude", ExecOptions{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected wrapped sentinel error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "node bootstrap failed") {
+		t.Fatalf("expected 'node bootstrap failed' prefix, got %v", err)
+	}
+}
+
+func TestEnsureNodeRuntime_WrapsNonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	rt := &nodeBootstrapTestRuntime{result: runtime.ExecResult{ExitCode: 7, Stderr: "checksum mismatch"}}
+	err := ensureNodeRuntime(context.Background(), rt, "codex", ExecOptions{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "node bootstrap failed") {
+		t.Fatalf("expected 'node bootstrap failed' prefix, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected stderr to be surfaced, got %v", err)
+	}
+}
+
+func TestEnsureNodeRuntime_RejectsEmptyCLIBin(t *testing.T) {
+	t.Parallel()
+
+	rt := &nodeBootstrapTestRuntime{}
+	if err := ensureNodeRuntime(context.Background(), rt, "", ExecOptions{}); err == nil {
+		t.Fatal("expected error when cliBin is empty")
+	}
+	if len(rt.commands) != 0 {
+		t.Fatalf("expected no Exec calls when cliBin is empty, got %v", rt.commands)
+	}
+}
+
+type nodeBootstrapTestRuntime struct {
+	commands []string
+	result   runtime.ExecResult
+	err      error
+}
+
+func (r *nodeBootstrapTestRuntime) Create(context.Context) error { return nil }
+func (r *nodeBootstrapTestRuntime) Close() error                 { return nil }
+func (r *nodeBootstrapTestRuntime) Start(context.Context) error  { return nil }
+func (r *nodeBootstrapTestRuntime) Stop(context.Context) error   { return nil }
+func (r *nodeBootstrapTestRuntime) UploadFile(context.Context, string, string) error {
+	return nil
+}
+func (r *nodeBootstrapTestRuntime) UploadDir(context.Context, string, string) error { return nil }
+func (r *nodeBootstrapTestRuntime) DownloadFile(context.Context, string, string) error {
+	return nil
+}
+func (r *nodeBootstrapTestRuntime) DownloadDir(context.Context, string, string) error { return nil }
+func (r *nodeBootstrapTestRuntime) Exec(_ context.Context, command string, _ runtime.ExecOptions) (runtime.ExecResult, error) {
+	r.commands = append(r.commands, command)
+	return r.result, r.err
+}
+func (r *nodeBootstrapTestRuntime) Workspace() string            { return "/workspace" }
+func (r *nodeBootstrapTestRuntime) RequiresProcessSandbox() bool { return false }
+func (r *nodeBootstrapTestRuntime) MergeEnv(map[string]string)   {}


### PR DESCRIPTION
## Summary

Splits the nvm/Node bootstrap and the agent invocation into two distinct `rt.Exec` calls so failures can be cleanly attributed and the agent's stderr buffer stays free of bootstrap noise.

Fixes #72

## Problem

`nodeRuntimeCommandWithGuard` (`internal/agent/node_install.go`) packed the bootstrap and the agent's real command (`claude -p`, `codex exec --json`, `claude mcp add`, `codex mcp add`) into a single multi-line shell script handed to one `rt.Exec` call. Consequences:

- Bootstrap failures (curl timeout to the nvm installer, sha256 mismatch, `nvm install` errors against an offline mirror) surfaced as `claude-code run failed: ...` / `codex run failed: ...`. Hard to triage without reading the wrapped script.
- Bootstrap stderr was concatenated into `result.Stderr`, which is then scanned by `providerAuthFailureSignal` / `providerRateLimitSignal` — widening their false-positive surface.
- Bootstrap stdout could prepend `stdout.json` artifacts.
- Bootstrap re-fired silently at Run time when `Install` failed or wasn't called, masking what should be a clear "Install was never called" failure.

## Fix

New `ensureNodeRuntime(ctx, rt, cliBin, opts)` helper runs only the bootstrap as its own `rt.Exec`. The script's first line short-circuits with `exit 0` when `command -v <cli>` succeeds, so the happy path is one extra `command -v` check with no output.

| Call site (before) | After |
|---|---|
| `claude_code.go:127` `nodeRuntimeCommandWithGuard("claude", ...)` (Run) | `ensureNodeRuntime` → Exec |
| `claude_code.go:72` `nodeRuntimeCommandWithGuard("claude", ...)` (MCP) | `InstallMCP` calls `ensureNodeRuntime` once before the per-server loop |
| `codex.go:236` (Run) | `ensureNodeRuntime` → Exec |
| `codex.go:136`, `:171` (MCP stdio / http+bridge) | wrap-once in `InstallMCP` |

`nodeRuntimeCommandWithGuard` and `nodeRuntimeCommand` are removed — no remaining production callers. `qodercli` is untouched (it never used the wrapper).

Errors from `ensureNodeRuntime` wrap with `node bootstrap failed: ...` so they're trivially distinguishable from agent run failures in result handling and signal detectors. Bootstrap stderr no longer reaches `result.Stderr` of the agent Exec.

A follow-up commit (`de46509`) preserves the existing convention of returning a non-nil `SessionResult{Engine, ExitCode: 1, DurationMs}` on bootstrap failure, so the evaluator still records telemetry for failed cases.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `make verify` (gofmt + vet + revive + golangci-lint, 0 issues)
- [x] New tests in `internal/agent/node_install_test.go`: script shape (CLI short-circuit at top), Exec-error wrapping, non-zero-exit wrapping with stderr surfacing, empty-cliBin guard
- [x] Updated fake runtimes (`claudeCodeTestRuntime`, `codexTestRuntime`) recognize bootstrap commands by content sniffing and short-circuit them so existing `lastCommand` / `execResult` assertions still observe the agent command
- [ ] Manual smoke: run an eval with claude-code and verify trace shows two distinct `rt.Exec` calls (bootstrap + run) and that `stdout.json` contains only stream-json from claude
- [ ] Negative smoke: set `NVM_SOURCE` to an unreachable host; failure should report `node bootstrap failed:` rather than `claude-code run failed:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)