### PR TITLE
feat(custom-engine): HTTP transport JSON request/response core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Custom Engine `http` transport (`engine.custom.transport: http`): calls a
+  remote (or local) HTTP agent service, POSTing the `SessionInput` and parsing
+  the `SessionResult` from the response. Renders `${...}` references in
+  `http.url` / `http.headers` / `http.request_body`; a `request_body` field
+  whose value is exactly `${session_input}`, `${messages}`, or `${kwargs}` is
+  injected as a JSON structure rather than a string. A non-2xx status is treated
+  as an engine execution error, and the API key is rejected in the URL (use a
+  header or the request body instead) and masked in responses. This is the JSON
+  request/response core; multipart file upload (`http.files`) and URL artifact
+  download are follow-ups and are currently rejected as not-yet-implemented.
+
 ## [0.2.4] - 2026-06-03
 
 ### Added

--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -41,11 +41,16 @@ const (
 	// maxInlineArtifactTotal caps the sum of inline artifact sizes across a
 	// single SessionResult.
 	maxInlineArtifactTotal = 200 * 1024 * 1024
+	// maxHTTPResponseBytes caps how much of an http transport response body is
+	// read, so a misbehaving or malicious agent service cannot exhaust memory
+	// with an unbounded SessionResult payload.
+	maxHTTPResponseBytes = 64 * 1024 * 1024
 )
 
 // CustomAgent implements Agent for user-defined engines configured via
-// engine.custom. Phase 1 supports the local transport; the http transport is
-// designed but not yet implemented. See docs/design/custom-engine.md.
+// engine.custom. The local transport is fully supported; the http transport
+// supports JSON request/response, with multipart file upload and URL artifact
+// download still pending. See docs/design/custom-engine.md.
 //
 // CustomAgent embeds BaseAgent directly (not CLIAgent) so it inherits only
 // shared agent infrastructure — Name, credential helpers, exec-options merge,
@@ -160,16 +165,16 @@ func (a *CustomAgent) Run(ctx context.Context, rt Runtime, opts ExecOptions, mes
 	return a.assembleResult(ctx, rt, opts, prep, outcome)
 }
 
-// selectTransport maps engine.custom.transport to its implementation. The http
-// transport is designed but not yet implemented; selecting it returns the
-// explicit error rather than a transport. When http lands, this case returns an
-// &httpTransport{} and CustomAgent.Run is otherwise unchanged.
+// selectTransport maps engine.custom.transport to its implementation: the
+// local transport runs a command in the runtime, the http transport calls a
+// remote agent service. Both produce a transportOutcome that CustomAgent.Run
+// hands to the shared assembleResult.
 func (a *CustomAgent) selectTransport(custom *config.CustomEngineConfig) (customTransport, error) {
 	switch custom.Transport {
 	case customTransportLocal:
 		return &localTransport{a: a}, nil
 	case customTransportHTTP:
-		return nil, errors.New("custom engine http transport is not yet implemented")
+		return &httpTransport{a: a}, nil
 	default:
 		return nil, fmt.Errorf("custom engine transport %q is not supported", custom.Transport)
 	}

--- a/internal/agent/custom_http.go
+++ b/internal/agent/custom_http.go
@@ -120,13 +120,19 @@ func (t *httpTransport) doRequest(client *http.Client, req *http.Request) *trans
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxHTTPResponseBytes))
+	// Read one byte past the cap so an over-limit body surfaces a clear error
+	// instead of silently truncating into an inscrutable JSON parse failure.
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxHTTPResponseBytes+1))
 	if readErr != nil {
 		return &transportOutcome{
 			exitCode: 1,
 			stderr:   a.maskAPIKey(readErr.Error()),
 			execErr:  errors.New(a.maskAPIKey("read custom engine http response: " + readErr.Error())),
 		}
+	}
+	if int64(len(respBody)) > maxHTTPResponseBytes {
+		msg := fmt.Sprintf("custom engine http response exceeded %d bytes", maxHTTPResponseBytes)
+		return &transportOutcome{exitCode: 1, stderr: msg, execErr: errors.New(msg)}
 	}
 	raw := string(respBody)
 

--- a/internal/agent/custom_http.go
+++ b/internal/agent/custom_http.go
@@ -1,0 +1,228 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// httpTransport calls a remote (or local) HTTP agent service: it POSTs the
+// SessionInput as a JSON body and parses the SessionResult from the response.
+// It owns the http-specific concerns — URL/header/body rendering, the request
+// body's JSON-structure injection, and status-to-outcome mapping. Shared
+// session preparation and result assembly live on CustomAgent, reused via the
+// back-reference.
+//
+// This transport currently supports JSON request/response only. Multipart file
+// upload (engine.custom.http.files) and URL artifact download are follow-ups; a
+// non-empty files list is rejected as not-yet-implemented.
+type httpTransport struct {
+	a *CustomAgent
+}
+
+// run renders the request from prep.vars, POSTs it, and maps the response onto
+// a transportOutcome for CustomAgent.assembleResult. A setup failure (missing
+// URL, secret in URL, unrenderable template, files configured) is returned as
+// run's error so the run is abandoned; a transport/status failure is carried in
+// transportOutcome.execErr so a partial SessionResult can still be assembled.
+func (t *httpTransport) run(ctx context.Context, _ Runtime, _ ExecOptions, prep *customRunPrep) (*transportOutcome, error) {
+	a := t.a
+	custom := prep.custom
+	// Guard against a nil/unsupported http block: a `--engine` override can
+	// reach here unvalidated (config validation skips engine.custom for
+	// built-in engine names).
+	if custom.HTTP == nil || custom.HTTP.URL == "" {
+		return nil, errors.New("engine.custom.http.url is required when transport is http")
+	}
+	if len(custom.HTTP.Files) > 0 {
+		return nil, errors.New("engine.custom.http.files (file upload) is not yet implemented")
+	}
+
+	url, err := renderTemplate(custom.HTTP.URL, prep.vars)
+	if err != nil {
+		return nil, fmt.Errorf("render http.url: %w", err)
+	}
+	// A credential in the URL would leak into request logs, proxies, and
+	// traces. The sanctioned channel for ${api_key} is a header or the request
+	// body, so it is rejected only here.
+	if a.containsAPIKey(url) {
+		return nil, errSecretInURL()
+	}
+
+	// Only POST is supported. validateCustomHTTP enforces this at config load,
+	// but a `--engine` override reaches here unvalidated, so re-check.
+	if custom.HTTP.Method != "" && !strings.EqualFold(custom.HTTP.Method, http.MethodPost) {
+		return nil, fmt.Errorf("engine.custom.http.method must be POST (got %q)", custom.HTTP.Method)
+	}
+	method := http.MethodPost
+
+	body, err := t.buildRequestBody(prep)
+	if err != nil {
+		return nil, err
+	}
+
+	headers, err := renderTemplateMap(custom.HTTP.Headers, prep.vars)
+	if err != nil {
+		return nil, fmt.Errorf("render http.headers: %w", err)
+	}
+
+	// Enforce the custom timeout via a context deadline (mirrors the local
+	// transport); the http.Client.Timeout is a backstop for the case where the
+	// transport ignores ctx.
+	reqCtx := ctx
+	var timeout time.Duration
+	if prep.timeoutSec > 0 {
+		timeout = time.Duration(prep.timeoutSec) * time.Second
+		var cancel context.CancelFunc
+		reqCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	req, err := http.NewRequestWithContext(reqCtx, method, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build http request: %w", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return t.doRequest(&http.Client{Timeout: timeout}, req), nil
+}
+
+// doRequest performs the request and maps the response onto a transportOutcome.
+// It never returns a setup error — a transport/read failure or a non-2xx status
+// is carried in the outcome's execErr so assembleResult can still salvage a
+// partial SessionResult from the body.
+func (t *httpTransport) doRequest(client *http.Client, req *http.Request) *transportOutcome {
+	a := t.a
+	// url is operator-supplied engine config (engine.custom.http.url); a dynamic
+	// endpoint is the whole point of the http transport.
+	resp, err := client.Do(req) //nolint:gosec // intentional operator-configured dynamic URL
+	if err != nil {
+		// The net/http error embeds the request URL; mask it like stderr so a
+		// secret a user mistakenly put in the URL cannot leak into result.Error
+		// / reports. (errors.New, not %w: the masked string is the payload and
+		// the chain is not matched downstream.)
+		return &transportOutcome{
+			exitCode: 1,
+			stderr:   a.maskAPIKey(err.Error()),
+			execErr:  errors.New(a.maskAPIKey("custom engine http request failed: " + err.Error())),
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxHTTPResponseBytes))
+	if readErr != nil {
+		return &transportOutcome{
+			exitCode: 1,
+			stderr:   a.maskAPIKey(readErr.Error()),
+			execErr:  errors.New(a.maskAPIKey("read custom engine http response: " + readErr.Error())),
+		}
+	}
+	raw := string(respBody)
+
+	// raw feeds session_result parsing; stdout is the text-format final-message
+	// source. For http both are the response body (there is no separate stream).
+	outcome := &transportOutcome{raw: raw, stdout: raw}
+	// A non-2xx status is an Engine execution error per the contract; still
+	// surface the body (it may carry a partial SessionResult) and let
+	// assembleResult decide.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		outcome.exitCode = resp.StatusCode
+		outcome.stderr = a.maskAPIKey(strings.TrimSpace(raw))
+		outcome.execErr = fmt.Errorf("custom engine http status %d", resp.StatusCode)
+	}
+	return outcome
+}
+
+// buildRequestBody produces the JSON request body. When request_body is unset
+// it defaults to the SessionInput JSON (equivalent to ${session_input});
+// otherwise the configured structure is rendered (see renderBodyValue) and
+// marshaled.
+func (t *httpTransport) buildRequestBody(prep *customRunPrep) ([]byte, error) {
+	rb := prep.custom.HTTP.RequestBody
+	if rb == nil {
+		return prep.sessJSON, nil
+	}
+	rendered, err := renderBodyValue(rb, prep.vars)
+	if err != nil {
+		return nil, err
+	}
+	out, err := json.Marshal(rendered)
+	if err != nil {
+		return nil, fmt.Errorf("marshal http.request_body: %w", err)
+	}
+	return out, nil
+}
+
+// renderBodyValue resolves template references inside a request_body value. A
+// string that is exactly ${session_input}/${messages}/${kwargs} is injected as
+// the corresponding JSON structure (so it embeds as a JSON object/array, not a
+// quoted string); any other string is rendered with the normal template
+// substitution; maps and slices are walked recursively; other scalars pass
+// through unchanged.
+func renderBodyValue(v any, vars map[string]string) (any, error) {
+	switch val := v.(type) {
+	case string:
+		if raw, ok := structuredInjection(val, vars); ok {
+			return raw, nil
+		}
+		return renderTemplate(val, vars)
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, item := range val {
+			r, err := renderBodyValue(item, vars)
+			if err != nil {
+				return nil, fmt.Errorf("request_body[%q]: %w", k, err)
+			}
+			out[k] = r
+		}
+		return out, nil
+	case []any:
+		out := make([]any, len(val))
+		for i, item := range val {
+			r, err := renderBodyValue(item, vars)
+			if err != nil {
+				return nil, fmt.Errorf("request_body[%d]: %w", i, err)
+			}
+			out[i] = r
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}
+
+// structuredInjection returns the JSON structure for the three aggregate
+// template tokens when s is exactly one of them, so they embed as JSON values
+// rather than strings. The backing vars entries are always valid JSON
+// (completeTemplateVars marshals them).
+func structuredInjection(s string, vars map[string]string) (json.RawMessage, bool) {
+	switch s {
+	case "${session_input}":
+		return json.RawMessage(vars["session_input"]), true
+	case "${messages}":
+		return json.RawMessage(vars["messages"]), true
+	case "${kwargs}":
+		return json.RawMessage(vars["kwargs"]), true
+	default:
+		return nil, false
+	}
+}
+
+// errSecretInURL mirrors errSecretInCommand for the http transport: a rendered
+// URL that embeds the API key would expose it in request logs and traces.
+func errSecretInURL() error {
+	return errors.New(
+		"engine.custom.http.url renders the API key into the URL, which would expose it in request logs and traces; reference ${api_key} from engine.custom.http.headers or request_body instead",
+	)
+}

--- a/internal/agent/custom_http_test.go
+++ b/internal/agent/custom_http_test.go
@@ -1,0 +1,256 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alibaba/skill-up/internal/config"
+)
+
+func httpAgent(custom *config.CustomEngineConfig, apiKey string) *CustomAgent {
+	return NewCustomAgent(Config{Name: "my-agent", APIKey: apiKey, Custom: custom})
+}
+
+func httpEngine(url string) *config.CustomEngineConfig {
+	return &config.CustomEngineConfig{
+		Transport: "http",
+		HTTP:      &config.CustomHTTPConfig{URL: url},
+	}
+}
+
+func TestCustomAgent_RunHTTP_SessionResult(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"done","turns":3}`)
+	}))
+	defer srv.Close()
+
+	rt := newCustomTestRuntime(t)
+	res, err := httpAgent(httpEngine(srv.URL), "").Run(context.Background(), rt, ExecOptions{}, userMessages())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.ExitCode != 0 || res.FinalMessage != "done" || res.Turns != 3 {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}
+
+func TestCustomAgent_RunHTTP_TextFormat(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "plain http answer")
+	}))
+	defer srv.Close()
+
+	custom := httpEngine(srv.URL)
+	custom.ResponseFormat = "text"
+	rt := newCustomTestRuntime(t)
+	res, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.FinalMessage != "plain http answer" {
+		t.Fatalf("final_message = %q, want plain http answer", res.FinalMessage)
+	}
+}
+
+func TestCustomAgent_RunHTTP_NonZeroStatusFails(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	defer srv.Close()
+
+	rt := newCustomTestRuntime(t)
+	res, err := httpAgent(httpEngine(srv.URL), "").Run(context.Background(), rt, ExecOptions{}, userMessages())
+	if err == nil {
+		t.Fatal("expected error for non-2xx status")
+	}
+	if res.ExitCode == 0 {
+		t.Fatalf("exit code = 0, want non-zero for http 500")
+	}
+}
+
+func TestCustomAgent_RunHTTP_DefaultBodyIsSessionInput(t *testing.T) {
+	t.Parallel()
+	var got struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &got)
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
+	}))
+	defer srv.Close()
+
+	rt := newCustomTestRuntime(t)
+	if _, err := httpAgent(httpEngine(srv.URL), "").Run(context.Background(), rt, ExecOptions{}, userMessages()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(got.Messages) != 1 || got.Messages[0].Content != "review the diff" {
+		t.Fatalf("default body did not carry SessionInput.messages: %#v", got.Messages)
+	}
+}
+
+func TestCustomAgent_RunHTTP_RequestBodyInjectsSessionInputStructure(t *testing.T) {
+	t.Parallel()
+	// payload references ${session_input}; it must arrive as a JSON object, not
+	// a quoted string. tag is a plain string leaf.
+	var raw map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &raw)
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
+	}))
+	defer srv.Close()
+
+	custom := httpEngine(srv.URL)
+	custom.HTTP.RequestBody = map[string]any{
+		"payload": "${session_input}",
+		"tag":     "review",
+	}
+	rt := newCustomTestRuntime(t)
+	if _, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(raw["payload"]) == 0 || raw["payload"][0] != '{' {
+		t.Fatalf("payload was not injected as a JSON object: %s", raw["payload"])
+	}
+	if string(raw["tag"]) != `"review"` {
+		t.Fatalf("tag = %s, want \"review\"", raw["tag"])
+	}
+}
+
+func TestCustomAgent_RunHTTP_RequestBodyRendersKwargs(t *testing.T) {
+	t.Parallel()
+	var got map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &got)
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
+	}))
+	defer srv.Close()
+
+	custom := httpEngine(srv.URL)
+	custom.Kwargs = map[string]string{"profile": "strict"}
+	custom.HTTP.RequestBody = map[string]any{"p": "${kwargs.profile}"}
+	rt := newCustomTestRuntime(t)
+	if _, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got["p"] != "strict" {
+		t.Fatalf("rendered kwargs in body = %q, want strict", got["p"])
+	}
+}
+
+func TestCustomAgent_RunHTTP_RendersHeaderWithAPIKey(t *testing.T) {
+	t.Parallel()
+	var auth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
+	}))
+	defer srv.Close()
+
+	custom := httpEngine(srv.URL)
+	custom.HTTP.Headers = map[string]string{"Authorization": "Bearer ${api_key}"}
+	rt := newCustomTestRuntime(t)
+	if _, err := httpAgent(custom, "secret-key-123456").Run(context.Background(), rt, ExecOptions{}, userMessages()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if auth != "Bearer secret-key-123456" {
+		t.Fatalf("Authorization header = %q, want rendered api_key", auth)
+	}
+}
+
+func TestCustomAgent_RunHTTP_RejectsAPIKeyInURL(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
+	}))
+	defer srv.Close()
+
+	custom := httpEngine(srv.URL + "?token=${api_key}")
+	rt := newCustomTestRuntime(t)
+	_, err := httpAgent(custom, "sk-secret-9999").Run(context.Background(), rt, ExecOptions{}, userMessages())
+	if err == nil || !strings.Contains(err.Error(), "renders the API key into the URL") {
+		t.Fatalf("expected api-key-in-url rejection, got: %v", err)
+	}
+}
+
+func TestCustomAgent_RunHTTP_RejectsNonPostMethod(t *testing.T) {
+	t.Parallel()
+	// Mirrors validateCustomHTTP, covering the --engine override path that
+	// bypasses config validation.
+	custom := httpEngine("http://127.0.0.1:0")
+	custom.HTTP.Method = "GET"
+	rt := newCustomTestRuntime(t)
+	_, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages())
+	if err == nil || !strings.Contains(err.Error(), "method must be POST") {
+		t.Fatalf("expected non-POST rejection, got: %v", err)
+	}
+}
+
+func TestCustomAgent_RunHTTP_FilesNotImplemented(t *testing.T) {
+	t.Parallel()
+	custom := httpEngine("http://127.0.0.1:0")
+	custom.HTTP.Files = []config.CustomHTTPFile{{Path: "diff.patch"}}
+	rt := newCustomTestRuntime(t)
+	_, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages())
+	if err == nil || !strings.Contains(err.Error(), "not yet implemented") {
+		t.Fatalf("expected files-not-implemented error, got: %v", err)
+	}
+}
+
+func TestCustomAgent_RunHTTP_TimeoutFails(t *testing.T) {
+	t.Parallel()
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release // hang past the 1s engine timeout
+		_, _ = io.WriteString(w, `{"exit_code":0}`)
+	}))
+	// Defers run LIFO: close(release) first unblocks the handler, then
+	// srv.Close() can drain it. The reverse order would deadlock Close.
+	defer srv.Close()
+	defer close(release)
+
+	custom := httpEngine(srv.URL)
+	custom.TimeoutSeconds = 1
+	rt := newCustomTestRuntime(t)
+	start := time.Now()
+	_, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages())
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("timeout took too long: %s", elapsed)
+	}
+}
+
+func TestCustomAgent_RunHTTP_MasksAPIKeyInResponse(t *testing.T) {
+	t.Parallel()
+	const key = "supersecret-abcdef"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"leaked `+key+`"}`)
+	}))
+	defer srv.Close()
+
+	rt := newCustomTestRuntime(t)
+	res, err := httpAgent(httpEngine(srv.URL), key).Run(context.Background(), rt, ExecOptions{}, userMessages())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.Contains(res.FinalMessage, key) {
+		t.Fatalf("api key not masked in final_message: %q", res.FinalMessage)
+	}
+}

--- a/internal/agent/custom_http_test.go
+++ b/internal/agent/custom_http_test.go
@@ -131,6 +131,33 @@ func TestCustomAgent_RunHTTP_RequestBodyInjectsSessionInputStructure(t *testing.
 	}
 }
 
+func TestCustomAgent_RunHTTP_ScalarRequestBodyIsSessionInput(t *testing.T) {
+	t.Parallel()
+	// The documented top-level form `request_body: ${session_input}` (a scalar,
+	// not a map) must POST the SessionInput JSON object, not a quoted string.
+	var probe struct {
+		Messages []struct {
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &probe)
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
+	}))
+	defer srv.Close()
+
+	custom := httpEngine(srv.URL)
+	custom.HTTP.RequestBody = "${session_input}"
+	rt := newCustomTestRuntime(t)
+	if _, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(probe.Messages) != 1 || probe.Messages[0].Content != "review the diff" {
+		t.Fatalf("scalar ${session_input} body did not carry the SessionInput: %#v", probe.Messages)
+	}
+}
+
 func TestCustomAgent_RunHTTP_RequestBodyRendersKwargs(t *testing.T) {
 	t.Parallel()
 	var got map[string]string

--- a/internal/agent/custom_test.go
+++ b/internal/agent/custom_test.go
@@ -768,20 +768,6 @@ echo '{"exit_code":0,"final_message":"same-path-ok"}' > '${output_file}'`},
 	}
 }
 
-func TestCustomAgent_RunHTTP_NotImplemented(t *testing.T) {
-	t.Parallel()
-	rt := newCustomTestRuntime(t)
-	ag := customLocalAgent(&config.CustomEngineConfig{
-		Transport: "http",
-		HTTP:      &config.CustomHTTPConfig{URL: "https://example.com"},
-	})
-
-	_, err := ag.Run(context.Background(), rt, ExecOptions{}, userMessages())
-	if err == nil || !strings.Contains(err.Error(), "not yet implemented") {
-		t.Fatalf("error = %v, want not-implemented error", err)
-	}
-}
-
 func TestRenderTemplate(t *testing.T) {
 	t.Setenv("RT_TEST_ENV", "env-value")
 

--- a/internal/config/customengine.go
+++ b/internal/config/customengine.go
@@ -302,8 +302,11 @@ func resolveHTTPEnv(h *CustomHTTPConfig) []string {
 	}
 	if rb, err := resolveEnvRefsInAny(h.RequestBody); err != nil {
 		errs = append(errs, fmt.Sprintf("engine.custom.http.request_body: %s", err))
-	} else if m, ok := rb.(map[string]any); ok {
-		h.RequestBody = m
+	} else {
+		// RequestBody is any (map, sequence, or scalar), so write the resolved
+		// value back unconditionally — a scalar like ${session_input} would be
+		// dropped by a map-only type assertion.
+		h.RequestBody = rb
 	}
 	return errs
 }

--- a/internal/config/customengine_test.go
+++ b/internal/config/customengine_test.go
@@ -5,7 +5,22 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
+
+func TestCustomHTTPConfig_UnmarshalsScalarRequestBody(t *testing.T) {
+	// Regression: request_body was declared map[string]any, so the documented
+	// top-level scalar form `request_body: ${session_input}` failed at YAML
+	// load. It must now accept a scalar value.
+	var h CustomHTTPConfig
+	if err := yaml.Unmarshal([]byte("url: https://x\nrequest_body: ${session_input}\n"), &h); err != nil {
+		t.Fatalf("unmarshal scalar request_body: %v", err)
+	}
+	if h.RequestBody != "${session_input}" {
+		t.Fatalf("RequestBody = %#v, want the scalar string \"${session_input}\"", h.RequestBody)
+	}
+}
 
 func TestResolveCustomEngineEnv_AllForms(t *testing.T) {
 	t.Setenv("CUSTOM_BIN", "/opt/agent")

--- a/internal/config/customengine_test.go
+++ b/internal/config/customengine_test.go
@@ -114,16 +114,16 @@ func TestResolveCustomEngineEnv_BuiltinEngineSkipsResolution(t *testing.T) {
 
 func TestResolveCustomEngineConfig_ValidatesOverriddenEngine(t *testing.T) {
 	// Simulates a --engine override turning a built-in engine (whose custom
-	// block was skipped at load) into a custom one with an unrunnable transport.
+	// block was skipped at load) into a custom one with an invalid config.
 	cfg := &EvalConfig{
 		Engine: EngineConfig{
 			Name:   "my-agent",
-			Custom: &CustomEngineConfig{Transport: "http", HTTP: &CustomHTTPConfig{URL: "https://x"}},
+			Custom: &CustomEngineConfig{Transport: "http", HTTP: &CustomHTTPConfig{}},
 		},
 	}
 	err := ResolveCustomEngineConfig(cfg)
-	if err == nil || !strings.Contains(err.Error(), "http is not yet implemented") {
-		t.Fatalf("error = %v, want the http transport to be rejected", err)
+	if err == nil || !strings.Contains(err.Error(), "http.url is required") {
+		t.Fatalf("error = %v, want the missing http.url to be rejected", err)
 	}
 }
 
@@ -465,9 +465,19 @@ func TestResolveCustomEngineConfig_CustomTransport(t *testing.T) {
 			wantError: "engine.custom.response_format must be one of",
 		},
 		{
-			name:      "http not yet implemented",
-			custom:    &CustomEngineConfig{Transport: "http", HTTP: &CustomHTTPConfig{URL: "https://x"}},
-			wantError: "http is not yet implemented",
+			name:      "http missing url",
+			custom:    &CustomEngineConfig{Transport: "http", HTTP: &CustomHTTPConfig{}},
+			wantError: "engine.custom.http.url is required",
+		},
+		{
+			name:      "http non-POST method",
+			custom:    &CustomEngineConfig{Transport: "http", HTTP: &CustomHTTPConfig{URL: "https://x", Method: "GET"}},
+			wantError: "engine.custom.http.method must be POST",
+		},
+		{
+			name:      "http file upload not yet implemented",
+			custom:    &CustomEngineConfig{Transport: "http", HTTP: &CustomHTTPConfig{URL: "https://x", Files: []CustomHTTPFile{{Path: "diff.patch"}}}},
+			wantError: "engine.custom.http.files (file upload) is not yet implemented",
 		},
 	}
 	for _, tc := range tests {
@@ -479,6 +489,16 @@ func TestResolveCustomEngineConfig_CustomTransport(t *testing.T) {
 				t.Fatalf("error = %v, want %q", err, tc.wantError)
 			}
 		})
+	}
+}
+
+func TestResolveCustomEngineConfig_ValidCustomHTTP(t *testing.T) {
+	cfg := customEngineEvalConfig("my-agent", &CustomEngineConfig{
+		Transport: "http",
+		HTTP:      &CustomHTTPConfig{URL: "https://example.com/run"},
+	})
+	if err := ResolveCustomEngineConfig(cfg); err != nil {
+		t.Fatalf("valid http config rejected: %v", err)
 	}
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -128,13 +128,19 @@ type CustomLocalConfig struct {
 }
 
 // CustomHTTPConfig configures the http transport: a remote or local HTTP agent
-// service. The implementation lands in a follow-up phase.
+// service. JSON request/response is implemented; multipart file upload (Files)
+// is not yet wired and is rejected at validation.
 type CustomHTTPConfig struct {
-	URL         string            `yaml:"url"`
-	Method      string            `yaml:"method,omitempty"` // POST
-	Headers     map[string]string `yaml:"headers,omitempty"`
-	Files       []CustomHTTPFile  `yaml:"files,omitempty"`
-	RequestBody map[string]any    `yaml:"request_body,omitempty"`
+	URL     string            `yaml:"url"`
+	Method  string            `yaml:"method,omitempty"` // POST
+	Headers map[string]string `yaml:"headers,omitempty"`
+	Files   []CustomHTTPFile  `yaml:"files,omitempty"`
+	// RequestBody is an arbitrary YAML value: a map, a sequence, or a scalar
+	// such as `request_body: ${session_input}`. It is rendered by the http
+	// transport (see renderBodyValue), which injects ${session_input} /
+	// ${messages} / ${kwargs} as JSON structures. Declared as `any` so yaml.v3
+	// can unmarshal a top-level scalar, not only a map.
+	RequestBody any `yaml:"request_body,omitempty"`
 }
 
 // CustomHTTPFile declares a workspace file (or glob) uploaded with an HTTP request.

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -237,20 +237,21 @@ func validateEngine(engine EngineConfig) []string {
 func validateCustomEngine(custom *CustomEngineConfig) []string {
 	var errs []string
 
-	// Only the local transport is implemented. The http transport is designed
-	// (see docs/design/custom-engine.md) but rejected here so `skill-up
-	// validate` does not approve a config that every run would fail.
+	// Both the local and http transports are implemented. The http transport
+	// currently supports JSON request/response only; multipart file upload
+	// (engine.custom.http.files) and URL artifact download are follow-ups, so
+	// they are rejected here rather than silently ignored.
 	switch custom.Transport {
 	case "":
-		errs = append(errs, "engine.custom.transport is required (local)")
+		errs = append(errs, "engine.custom.transport is required (local or http)")
 	case customTransportLocal:
 		if custom.Local == nil || custom.Local.Command == "" {
 			errs = append(errs, "engine.custom.local.command is required when transport is local")
 		}
 	case customTransportHTTP:
-		errs = append(errs, "engine.custom.transport: http is not yet implemented; use transport: local")
+		errs = append(errs, validateCustomHTTP(custom.HTTP)...)
 	default:
-		errs = append(errs, fmt.Sprintf("engine.custom.transport must be \"local\" (got %q)", custom.Transport))
+		errs = append(errs, fmt.Sprintf("engine.custom.transport must be \"local\" or \"http\" (got %q)", custom.Transport))
 	}
 
 	if custom.ResponseFormat != "" &&
@@ -272,6 +273,26 @@ func validateCustomEngine(custom *CustomEngineConfig) []string {
 		}
 	}
 
+	return errs
+}
+
+// validateCustomHTTP validates the engine.custom.http block. The http transport
+// supports JSON request/response today; file upload and URL artifact download
+// are follow-ups, so a non-empty files list is rejected as not-yet-implemented.
+func validateCustomHTTP(h *CustomHTTPConfig) []string {
+	if h == nil {
+		return []string{"engine.custom.http.url is required when transport is http"}
+	}
+	var errs []string
+	if h.URL == "" {
+		errs = append(errs, "engine.custom.http.url is required when transport is http")
+	}
+	if h.Method != "" && !strings.EqualFold(h.Method, "POST") {
+		errs = append(errs, fmt.Sprintf("engine.custom.http.method must be POST (got %q)", h.Method))
+	}
+	if len(h.Files) > 0 {
+		errs = append(errs, "engine.custom.http.files (file upload) is not yet implemented")
+	}
 	return errs
 }
 


### PR DESCRIPTION
## Summary

Implements the **JSON core** of the Custom Engine `http` transport (Phase 2). A `transport: http` engine now POSTs the `SessionInput` and parses the `SessionResult` from the response, reusing the transport seam from #51 (`prepareRun → transport.run → assembleResult`) — `httpTransport` is a parallel of `localTransport`, so all result parsing, secret masking, and artifact handling are shared.

Refs `docs/design/custom-engine.md` (HTTP transport). Not `Closes` — multipart file upload and URL artifact download are separate follow-ups.

## What's implemented

- **config** (`validator.go`): `validateCustomEngine` now accepts `http` (requires `http.url`; `method` empty-or-POST; rejects `http.files` as not-yet-implemented) instead of rejecting the transport outright.
- **agent** (`custom.go` `selectTransport` → new `custom_http.go`): renders `${...}` in `http.url` / `http.headers` / `http.request_body`. A `request_body` field whose value is **exactly** `${session_input}` / `${messages}` / `${kwargs}` is injected as a JSON **structure** (`json.RawMessage`), not a quoted string; `request_body` defaults to `${session_input}`. A non-2xx status is an execution error (the body is still salvaged by `assembleResult`). Response bytes are capped at `maxHTTPResponseBytes` (64 MiB).
- **secrets**: the API key is **rejected in the URL** (it would leak in logs/traces) but allowed in headers/body — the sanctioned credential channel (`Authorization: Bearer ${api_key}`). Response, stderr, and the wrapped transport error are all masked via `maskAPIKey`. POST is enforced in `run` too (not only at config load), covering the `--engine` override path.

## Scope / follow-ups

- **PR-B**: multipart file upload (`http.files`) — rejected here as not-yet-implemented.
- **PR-C**: URL artifact download (`artifacts.files[].url`) — `collectArtifacts` still logs "not downloaded".
- **PR-E**: end-to-end http pipeline e2e + design-doc completion.

## Known limitations (noted, not blocking)

- The URL secret guard knows only the model `api_key`; a credential a user templates into the URL from `kwargs` is neither rejected nor masked (skill-up does not treat `kwargs` as secret). The documented channel is headers/body.
- No host allowlist (SSRF): the endpoint is operator config; Go's default client does not forward `Authorization` across cross-host redirects.
- When **no** timeout is configured anywhere (`timeout_seconds` unset, no case/default timeout), there is no deadline — consistent with the local transport, which also relies on the case context.

## Test plan

- [x] `make test` (`go test -race ./...`) — green; new `custom_http_test.go` (httptest-driven: session_result + text, non-2xx, default body = session_input, `${session_input}` structure injection, kwargs render, header api_key render, api-key-in-URL reject, non-POST reject, files not-impl, bounded timeout, response masking).
- [x] `internal/config` http validator cases (valid / missing url / non-POST / files).
- [x] `make verify` (fmt + vet + revive + golangci-lint) — **0 issues**.
- [x] `make e2e` custom-engine (local) suite — green (seam change didn't regress local).

## Notes for reviewers

- This is the first `net/http` client in the repo; client policy (timeout via context + `Client.Timeout`, default TLS, response-size cap, default redirect) is documented inline in `custom_http.go`.
- The stale `TestCustomAgent_RunHTTP_NotImplemented` unit test and the "http is not yet implemented" config assertions were updated/removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)