### PR TITLE
chore(agent): remove unused codexStatusSuccess/codexStatusError consts

### DIFF
--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -45,8 +45,6 @@ const (
 	codexFnCall                 = "function_call"
 	codexFnCallOut              = "function_call_output"
 	codexTokenCount             = "token_count"
-	codexStatusSuccess          = "success"
-	codexStatusError            = "error"
 )
 
 // codexExecPathProbeCmd resolves $HOME/.local/bin (the codex binary, installed


### PR DESCRIPTION
## Summary

`codexStatusSuccess` and `codexStatusError` in `internal/agent/codex.go` are defined but referenced nowhere in the tree — every other const in the same block has at least one use. Pure dead-code removal.

```
$ git grep -n 'codexStatusSuccess\|codexStatusError'
internal/agent/codex.go:  codexStatusSuccess = "success"   # definition only
internal/agent/codex.go:  codexStatusError   = "error"     # definition only
```

## Test plan

- [x] `go build ./...` / `make verify` (0 issues, via pre-commit hook)
- [x] `go test ./internal/agent/` green

Independent cleanup — no dependency on the in-flight custom-engine PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)