### PR TITLE
docs: document SKILL_UP_BASH env var for all platforms

### DIFF
--- a/docs/guide/user-config.md
+++ b/docs/guide/user-config.md
@@ -120,6 +120,50 @@ skill-up init --config ./team-config.yaml --print
 
 ---
 
+## Environment Variables
+
+Beyond the YAML config file, skill-up respects certain environment variables
+that influence runtime behavior. These are separate from the `env` map in
+`config.yaml` (which injects variables into the child process environment).
+
+### `SKILL_UP_BASH`
+
+Override the bash interpreter used by skill-up for `.sh` script judges and
+shell commands.
+
+| Aspect       | Detail                                                                 |
+| :----------- | :--------------------------------------------------------------------- |
+| **Purpose**  | Point skill-up at a specific `bash` binary                             |
+| **Applies**  | All platforms — Linux, macOS, and Windows                              |
+| **Default**  | Unset; skill-up falls back to `bash` on `PATH` (and on Windows, well-known Git Bash locations) |
+
+**Precedence:** When `SKILL_UP_BASH` is set and points to a valid file,
+skill-up uses it unconditionally — it is checked **before** any `PATH` lookup
+or well-known-path probing.
+
+**Full-trust requirement:** The path you supply is used as-is without further
+sandboxing. You are responsible for ensuring it points to a trustworthy bash
+binary.
+
+Example (macOS / Linux):
+
+```bash
+export SKILL_UP_BASH=/opt/homebrew/bin/bash
+skill-up run ./evals/eval.yaml
+```
+
+Example (Windows — Git Bash in a non-standard location):
+
+```powershell
+$env:SKILL_UP_BASH = "D:\tools\git\bin\bash.exe"
+skill-up run .\evals\eval.yaml
+```
+
+On Windows, the WSL shim at `C:\Windows\System32\bash.exe` is rejected even
+when specified via `SKILL_UP_BASH`; see [Windows Support](./windows.md#running-sh-script-judges-on-windows) for details.
+
+---
+
 ## Examples
 
 ### Always export traces to a local collector

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -32,7 +32,8 @@ this order:
    `C:\Program Files (x86)\Git\bin\bash.exe`.
 
 If none is found the script judge fails with a clear error. Install
-[Git for Windows](https://git-scm.com/download/win) or set `SKILL_UP_BASH`.
+[Git for Windows](https://git-scm.com/download/win) or set `SKILL_UP_BASH`
+(see [Environment Variables](./user-config.md#skill_up_bash) for full details).
 
 The WSL shim at `C:\Windows\System32\bash.exe` is intentionally rejected at
 all three steps (override, PATH, well-known) because it expects Linux-format

--- a/docs/zh/guide/user-config.md
+++ b/docs/zh/guide/user-config.md
@@ -112,6 +112,46 @@ skill-up init --config ./team-config.yaml --print
 
 ---
 
+## 环境变量
+
+除了 YAML 配置文件外，skill-up 还支持若干影响运行时行为的环境变量。这些变量
+与 `config.yaml` 中的 `env` 字典（用于向子进程注入环境变量）是分开的。
+
+### `SKILL_UP_BASH`
+
+覆盖 skill-up 用于 `.sh` script judge 和 shell 命令的 bash 解释器。
+
+| 属性         | 说明                                                                   |
+| :----------- | :--------------------------------------------------------------------- |
+| **用途**     | 让 skill-up 使用指定的 `bash` 可执行文件                               |
+| **适用平台** | 所有平台 —— Linux、macOS、Windows                                      |
+| **默认值**   | 未设置；回退到 `PATH` 上的 `bash`（Windows 上还会探测常见 Git Bash 路径） |
+
+**优先级：** 设置 `SKILL_UP_BASH` 且其值指向有效文件时，skill-up 会无条件使用它
+—— 该变量的检查**先于**任何 `PATH` 查找或知名路径探测。
+
+**完全信任要求：** 你提供的路径会被原样使用，不经过额外沙箱。你有责任确保它指向
+一个可信的 bash 可执行文件。
+
+示例（macOS / Linux）：
+
+```bash
+export SKILL_UP_BASH=/opt/homebrew/bin/bash
+skill-up run ./evals/eval.yaml
+```
+
+示例（Windows —— Git Bash 安装在非标准位置）：
+
+```powershell
+$env:SKILL_UP_BASH = "D:\tools\git\bin\bash.exe"
+skill-up run .\evals\eval.yaml
+```
+
+在 Windows 上，即使通过 `SKILL_UP_BASH` 显式指定 `C:\Windows\System32\bash.exe`
+（WSL shim）也会被拒绝；详见 [Windows 支持](./windows.md#在-windows-上运行-sh-script-judge)。
+
+---
+
 ## 示例
 
 ### 默认导出 trace 到本地 collector

--- a/docs/zh/guide/windows.md
+++ b/docs/zh/guide/windows.md
@@ -28,7 +28,8 @@ skill-up 原生支持 Windows。本页说明哪些功能可用、当前的限制
    `C:\Program Files (x86)\Git\bin\bash.exe`。
 
 若都找不到，script judge 会以明确的错误失败。请安装
-[Git for Windows](https://git-scm.com/download/win) 或设置 `SKILL_UP_BASH`。
+[Git for Windows](https://git-scm.com/download/win) 或设置 `SKILL_UP_BASH`
+（完整说明见[环境变量](./user-config.md#skill_up_bash)）。
 
 `C:\Windows\System32\bash.exe`（WSL shim）会在三个步骤里都被主动忽略 ——
 即使通过 `SKILL_UP_BASH` 显式指向或它在 PATH 上排在前面，因为它期望 Linux


### PR DESCRIPTION
## Summary
- Add "Environment Variables" section to `docs/guide/user-config.md` documenting `SKILL_UP_BASH` (precedence over PATH, full-trust requirement, all-platform applicability)
- Add equivalent Chinese section in `docs/zh/guide/user-config.md`
- Cross-link from `docs/guide/windows.md` and `docs/zh/guide/windows.md`

Closes #47

## Test plan
- [ ] Docs render correctly (VitePress dev server)
- [ ] Cross-links resolve to correct anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)