### PR TITLE
fix(runner): report skill name from SKILL.md frontmatter, not dir basename

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -2,9 +2,11 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -171,6 +173,14 @@ func (l *Loader) SkillDir() string {
 	return l.skillDir
 }
 
+// SkillName returns the skill's declared name from the `name:` field of
+// SKILL.md's YAML frontmatter in the resolved skill directory. It returns
+// ("", false) when SKILL.md is absent, lacks YAML frontmatter, or declares no
+// name — callers should fall back to the directory basename in that case.
+func (l *Loader) SkillName() (string, bool) {
+	return parseSkillName(l.skillDir)
+}
+
 // CasesDir returns the path to the cases directory.
 func (l *Loader) CasesDir() string {
 	return filepath.Join(l.skillDir, evalsSubdir, casesSubdir)
@@ -209,4 +219,66 @@ func FindSkillDir(startDir string) (string, bool) {
 	}
 
 	return filepath.Dir(startDir), true
+}
+
+// skillFrontmatter holds the fields skill-up reads from a SKILL.md YAML
+// frontmatter block. Only the name is needed today.
+type skillFrontmatter struct {
+	Name string `yaml:"name"`
+}
+
+// parseSkillName reads SKILL.md from skillDir and extracts the `name` field of
+// its YAML frontmatter. It returns ("", false) when the file is missing, has no
+// frontmatter fence, fails to parse, or declares an empty name.
+func parseSkillName(skillDir string) (string, bool) {
+	data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		return "", false
+	}
+
+	fm, ok := extractFrontmatter(data)
+	if !ok {
+		return "", false
+	}
+
+	var meta skillFrontmatter
+	if err := yaml.Unmarshal(fm, &meta); err != nil {
+		return "", false
+	}
+
+	name := strings.TrimSpace(meta.Name)
+	if name == "" {
+		return "", false
+	}
+
+	return name, true
+}
+
+// extractFrontmatter returns the bytes of the leading YAML frontmatter block
+// delimited by a `---` fence at the very start of the document and the next
+// `---` line. It returns (nil, false) when the content does not open with a
+// frontmatter fence or the closing fence is missing, so the markdown body is
+// never fed to the YAML parser.
+func extractFrontmatter(data []byte) ([]byte, bool) {
+	lines := bytes.Split(data, []byte("\n"))
+
+	// Require the very first line to be a `---` fence (trailing whitespace/CR
+	// tolerated), then return everything up to the next fence.
+	if len(lines) == 0 || !isFence(lines[0]) {
+		return nil, false
+	}
+
+	for i := 1; i < len(lines); i++ {
+		if isFence(lines[i]) {
+			return bytes.Join(lines[1:i], []byte("\n")), true
+		}
+	}
+
+	return nil, false
+}
+
+// isFence reports whether a line is a `---` frontmatter fence, tolerating a
+// trailing carriage return and surrounding whitespace.
+func isFence(line []byte) bool {
+	return string(bytes.TrimRight(line, " \t\r")) == "---"
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -752,3 +752,70 @@ func TestLoader_SkillDirSearchDepthLimit(t *testing.T) {
 		t.Errorf("expected depth-limited fallback SkillDir '%s', got '%s'", want, loader.SkillDir())
 	}
 }
+
+func TestLoader_SkillName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		skillMD   *string // nil => no SKILL.md file written
+		wantName  string
+		wantFound bool
+	}{
+		{
+			name:      "frontmatter name differs from dir basename",
+			skillMD:   strPtr("---\nname: code-stats\ndescription: stuff\n---\n\n# Body\n"),
+			wantName:  "code-stats",
+			wantFound: true,
+		},
+		{
+			name:      "frontmatter without name field",
+			skillMD:   strPtr("---\ndescription: stuff\n---\n\n# Body\n"),
+			wantName:  "",
+			wantFound: false,
+		},
+		{
+			name:      "empty name value",
+			skillMD:   strPtr("---\nname: \"\"\n---\n"),
+			wantName:  "",
+			wantFound: false,
+		},
+		{
+			name:      "no frontmatter fence",
+			skillMD:   strPtr("# Just a heading\n"),
+			wantName:  "",
+			wantFound: false,
+		},
+		{
+			name:      "missing SKILL.md",
+			skillMD:   nil,
+			wantName:  "",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Use a directory basename that never matches a frontmatter name,
+			// so a non-fallback result must come from SKILL.md.
+			skillDir := filepath.Join(t.TempDir(), "dir-basename")
+			if err := os.MkdirAll(skillDir, 0o755); err != nil {
+				t.Fatalf("failed to create skill dir: %v", err)
+			}
+			if tt.skillMD != nil {
+				if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(*tt.skillMD), 0o600); err != nil {
+					t.Fatalf("failed to write SKILL.md: %v", err)
+				}
+			}
+
+			loader := &Loader{skillDir: skillDir}
+			gotName, gotFound := loader.SkillName()
+			if gotName != tt.wantName || gotFound != tt.wantFound {
+				t.Errorf("SkillName() = (%q, %t), want (%q, %t)", gotName, gotFound, tt.wantName, tt.wantFound)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -107,6 +107,15 @@ func (r *Runner) Evaluate(ctx context.Context, cases []*config.CaseConfig, ag ag
 		cwd, _ := os.Getwd()
 		skillName = filepath.Base(cwd)
 	}
+	// reportName is the identity shown in reports (result.json, benchmark,
+	// JUnit, HTML). It prefers the authoritative `name` from SKILL.md
+	// frontmatter and falls back to the directory basename (skillName) when
+	// SKILL.md is missing or declares no name. The dir-based skillName is kept
+	// for the workspace layout below so existing paths are unaffected.
+	reportName := skillName
+	if name, ok := r.loader.SkillName(); ok {
+		reportName = name
+	}
 	concurrency := r.evalCfg.Cases.Parallelism
 
 	workspaceDir := opts.OutputDir
@@ -142,7 +151,7 @@ func (r *Runner) Evaluate(ctx context.Context, cases []*config.CaseConfig, ag ag
 		logging.DebugContextf(ctx, "Runner: benchmark=%t concurrency=%d output_dir=%s iteration=%d", r.evalCfg.Benchmark.Enabled, concurrency, workspaceDir, runNumber)
 
 		ev := newEvaluator(evaluator.EvalOptions{
-			SkillName:       skillName,
+			SkillName:       reportName,
 			SkillDir:        skillDir,
 			EvalCfg:         r.evalCfg,
 			Loader:          r.loader,
@@ -163,7 +172,7 @@ func (r *Runner) Evaluate(ctx context.Context, cases []*config.CaseConfig, ag ag
 		allResults = append(allResults, results...)
 		r.endTime = time.Now()
 
-		if err := r.WriteResults(ctx, results, skillName, skillDir, runNumber, opts.Formats); err != nil {
+		if err := r.WriteResults(ctx, results, reportName, skillDir, runNumber, opts.Formats); err != nil {
 			logging.WarnContextf(ctx, "Runner: failed to write results for run %d: %v", runNumber, err)
 		}
 	}


### PR DESCRIPTION
## Problem

Evaluation reports (`result.json`, `benchmark.json`/`.md`, JUnit class name, HTML title) derived the skill name from the **skill directory's basename** via `filepath.Base(...)` in [`internal/runner/runner.go`](internal/runner/runner.go). The authoritative `name:` field in `SKILL.md`'s YAML frontmatter was never parsed anywhere in the codebase (`FindSkillDir` only `os.Stat`s the file for existence). So a skill whose directory name differs from its declared `name` showed the wrong identity in every report.

## Fix

- Add `Loader.SkillName()` in [`internal/config/loader.go`](internal/config/loader.go), which extracts the `name` field from `SKILL.md`'s YAML frontmatter. It returns `("", false)` when `SKILL.md` is missing, has no frontmatter fence, fails to parse, or declares an empty name.
- The runner derives a separate `reportName` that prefers the frontmatter name and **falls back to the directory basename** otherwise, then uses it for the report-facing consumers (`newEvaluator` and `WriteResults`).

## No impact on existing functional links

The dir-based name is **retained** for the workspace layout (`<skill>-workspace`) and the install paths — only the *reported* identity changed. When `SKILL.md` has no `name` (or is absent), behavior is identical to before.

## Tests

- `TestLoader_SkillName` (table-driven): frontmatter name differs from dir / no name field / empty name / no frontmatter fence / missing `SKILL.md`.
- Manually verified end-to-end: a skill in dir `tmp-xyz` with `name: code-stats` reports `code-stats` while the workspace dir stays `tmp-xyz-workspace`.
- `go build ./...`, `go vet`, `gofmt`, and `go test ./internal/config/... ./internal/runner/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)