### PR TITLE
refactor(runtime): move case metadata into AgentMetadata off generic ExecOptions (#49)

### DIFF
--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -894,14 +894,15 @@ func (a *CustomAgent) buildSessionInput(rt Runtime, opts ExecOptions, messages [
 	for _, m := range messages {
 		msgs = append(msgs, SessionMessage{Role: string(m.Role), Content: m.Content})
 	}
+	meta := opts.AgentMeta()
 	return SessionInput{
-		CaseID:         opts.CaseID,
-		Variant:        opts.Variant,
+		CaseID:         meta.CaseID,
+		Variant:        meta.Variant,
 		Workspace:      rt.Workspace(),
 		Model:          formatAgentModel(a.Cfg.ModelProvider, a.Cfg.ModelName),
 		Kwargs:         kwargs,
 		Messages:       msgs,
-		MaxTurns:       opts.MaxTurns,
+		MaxTurns:       meta.MaxTurns,
 		TimeoutSeconds: timeoutSec,
 	}
 }
@@ -912,6 +913,7 @@ func (a *CustomAgent) buildSessionInput(rt Runtime, opts ExecOptions, messages [
 // once resolveCustomIOFiles has run.
 func (a *CustomAgent) buildBaseVars(rt Runtime, opts ExecOptions, messages []transcript.Message, timeoutSec int) map[string]string {
 	workspace := rt.Workspace()
+	meta := opts.AgentMeta()
 	return map[string]string{
 		"workspace":       workspace,
 		"prompt":          singleTurnPrompt(messages),
@@ -921,9 +923,9 @@ func (a *CustomAgent) buildBaseVars(rt Runtime, opts ExecOptions, messages []tra
 		"model_provider":  a.Cfg.ModelProvider,
 		"model_name":      a.Cfg.ModelName,
 		"api_key":         a.Cfg.APIKey,
-		"case_id":         opts.CaseID,
-		"variant":         opts.Variant,
-		"max_turns":       strconv.Itoa(opts.MaxTurns),
+		"case_id":         meta.CaseID,
+		"variant":         meta.Variant,
+		"max_turns":       strconv.Itoa(meta.MaxTurns),
 		"timeout_seconds": strconv.Itoa(timeoutSec),
 	}
 }

--- a/internal/agent/custom_test.go
+++ b/internal/agent/custom_test.go
@@ -43,7 +43,7 @@ func TestCustomAgent_RunLocal_StdoutSessionResult(t *testing.T) {
 		},
 	})
 
-	res, err := ag.Run(context.Background(), rt, ExecOptions{CaseID: "c1", Variant: "with_skill"}, userMessages())
+	res, err := ag.Run(context.Background(), rt, ExecOptions{AgentMetadata: &runtime.AgentMetadata{CaseID: "c1", Variant: "with_skill"}}, userMessages())
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -579,7 +579,7 @@ func TestCustomAgent_RunLocal_RendersTemplatedKwargs(t *testing.T) {
 		},
 	})
 
-	res, err := ag.Run(context.Background(), rt, ExecOptions{CaseID: "case-42"}, userMessages())
+	res, err := ag.Run(context.Background(), rt, ExecOptions{AgentMetadata: &runtime.AgentMetadata{CaseID: "case-42"}}, userMessages())
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -401,10 +401,12 @@ func (e *defaultEvaluator) executeCaseOnce(ctx context.Context, caseCfg *config.
 	}
 	agentExecOpts := agent.ExecOptions{
 		ArtifactDir: agentArtifactDir,
-		CaseID:      caseCfg.ID,
-		Variant:     configName,
-		MaxTurns:    caseMaxTurns(e.evalCfg, caseCfg),
 		TimeoutSec:  caseTimeoutSeconds(e.evalCfg, caseCfg),
+		AgentMetadata: &runtime.AgentMetadata{
+			CaseID:   caseCfg.ID,
+			Variant:  configName,
+			MaxTurns: caseMaxTurns(e.evalCfg, caseCfg),
+		},
 	}
 	sessionResult, execErr := runAgent.Run(agentCtx, rt, agentExecOpts, messages)
 	agentSpan.End()

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -76,6 +76,16 @@ type ExecResult struct {
 	ExitCode int
 }
 
+// AgentMetadata carries case-level metadata that only agents building a
+// structured session input (e.g. the Custom Engine) consume. It is threaded
+// per-Run via ExecOptions.AgentMetadata rather than baked into the agent at
+// construction, because a single agent instance is reused across cases.
+type AgentMetadata struct {
+	CaseID   string
+	Variant  string
+	MaxTurns int
+}
+
 // ExecOptions configures how a command is executed.
 type ExecOptions struct {
 	Cwd         string
@@ -83,11 +93,20 @@ type ExecOptions struct {
 	TimeoutSec  int
 	ArtifactDir string
 
-	// Case metadata passed through to agents that build a structured session
-	// input (e.g. Custom Engine). Built-in agents ignore these fields.
-	CaseID   string
-	Variant  string
-	MaxTurns int
+	// AgentMetadata carries case-level metadata for agents that build a
+	// structured session input (e.g. Custom Engine). It is nil for runs that
+	// do not need it; built-in agents ignore it. Read it via AgentMeta, which
+	// is nil-safe.
+	AgentMetadata *AgentMetadata
+}
+
+// AgentMeta returns the case-level agent metadata, or a zero value when unset,
+// so callers can read its fields without a nil check.
+func (o ExecOptions) AgentMeta() AgentMetadata {
+	if o.AgentMetadata == nil {
+		return AgentMetadata{}
+	}
+	return *o.AgentMetadata
 }
 
 // Runtime defines the interface for sandbox runtimes.


### PR DESCRIPTION
## Summary

Closes #49. `CaseID` / `Variant` / `MaxTurns` were added directly to the universal `runtime.ExecOptions` when the Custom Engine landed (#24), with a comment that "built-in agents ignore these fields" — implicit coupling: a generic exec struct carrying metadata only `CustomAgent` consumes. This bundles them into a dedicated `runtime.AgentMetadata` threaded via `ExecOptions.AgentMetadata` (a pointer, nil when unused), so the contract is explicit.

## Why Option A (pointer on ExecOptions), not Option B (agent.Config at construction)

The issue offered two designs. Option B doesn't fit: the evaluator holds a **single agent instance and reuses it across cases** (`runAgent := e.ag` in `executeCaseOnce`), so per-case metadata can't be baked into the agent at construction — it must travel per-`Run`. `ExecOptions` is the per-Run parameter, so the metadata belongs there.

## Changes

- **runtime** (`runtime.go`): add `AgentMetadata{CaseID,Variant,MaxTurns}` + a nil-safe `ExecOptions.AgentMeta()` accessor; drop the three bare fields from `ExecOptions`.
- **evaluator** (`evaluator.go`): the sole writer wraps the trio into `&runtime.AgentMetadata{...}`.
- **agent** (`custom.go`): the six read sites (`buildSessionInput`, `buildBaseVars`) read via `opts.AgentMeta()`.

## Behavior-preserving

`AgentMeta()` returns a zero value when `AgentMetadata` is nil — matching the old "fields unset" semantics (empty `CaseID`/`Variant`, `MaxTurns` 0). Built-in agents never read these fields, so nothing changes for them.

This is a struct-shape refactor, so unlike the previous pure-internal refactors it touches a few test constructions (`custom_test.go`) that set the fields — `evaluator_test.go` was confirmed unaffected (its `CaseID` is on a different struct).

## Test plan

- [x] `make test` (`go test -race ./...`) — runtime, agent, evaluator packages green.
- [x] `make verify` (fmt + vet + revive + golangci-lint) — **0 issues**.
- [x] `make e2e` custom-engine suite — `LocalTransport` / `Validate` / `RejectsMissingEnvVar` all pass (exercises the CaseID/Variant/MaxTurns flow end-to-end).

## Context

This is the last small prerequisite flagged "before HTTP transport lands" (#51 transport seam ✅ merged; #50 part 1 parser dedup ✅ merged). The HTTP transport will consume the same per-case metadata, so tightening the contract now avoids the smell compounding across a second transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)