### PR TITLE
refactor(custom-engine): share ${...} token parsing between config and agent resolvers (#50)

### DIFF
--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -1147,37 +1147,29 @@ func renderTemplate(s string, vars map[string]string) (string, error) {
 }
 
 func resolveTemplateToken(inner string, vars map[string]string) (string, error) {
-	name := inner
-	var defaultVal, errMsg string
-	hasDefault, hasErrForm := false, false
-	if before, after, found := strings.Cut(inner, ":-"); found {
-		name, defaultVal, hasDefault = before, after, true
-	} else if before, after, found := strings.Cut(inner, "?"); found {
-		name, errMsg, hasErrForm = before, after, true
-	}
+	// Share the ${X} / ${X:-default} / ${X?msg} grammar with the config-load-time
+	// resolver (config.resolveEnvToken) so the two cannot drift apart.
+	tok := config.ParseTemplateToken(inner)
 
-	if v, ok := vars[name]; ok {
+	if v, ok := vars[tok.Name]; ok {
 		// A present-but-empty built-in value (e.g. an unconfigured api_key)
 		// is treated as unset so ${X:-default} and ${X?msg} still apply.
-		if v != "" || (!hasDefault && !hasErrForm) {
+		if v != "" || (!tok.HasDefault && !tok.HasErrForm) {
 			return v, nil
 		}
 	}
-	if v := os.Getenv(name); v != "" {
+	if v := os.Getenv(tok.Name); v != "" {
 		return v, nil
 	}
-	if hasDefault {
-		return defaultVal, nil
+	if tok.HasDefault {
+		return tok.Default, nil
 	}
-	if hasErrForm {
-		if strings.TrimSpace(errMsg) == "" {
-			errMsg = name + " is required"
-		}
-		return "", errors.New(errMsg)
+	if tok.HasErrForm {
+		return "", tok.RequiredErr()
 	}
 	// kwargs.<key> references that were not provided resolve to empty.
-	if strings.HasPrefix(name, "kwargs.") {
+	if strings.HasPrefix(tok.Name, "kwargs.") {
 		return "", nil
 	}
-	return "", fmt.Errorf("unresolved template variable %q", name)
+	return "", fmt.Errorf("unresolved template variable %q", tok.Name)
 }

--- a/internal/config/customengine.go
+++ b/internal/config/customengine.go
@@ -472,49 +472,39 @@ func resolveEnvRefsWith(s string, rejectSecrets bool) (string, error) {
 //
 //revive:disable-next-line:flag-parameter
 func resolveEnvToken(inner string, rejectSecrets bool) (value string, leaveIntact bool, err error) {
-	name := inner
-	var defaultVal, errMsg string
-	hasDefault, hasErrForm := false, false
-	if before, after, found := strings.Cut(inner, ":-"); found {
-		name, defaultVal, hasDefault = before, after, true
-	} else if before, after, found := strings.Cut(inner, "?"); found {
-		name, errMsg, hasErrForm = before, after, true
-	}
+	tok := ParseTemplateToken(inner)
 
-	if IsBuiltinTemplateVar(name) {
-		if rejectSecrets && isSensitiveTemplateVar(name) {
+	if IsBuiltinTemplateVar(tok.Name) {
+		if rejectSecrets && isSensitiveTemplateVar(tok.Name) {
 			return "", false, fmt.Errorf(
 				"secret-like template variable ${%s} must not be referenced in a command line; pass credentials via engine.custom.env instead",
-				name,
+				tok.Name,
 			)
 		}
 		return "", true, nil
 	}
 
-	if rejectSecrets && isSensitiveEnvName(name) {
+	if rejectSecrets && isSensitiveEnvName(tok.Name) {
 		return "", false, fmt.Errorf(
 			"secret-like environment variable %q must not be referenced in a command line; pass credentials via engine.custom.env instead",
-			name,
+			tok.Name,
 		)
 	}
 
-	if v := os.Getenv(name); v != "" {
-		if err := rejectIfSecretLiteral(name, v, rejectSecrets, false); err != nil {
+	if v := os.Getenv(tok.Name); v != "" {
+		if err := rejectIfSecretLiteral(tok.Name, v, rejectSecrets, false); err != nil {
 			return "", false, err
 		}
 		return v, false, nil
 	}
-	if hasDefault {
-		if err := rejectIfSecretLiteral(name, defaultVal, rejectSecrets, true); err != nil {
+	if tok.HasDefault {
+		if err := rejectIfSecretLiteral(tok.Name, tok.Default, rejectSecrets, true); err != nil {
 			return "", false, err
 		}
-		return defaultVal, false, nil
+		return tok.Default, false, nil
 	}
-	if hasErrForm {
-		if strings.TrimSpace(errMsg) == "" {
-			errMsg = name + " is required"
-		}
-		return "", false, errors.New(errMsg)
+	if tok.HasErrForm {
+		return "", false, tok.RequiredErr()
 	}
-	return "", false, fmt.Errorf("environment variable %s is required but not set", name)
+	return "", false, fmt.Errorf("environment variable %s is required but not set", tok.Name)
 }

--- a/internal/config/template_token.go
+++ b/internal/config/template_token.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"errors"
+	"strings"
+)
+
+// TemplateToken is the parsed body of a ${...} reference. It is shared by the
+// config-load-time resolver (resolveEnvToken) and the agent-runtime resolver
+// (agent.resolveTemplateToken) so the ${X} / ${X:-default} / ${X?msg} grammar
+// has a single source of truth and the two resolvers cannot drift apart.
+//
+// Interim home: when the deferred internal/customengine leaf package of #50
+// lands, this type moves there alongside the custom-engine config types.
+type TemplateToken struct {
+	// Name is the variable name (the part before any :- or ? clause).
+	Name string
+	// Default is the fallback value of a ${X:-default} form.
+	Default string
+	// ErrMsg is the message of a ${X?msg} form (may be empty).
+	ErrMsg string
+	// HasDefault is set for the ${X:-default} form.
+	HasDefault bool
+	// HasErrForm is set for the ${X?msg} form.
+	HasErrForm bool
+}
+
+// ParseTemplateToken splits a reference body into its variable name plus an
+// optional default-value or error-message clause. `:-` is matched before `?`,
+// so ${X:-a?b} keeps "a?b" as the default — preserving the precedence both
+// resolvers already relied on.
+func ParseTemplateToken(inner string) TemplateToken {
+	t := TemplateToken{Name: inner}
+	if before, after, found := strings.Cut(inner, ":-"); found {
+		t.Name, t.Default, t.HasDefault = before, after, true
+	} else if before, after, found := strings.Cut(inner, "?"); found {
+		t.Name, t.ErrMsg, t.HasErrForm = before, after, true
+	}
+	return t
+}
+
+// RequiredErr builds the error for the ${X?msg} form, defaulting a blank or
+// whitespace-only message to "<name> is required".
+func (t TemplateToken) RequiredErr() error {
+	msg := t.ErrMsg
+	if strings.TrimSpace(msg) == "" {
+		msg = t.Name + " is required"
+	}
+	return errors.New(msg)
+}

--- a/internal/config/template_token_test.go
+++ b/internal/config/template_token_test.go
@@ -1,0 +1,62 @@
+package config
+
+import "testing"
+
+func TestParseTemplateToken(t *testing.T) {
+	type tc struct {
+		name       string
+		inner      string
+		wantName   string
+		wantDef    string
+		wantErrMsg string
+		wantHasDef bool
+		wantHasErr bool
+	}
+	// `:-` is matched before `?`, so the "default wins"/"colon-dash anywhere
+	// wins" cases assert that a `?` inside (or after the start of) a default
+	// clause is kept verbatim rather than splitting an error form.
+	tests := []tc{
+		{name: "plain", inner: "FOO", wantName: "FOO"},
+		{name: "default form", inner: "FOO:-bar", wantName: "FOO", wantDef: "bar", wantHasDef: true},
+		{name: "empty default", inner: "FOO:-", wantName: "FOO", wantHasDef: true},
+		{name: "error form", inner: "FOO?must set FOO", wantName: "FOO", wantErrMsg: "must set FOO", wantHasErr: true},
+		{name: "error form empty message", inner: "FOO?", wantName: "FOO", wantHasErr: true},
+		{name: "default wins over question mark", inner: "FOO:-a?b", wantName: "FOO", wantDef: "a?b", wantHasDef: true},
+		{name: "colon-dash anywhere wins over question", inner: "FOO?a:-b", wantName: "FOO?a", wantDef: "b", wantHasDef: true},
+		{name: "kwargs dotted name", inner: "kwargs.profile", wantName: "kwargs.profile"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseTemplateToken(tc.inner)
+			if got.Name != tc.wantName {
+				t.Errorf("Name = %q, want %q", got.Name, tc.wantName)
+			}
+			if got.Default != tc.wantDef {
+				t.Errorf("Default = %q, want %q", got.Default, tc.wantDef)
+			}
+			if got.ErrMsg != tc.wantErrMsg {
+				t.Errorf("ErrMsg = %q, want %q", got.ErrMsg, tc.wantErrMsg)
+			}
+			if got.HasDefault != tc.wantHasDef {
+				t.Errorf("HasDefault = %v, want %v", got.HasDefault, tc.wantHasDef)
+			}
+			if got.HasErrForm != tc.wantHasErr {
+				t.Errorf("HasErrForm = %v, want %v", got.HasErrForm, tc.wantHasErr)
+			}
+		})
+	}
+}
+
+func TestTemplateTokenRequiredErr(t *testing.T) {
+	// An explicit message is used verbatim.
+	if got := (TemplateToken{Name: "FOO", ErrMsg: "set FOO please"}).RequiredErr(); got == nil || got.Error() != "set FOO please" {
+		t.Errorf("RequiredErr with message = %v, want %q", got, "set FOO please")
+	}
+	// A blank or whitespace-only message defaults to "<name> is required".
+	for _, msg := range []string{"", "   "} {
+		got := (TemplateToken{Name: "FOO", ErrMsg: msg}).RequiredErr()
+		if got == nil || got.Error() != "FOO is required" {
+			t.Errorf("RequiredErr(%q) = %v, want %q", msg, got, "FOO is required")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Part 1 of #50. The config-load-time resolver (`config.resolveEnvToken`) and the agent-runtime resolver (`agent.resolveTemplateToken`) each hand-rolled the **same** `${X}` / `${X:-default}` / `${X?msg}` grammar split, so a fix to one was easy to miss in the other. This extracts the shared parse into `config.ParseTemplateToken` (+ `TemplateToken.RequiredErr` for the `${X?msg}` blank-message default) and has both resolvers call it — the grammar now has a single source of truth.

## Scope (important)

Investigation showed the issue's premise ("two near-identical parsers") only holds for the **grammar split**. The two resolvers otherwise differ substantially:

| | agent `resolveTemplateToken` | config `resolveEnvToken` |
|---|---|---|
| lookup | vars map + env fallback | env only |
| builtin vars | resolved as normal | left intact (`leaveIntact`) |
| empty value | present-but-empty → triggers default | n/a |
| `kwargs.*` missing | → empty string | n/a |
| secrets | none | multi-layer rejection |
| passes | single | strict: up to 10 |
| return | `(string, error)` | `(value, leaveIntact, error)` |

Forcing these into one `ResolveToken` (lookup callback + options + merged return) would be *more* complex, not less. So **only the genuinely-shared grammar is unified**; each resolver keeps its own lookup/secret/empty policy verbatim.

**Part 2** of #50 (extracting the four custom-engine config types into an `internal/customengine` leaf package) is deferred as a separate follow-up before HTTP transport — its current ROI is low (config still needs the types for `EngineConfig.Custom`). Hence `Refs #50`, not `Closes`.

## Where the helper lives

`internal/config` for now — it's already imported by `internal/agent` (no import cycle; config does not import agent). When part 2 lands, the helper moves to the `internal/customengine` leaf package alongside the types.

## Test plan

- [x] `make test` (`go test -race ./...`) — green. Existing parser tests (`TestRenderTemplate*` in agent, config env-ref resolution) are **unchanged** and pass (the behavior safety net).
- [x] New `internal/config/template_token_test.go` — covers the three forms, `:-` before `?` precedence, and the `RequiredErr` blank-message default.
- [x] `make verify` (fmt + vet + revive + golangci-lint) — **0 issues**.
- [x] `make e2e` custom-engine suite — `RejectsMissingEnvVar` (config strict path), `LocalTransport` (agent render path), `Validate` all pass.

## Why not an existing envsubst library?

Libraries exist for `${VAR}` / `${VAR:-default}` substitution (`os.Expand` in stdlib, `drone/envsubst`, `a8m/envsubst`, or the full `mvdan.cc/sh`), but they only cover the **grammar split** — which is ~6 lines. The parts that actually matter here are bespoke and can't be delegated to a generic substituter:

- **Custom lookup sources** — the agent resolver resolves against a runtime *vars map* (`case_id`, `kwargs.<key>`, `model`, …) with env only as fallback, not just `os.Getenv`.
- **Two-stage `leaveIntact` resolution** — the config resolver deliberately leaves builtin template vars (`${api_key}`, `${kwargs}`, …) untouched at load time for the agent to resolve at run time. No generic lib models this.
- **Secret-leak prevention** — strict mode rejects credentials reaching a command line via three layers (sensitive var name / credential-shaped `:-` default literal / credential-shaped resolved value) plus a multi-pass (≤10) anti-smuggling expansion so a non-sensitive wrapper var can't smuggle a sensitive name through. This security policy is the whole point and no envsubst lib provides it.

Pulling a third-party dependency to save ~6 lines — while that dependency *cannot* carry the credential-leak-prevention responsibility — is a poor trade, especially in a supply-chain-sensitive repo. So #50 keeps the resolvers in-house and only dedups the shared grammar split into a unit-tested `ParseTemplateToken`. If the grammar ever needs to converge on full POSIX (`:+`, `:=`, …), swapping in `a8m/envsubst` for the split would be worth revisiting then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
