### PR TITLE
feat(custom-engine): HTTP transport multipart file upload (http.files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whose value is exactly `${session_input}`, `${messages}`, or `${kwargs}` is
   injected as a JSON structure rather than a string. A non-2xx status is treated
   as an engine execution error, and the API key is rejected in the URL (use a
-  header or the request body instead) and masked in responses. This is the JSON
-  request/response core; multipart file upload (`http.files`) and URL artifact
-  download are follow-ups and are currently rejected as not-yet-implemented.
+  header or the request body instead) and masked in responses.
+- Custom Engine `http` transport multipart file upload (`engine.custom.http.files`):
+  when files are declared the request becomes `multipart/form-data` — the JSON
+  body is sent as the `payload` field and each matched workspace file as a
+  `files` part (the part filename is the workspace-relative path). Paths may be
+  exact or doublestar globs (`*`, `**`), are confined to the workspace, and only
+  regular files are uploaded; `required: true` (the default) errors when an
+  entry matches nothing, `required: false` skips it. URL artifact download in
+  the result remains a follow-up.
 
 ## [0.2.4] - 2026-06-03
 

--- a/internal/agent/custom_http.go
+++ b/internal/agent/custom_http.go
@@ -19,9 +19,9 @@ import (
 // session preparation and result assembly live on CustomAgent, reused via the
 // back-reference.
 //
-// This transport currently supports JSON request/response only. Multipart file
-// upload (engine.custom.http.files) and URL artifact download are follow-ups; a
-// non-empty files list is rejected as not-yet-implemented.
+// It supports JSON request/response and multipart file upload
+// (engine.custom.http.files). URL artifact download in the result is a
+// follow-up.
 type httpTransport struct {
 	a *CustomAgent
 }
@@ -31,7 +31,7 @@ type httpTransport struct {
 // URL, secret in URL, unrenderable template, files configured) is returned as
 // run's error so the run is abandoned; a transport/status failure is carried in
 // transportOutcome.execErr so a partial SessionResult can still be assembled.
-func (t *httpTransport) run(ctx context.Context, _ Runtime, _ ExecOptions, prep *customRunPrep) (*transportOutcome, error) {
+func (t *httpTransport) run(ctx context.Context, rt Runtime, _ ExecOptions, prep *customRunPrep) (*transportOutcome, error) {
 	a := t.a
 	custom := prep.custom
 	// Guard against a nil/unsupported http block: a `--engine` override can
@@ -39,9 +39,6 @@ func (t *httpTransport) run(ctx context.Context, _ Runtime, _ ExecOptions, prep 
 	// built-in engine names).
 	if custom.HTTP == nil || custom.HTTP.URL == "" {
 		return nil, errors.New("engine.custom.http.url is required when transport is http")
-	}
-	if len(custom.HTTP.Files) > 0 {
-		return nil, errors.New("engine.custom.http.files (file upload) is not yet implemented")
 	}
 
 	url, err := renderTemplate(custom.HTTP.URL, prep.vars)
@@ -67,11 +64,6 @@ func (t *httpTransport) run(ctx context.Context, _ Runtime, _ ExecOptions, prep 
 		return nil, err
 	}
 
-	headers, err := renderTemplateMap(custom.HTTP.Headers, prep.vars)
-	if err != nil {
-		return nil, fmt.Errorf("render http.headers: %w", err)
-	}
-
 	// Enforce the custom timeout via a context deadline (mirrors the local
 	// transport); the http.Client.Timeout is a backstop for the case where the
 	// transport ignores ctx.
@@ -84,18 +76,50 @@ func (t *httpTransport) run(ctx context.Context, _ Runtime, _ ExecOptions, prep 
 		defer cancel()
 	}
 
-	req, err := http.NewRequestWithContext(reqCtx, method, url, bytes.NewReader(body))
+	req, err := t.buildRequest(ctx, reqCtx, rt, prep, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	return t.doRequest(&http.Client{Timeout: timeout}, req), nil
+}
+
+// buildRequest constructs the HTTP request. With files configured the request
+// is multipart/form-data — the JSON body becomes the `payload` field and each
+// matched workspace file a `files` part; otherwise it is a plain JSON body.
+// reqCtx carries the per-request deadline; ctx is used for reading workspace
+// files. headers are rendered and applied, and the multipart Content-Type (with
+// boundary) wins over any user-supplied one.
+func (t *httpTransport) buildRequest(ctx, reqCtx context.Context, rt Runtime, prep *customRunPrep, method, url string, jsonBody []byte) (*http.Request, error) {
+	custom := prep.custom
+	reqBody := io.Reader(bytes.NewReader(jsonBody))
+	contentType := ""
+	if len(custom.HTTP.Files) > 0 {
+		mpBody, ct, mErr := t.buildMultipartBody(ctx, rt, custom.HTTP, jsonBody)
+		if mErr != nil {
+			return nil, mErr
+		}
+		reqBody, contentType = bytes.NewReader(mpBody), ct
+	}
+
+	req, err := http.NewRequestWithContext(reqCtx, method, url, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("build http request: %w", err)
+	}
+
+	headers, err := renderTemplateMap(custom.HTTP.Headers, prep.vars)
+	if err != nil {
+		return nil, fmt.Errorf("render http.headers: %w", err)
 	}
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	if req.Header.Get("Content-Type") == "" {
+	switch {
+	case contentType != "":
+		req.Header.Set("Content-Type", contentType)
+	case req.Header.Get("Content-Type") == "":
 		req.Header.Set("Content-Type", "application/json")
 	}
-
-	return t.doRequest(&http.Client{Timeout: timeout}, req), nil
+	return req, nil
 }
 
 // doRequest performs the request and maps the response onto a transportOutcome.

--- a/internal/agent/custom_http_files.go
+++ b/internal/agent/custom_http_files.go
@@ -176,8 +176,10 @@ func listWorkspaceFiles(ctx context.Context, rt Runtime) ([]string, error) {
 		}
 		rel := strings.TrimPrefix(entry, "./")
 		// Defence in depth: never surface an absolute or ..-bearing entry so it
-		// can never reach DownloadFile, regardless of how find behaves.
-		if rel != "" && config.WorkspaceRelPathSafe(rel) {
+		// can never reach DownloadFile, regardless of how find behaves. Also drop
+		// names with a CR/LF — they cannot be safely written into a multipart
+		// Content-Disposition filename (header corruption / injection).
+		if rel != "" && config.WorkspaceRelPathSafe(rel) && !strings.ContainsAny(rel, "\r\n") {
 			files = append(files, rel)
 		}
 	}

--- a/internal/agent/custom_http_files.go
+++ b/internal/agent/custom_http_files.go
@@ -1,0 +1,185 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+
+	"github.com/alibaba/skill-up/internal/config"
+)
+
+// maxHTTPUploadBytes caps the total size of files uploaded in a single
+// multipart request, so a broad glob (e.g. **/*) over a large workspace cannot
+// exhaust memory while the body is assembled in-process.
+const maxHTTPUploadBytes = 256 * 1024 * 1024
+
+// buildMultipartBody assembles a multipart/form-data body: a `payload` field
+// carrying the rendered JSON request body, plus one `files` part per matched
+// workspace file (the part filename is the workspace-relative path). It returns
+// the body bytes and the multipart Content-Type (which carries the boundary).
+func (t *httpTransport) buildMultipartBody(ctx context.Context, rt Runtime, h *config.CustomHTTPConfig, payload []byte) ([]byte, string, error) {
+	relPaths, err := expandHTTPFiles(ctx, rt, h.Files)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	field, err := mw.CreateFormField("payload")
+	if err != nil {
+		return nil, "", fmt.Errorf("http.files: write payload field: %w", err)
+	}
+	if _, err := field.Write(payload); err != nil {
+		return nil, "", fmt.Errorf("http.files: write payload field: %w", err)
+	}
+
+	var total int64
+	for _, rel := range relPaths {
+		if err := addFilePart(ctx, rt, mw, rel, &total); err != nil {
+			return nil, "", err
+		}
+	}
+	if err := mw.Close(); err != nil {
+		return nil, "", fmt.Errorf("http.files: close multipart: %w", err)
+	}
+	return buf.Bytes(), mw.FormDataContentType(), nil
+}
+
+// addFilePart downloads rel to a per-call temp file, enforces the cumulative
+// upload cap using the file's size (so an oversized file is rejected before it
+// is loaded into memory), then streams it into a `files` multipart part. The
+// part filename is the workspace-relative path. The whole multipart body is
+// still buffered in memory, bounded by maxHTTPUploadBytes; with many parallel
+// cases a streaming (io.Pipe) body would lower peak RAM — a future improvement.
+func addFilePart(ctx context.Context, rt Runtime, mw *multipart.Writer, rel string, total *int64) error {
+	tmpFile, err := os.CreateTemp("", "skill-up-http-upload-*")
+	if err != nil {
+		return err
+	}
+	tmp := tmpFile.Name()
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmp) }()
+
+	if err := rt.DownloadFile(ctx, rel, tmp); err != nil {
+		return fmt.Errorf("http.files: read %q: %w", rel, err)
+	}
+	info, err := os.Stat(tmp)
+	if err != nil {
+		return fmt.Errorf("http.files: stat %q: %w", rel, err)
+	}
+	*total += info.Size()
+	if *total > maxHTTPUploadBytes {
+		return fmt.Errorf("http.files: total upload exceeds %d bytes", maxHTTPUploadBytes)
+	}
+
+	f, err := os.Open(tmp)
+	if err != nil {
+		return fmt.Errorf("http.files: open %q: %w", rel, err)
+	}
+	defer func() { _ = f.Close() }()
+	part, err := mw.CreateFormFile("files", rel)
+	if err != nil {
+		return fmt.Errorf("http.files: create part for %q: %w", rel, err)
+	}
+	if _, err := io.Copy(part, f); err != nil {
+		return fmt.Errorf("http.files: write %q: %w", rel, err)
+	}
+	return nil
+}
+
+// expandHTTPFiles resolves the declared file set against the runtime workspace.
+// Each entry's path is an exact workspace-relative path or a doublestar glob;
+// only regular files are uploaded (the workspace listing excludes directories
+// and .git). With required (the default), an entry that matches nothing is an
+// error; with required:false it is skipped. Results are deduplicated and sorted
+// for a deterministic request.
+func expandHTTPFiles(ctx context.Context, rt Runtime, files []config.CustomHTTPFile) ([]string, error) {
+	listing, err := listWorkspaceFiles(ctx, rt)
+	if err != nil {
+		return nil, fmt.Errorf("http.files: list workspace: %w", err)
+	}
+	present := make(map[string]bool, len(listing))
+	for _, rel := range listing {
+		present[rel] = true
+	}
+
+	seen := make(map[string]bool)
+	var out []string
+	for i, f := range files {
+		if !config.WorkspaceRelPathSafe(f.Path) {
+			return nil, fmt.Errorf(
+				"engine.custom.http.files[%d].path %q must be a non-empty relative path inside the workspace", i, f.Path)
+		}
+		var matched []string
+		if isGlobPattern(f.Path) {
+			for _, rel := range listing {
+				ok, mErr := doublestar.Match(f.Path, rel)
+				if mErr != nil {
+					return nil, fmt.Errorf("engine.custom.http.files[%d].path %q: invalid glob: %w", i, f.Path, mErr)
+				}
+				if ok {
+					matched = append(matched, rel)
+				}
+			}
+		} else if present[f.Path] {
+			matched = []string{f.Path}
+		}
+		if len(matched) == 0 {
+			if f.Required == nil || *f.Required {
+				return nil, fmt.Errorf("engine.custom.http.files[%d]: %q matched no files in the workspace", i, f.Path)
+			}
+			continue
+		}
+		for _, m := range matched {
+			if !seen[m] {
+				seen[m] = true
+				out = append(out, m)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// isGlobPattern reports whether p contains glob metacharacters and so must be
+// expanded rather than treated as an exact path.
+func isGlobPattern(p string) bool {
+	return strings.ContainsAny(p, "*?[")
+}
+
+// listWorkspaceFiles returns the workspace-relative paths of every regular file
+// in the runtime workspace (excluding .git). It mirrors the evaluator's
+// artifacts_collect.listWorkspaceFiles; the two are kept separate only because
+// agent cannot import evaluator (evaluator already imports agent). A shared
+// leaf package would consolidate them (see issue #50's theme).
+func listWorkspaceFiles(ctx context.Context, rt Runtime) ([]string, error) {
+	// -print0 (NUL-separated) so a filename containing a newline cannot split
+	// one entry into two — otherwise a crafted name like "a\n/etc/passwd" would
+	// yield a bogus absolute entry that a glob could match and read off the
+	// workspace.
+	result, err := rt.Exec(ctx, "find . -type f -not -path './.git/*' -print0", ExecOptions{Cwd: rt.Workspace()})
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for entry := range strings.SplitSeq(result.Stdout, "\x00") {
+		if entry == "" {
+			continue
+		}
+		rel := strings.TrimPrefix(entry, "./")
+		// Defence in depth: never surface an absolute or ..-bearing entry so it
+		// can never reach DownloadFile, regardless of how find behaves.
+		if rel != "" && config.WorkspaceRelPathSafe(rel) {
+			files = append(files, rel)
+		}
+	}
+	return files, nil
+}

--- a/internal/agent/custom_http_files.go
+++ b/internal/agent/custom_http_files.go
@@ -118,10 +118,14 @@ func expandHTTPFiles(ctx context.Context, rt Runtime, files []config.CustomHTTPF
 			return nil, fmt.Errorf(
 				"engine.custom.http.files[%d].path %q must be a non-empty relative path inside the workspace", i, f.Path)
 		}
+		// listWorkspaceFiles strips a leading ./ from every entry, so normalize
+		// the configured pattern the same way — otherwise "./diff.patch" or
+		// "./src/*.go" would never match the stripped listing.
+		pat := strings.TrimPrefix(f.Path, "./")
 		var matched []string
-		if isGlobPattern(f.Path) {
+		if isGlobPattern(pat) {
 			for _, rel := range listing {
-				ok, mErr := doublestar.Match(f.Path, rel)
+				ok, mErr := doublestar.Match(pat, rel)
 				if mErr != nil {
 					return nil, fmt.Errorf("engine.custom.http.files[%d].path %q: invalid glob: %w", i, f.Path, mErr)
 				}
@@ -129,8 +133,8 @@ func expandHTTPFiles(ctx context.Context, rt Runtime, files []config.CustomHTTPF
 					matched = append(matched, rel)
 				}
 			}
-		} else if present[f.Path] {
-			matched = []string{f.Path}
+		} else if present[pat] {
+			matched = []string{pat}
 		}
 		if len(matched) == 0 {
 			if f.Required == nil || *f.Required {

--- a/internal/agent/custom_http_test.go
+++ b/internal/agent/custom_http_test.go
@@ -401,6 +401,23 @@ func TestExpandHTTPFiles_FiltersUnsafeListingEntries(t *testing.T) {
 	}
 }
 
+func TestExpandHTTPFiles_NormalizesDotSlashPrefix(t *testing.T) {
+	t.Parallel()
+	// A ./-prefixed exact path and glob must match the listing, which has the
+	// ./ stripped from every entry.
+	rt := fakeFindRuntime{workspace: "/ws", findOut: "./diff.patch\x00./src/a.go\x00"}
+	got, err := expandHTTPFiles(context.Background(), rt, []config.CustomHTTPFile{
+		{Path: "./diff.patch"},
+		{Path: "./src/*.go"},
+	})
+	if err != nil {
+		t.Fatalf("expandHTTPFiles: %v", err)
+	}
+	if len(got) != 2 || got[0] != "diff.patch" || got[1] != "src/a.go" {
+		t.Fatalf("expandHTTPFiles = %v, want [diff.patch src/a.go] (./ prefix normalized)", got)
+	}
+}
+
 func TestCustomAgent_RunHTTP_RejectsUnsafeFilePath(t *testing.T) {
 	t.Parallel()
 	rt := newCustomTestRuntime(t)

--- a/internal/agent/custom_http_test.go
+++ b/internal/agent/custom_http_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"mime"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -228,14 +231,186 @@ func TestCustomAgent_RunHTTP_RejectsNonPostMethod(t *testing.T) {
 	}
 }
 
-func TestCustomAgent_RunHTTP_FilesNotImplemented(t *testing.T) {
+func writeWorkspaceFile(t *testing.T, rt Runtime, rel, content string) {
+	t.Helper()
+	p := filepath.Join(rt.Workspace(), filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// captureMultipart parses a multipart request into the payload field and a
+// filename -> content map for the `files` parts.
+func captureMultipart(t *testing.T, r *http.Request) (payload string, files map[string]string) {
+	t.Helper()
+	mr, err := r.MultipartReader()
+	if err != nil {
+		t.Fatalf("not a multipart request: %v", err)
+	}
+	files = map[string]string{}
+	for {
+		part, perr := mr.NextPart()
+		if perr == io.EOF {
+			break
+		}
+		if perr != nil {
+			t.Fatalf("read multipart part: %v", perr)
+		}
+		data, _ := io.ReadAll(part)
+		// part.FileName() returns filepath.Base for receiver-side safety; read
+		// the raw disposition filename to verify the full workspace-relative
+		// path is on the wire.
+		_, params, _ := mime.ParseMediaType(part.Header.Get("Content-Disposition"))
+		switch part.FormName() {
+		case "payload":
+			payload = string(data)
+		case "files":
+			files[params["filename"]] = string(data)
+		}
+	}
+	return payload, files
+}
+
+func TestCustomAgent_RunHTTP_MultipartExactFile(t *testing.T) {
 	t.Parallel()
-	custom := httpEngine("http://127.0.0.1:0")
-	custom.HTTP.Files = []config.CustomHTTPFile{{Path: "diff.patch"}}
+	var (
+		contentType string
+		payload     string
+		files       map[string]string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType = r.Header.Get("Content-Type")
+		payload, files = captureMultipart(t, r)
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
+	}))
+	defer srv.Close()
+
 	rt := newCustomTestRuntime(t)
+	writeWorkspaceFile(t, rt, "diff.patch", "DIFF-CONTENT")
+	custom := httpEngine(srv.URL)
+	custom.HTTP.Files = []config.CustomHTTPFile{{Path: "diff.patch"}}
+	if _, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.HasPrefix(contentType, "multipart/form-data") {
+		t.Fatalf("Content-Type = %q, want multipart/form-data", contentType)
+	}
+	if files["diff.patch"] != "DIFF-CONTENT" {
+		t.Fatalf("file part = %#v, want diff.patch -> DIFF-CONTENT", files)
+	}
+	if !strings.Contains(payload, "review the diff") {
+		t.Fatalf("payload field did not carry the SessionInput: %q", payload)
+	}
+}
+
+func TestCustomAgent_RunHTTP_MultipartGlobExcludesDirsAndNonMatches(t *testing.T) {
+	t.Parallel()
+	var files map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, files = captureMultipart(t, r)
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
+	}))
+	defer srv.Close()
+
+	rt := newCustomTestRuntime(t)
+	writeWorkspaceFile(t, rt, "src/a.go", "A")
+	writeWorkspaceFile(t, rt, "src/b.go", "B")
+	writeWorkspaceFile(t, rt, "README.md", "readme")
+	custom := httpEngine(srv.URL)
+	custom.HTTP.Files = []config.CustomHTTPFile{{Path: "src/*.go"}}
+	if _, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(files) != 2 || files["src/a.go"] != "A" || files["src/b.go"] != "B" {
+		t.Fatalf("glob upload = %#v, want exactly src/a.go and src/b.go", files)
+	}
+	if _, ok := files["README.md"]; ok {
+		t.Fatalf("non-matching README.md should not be uploaded: %#v", files)
+	}
+	if _, ok := files["src"]; ok {
+		t.Fatalf("directory src should never be uploaded as a part: %#v", files)
+	}
+}
+
+func TestCustomAgent_RunHTTP_RequiredFileMissingErrors(t *testing.T) {
+	t.Parallel()
+	rt := newCustomTestRuntime(t)
+	custom := httpEngine("http://127.0.0.1:0")
+	custom.HTTP.Files = []config.CustomHTTPFile{{Path: "nope.txt"}} // required defaults to true
 	_, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages())
-	if err == nil || !strings.Contains(err.Error(), "not yet implemented") {
-		t.Fatalf("expected files-not-implemented error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "matched no files") {
+		t.Fatalf("expected required-missing error, got: %v", err)
+	}
+}
+
+func TestCustomAgent_RunHTTP_OptionalMissingSkipped(t *testing.T) {
+	t.Parallel()
+	var files map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, files = captureMultipart(t, r)
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
+	}))
+	defer srv.Close()
+
+	rt := newCustomTestRuntime(t)
+	optional := false
+	custom := httpEngine(srv.URL)
+	custom.HTTP.Files = []config.CustomHTTPFile{{Path: "nope.txt", Required: &optional}}
+	if _, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("optional missing file should be skipped, got parts: %#v", files)
+	}
+}
+
+func TestCustomAgent_RunHTTP_MultipartNewlineFilenameStaysOneEntry(t *testing.T) {
+	t.Parallel()
+	// Regression: with newline-separated `find` output a filename containing a
+	// newline would split into a bogus (possibly absolute) entry. -print0 keeps
+	// it a single in-workspace entry; assert it uploads intact with no escape.
+	var files map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, files = captureMultipart(t, r)
+		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
+	}))
+	defer srv.Close()
+
+	rt := newCustomTestRuntime(t)
+	weird := "weird\n/etc/passwd"
+	writeWorkspaceFile(t, rt, weird, "IN-WORKSPACE")
+	custom := httpEngine(srv.URL)
+	custom.HTTP.Files = []config.CustomHTTPFile{{Path: "**/*"}}
+	if _, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Exactly one part (no newline split), carrying the in-workspace content,
+	// and no separate off-workspace entry. The header encodes the newline, so
+	// match on content rather than the exact (encoded) filename.
+	if len(files) != 1 {
+		t.Fatalf("newline filename should be a single upload entry, got: %#v", files)
+	}
+	for name, content := range files {
+		if content != "IN-WORKSPACE" {
+			t.Fatalf("uploaded content = %q, want IN-WORKSPACE", content)
+		}
+		if name == "/etc/passwd" {
+			t.Fatalf("newline split produced an off-workspace entry: %q", name)
+		}
+	}
+}
+
+func TestCustomAgent_RunHTTP_RejectsUnsafeFilePath(t *testing.T) {
+	t.Parallel()
+	rt := newCustomTestRuntime(t)
+	custom := httpEngine("http://127.0.0.1:0")
+	custom.HTTP.Files = []config.CustomHTTPFile{{Path: "../escape.txt"}}
+	_, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages())
+	if err == nil || !strings.Contains(err.Error(), "relative path inside the workspace") {
+		t.Fatalf("expected unsafe-path rejection, got: %v", err)
 	}
 }
 

--- a/internal/agent/custom_http_test.go
+++ b/internal/agent/custom_http_test.go
@@ -367,39 +367,37 @@ func TestCustomAgent_RunHTTP_OptionalMissingSkipped(t *testing.T) {
 	}
 }
 
-func TestCustomAgent_RunHTTP_MultipartNewlineFilenameStaysOneEntry(t *testing.T) {
-	t.Parallel()
-	// Regression: with newline-separated `find` output a filename containing a
-	// newline would split into a bogus (possibly absolute) entry. -print0 keeps
-	// it a single in-workspace entry; assert it uploads intact with no escape.
-	var files map[string]string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, files = captureMultipart(t, r)
-		_, _ = io.WriteString(w, `{"exit_code":0,"final_message":"ok"}`)
-	}))
-	defer srv.Close()
+// fakeFindRuntime is a minimal Runtime whose Exec returns canned `find` output,
+// used to test that listWorkspaceFiles/expandHTTPFiles filter unsafe entries
+// without needing real (and non-portable) exotic filenames. Only Exec and
+// Workspace are exercised; other methods would panic via the nil embedded
+// interface if called.
+type fakeFindRuntime struct {
+	Runtime
 
-	rt := newCustomTestRuntime(t)
-	weird := "weird\n/etc/passwd"
-	writeWorkspaceFile(t, rt, weird, "IN-WORKSPACE")
-	custom := httpEngine(srv.URL)
-	custom.HTTP.Files = []config.CustomHTTPFile{{Path: "**/*"}}
-	if _, err := httpAgent(custom, "").Run(context.Background(), rt, ExecOptions{}, userMessages()); err != nil {
-		t.Fatalf("Run: %v", err)
+	workspace string
+	findOut   string
+}
+
+func (f fakeFindRuntime) Workspace() string { return f.workspace }
+func (f fakeFindRuntime) Exec(_ context.Context, _ string, _ ExecOptions) (ExecResult, error) {
+	return ExecResult{Stdout: f.findOut}, nil
+}
+
+func TestExpandHTTPFiles_FiltersUnsafeListingEntries(t *testing.T) {
+	t.Parallel()
+	// Simulated `find -print0` output: a safe relative file, an absolute entry
+	// (what a newline split would have produced without -print0), and a name
+	// containing a newline (cannot be a safe multipart filename). Only the safe
+	// relative path must survive — the others are filtered before any download.
+	out := "./src/a.go\x00/etc/passwd\x00./bad\nname.txt\x00"
+	rt := fakeFindRuntime{workspace: "/ws", findOut: out}
+	got, err := expandHTTPFiles(context.Background(), rt, []config.CustomHTTPFile{{Path: "**/*"}})
+	if err != nil {
+		t.Fatalf("expandHTTPFiles: %v", err)
 	}
-	// Exactly one part (no newline split), carrying the in-workspace content,
-	// and no separate off-workspace entry. The header encodes the newline, so
-	// match on content rather than the exact (encoded) filename.
-	if len(files) != 1 {
-		t.Fatalf("newline filename should be a single upload entry, got: %#v", files)
-	}
-	for name, content := range files {
-		if content != "IN-WORKSPACE" {
-			t.Fatalf("uploaded content = %q, want IN-WORKSPACE", content)
-		}
-		if name == "/etc/passwd" {
-			t.Fatalf("newline split produced an off-workspace entry: %q", name)
-		}
+	if len(got) != 1 || got[0] != "src/a.go" {
+		t.Fatalf("expandHTTPFiles = %v, want [src/a.go] (absolute and CR/LF entries filtered)", got)
 	}
 }
 

--- a/internal/config/customengine_test.go
+++ b/internal/config/customengine_test.go
@@ -490,9 +490,14 @@ func TestResolveCustomEngineConfig_CustomTransport(t *testing.T) {
 			wantError: "engine.custom.http.method must be POST",
 		},
 		{
-			name:      "http file upload not yet implemented",
-			custom:    &CustomEngineConfig{Transport: "http", HTTP: &CustomHTTPConfig{URL: "https://x", Files: []CustomHTTPFile{{Path: "diff.patch"}}}},
-			wantError: "engine.custom.http.files (file upload) is not yet implemented",
+			name:      "http file path escapes workspace",
+			custom:    &CustomEngineConfig{Transport: "http", HTTP: &CustomHTTPConfig{URL: "https://x", Files: []CustomHTTPFile{{Path: "../escape"}}}},
+			wantError: "must be a non-empty relative path inside the workspace",
+		},
+		{
+			name:      "http file path absolute",
+			custom:    &CustomEngineConfig{Transport: "http", HTTP: &CustomHTTPConfig{URL: "https://x", Files: []CustomHTTPFile{{Path: "/etc/passwd"}}}},
+			wantError: "must be a non-empty relative path inside the workspace",
 		},
 	}
 	for _, tc := range tests {
@@ -510,10 +515,13 @@ func TestResolveCustomEngineConfig_CustomTransport(t *testing.T) {
 func TestResolveCustomEngineConfig_ValidCustomHTTP(t *testing.T) {
 	cfg := customEngineEvalConfig("my-agent", &CustomEngineConfig{
 		Transport: "http",
-		HTTP:      &CustomHTTPConfig{URL: "https://example.com/run"},
+		HTTP: &CustomHTTPConfig{
+			URL:   "https://example.com/run",
+			Files: []CustomHTTPFile{{Path: "diff.patch"}, {Path: "src/**/*.go"}},
+		},
 	})
 	if err := ResolveCustomEngineConfig(cfg); err != nil {
-		t.Fatalf("valid http config rejected: %v", err)
+		t.Fatalf("valid http config (with files) rejected: %v", err)
 	}
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -128,8 +128,8 @@ type CustomLocalConfig struct {
 }
 
 // CustomHTTPConfig configures the http transport: a remote or local HTTP agent
-// service. JSON request/response is implemented; multipart file upload (Files)
-// is not yet wired and is rejected at validation.
+// service. JSON request/response and multipart file upload (Files) are
+// implemented; URL artifact download in the result is a follow-up.
 type CustomHTTPConfig struct {
 	URL     string            `yaml:"url"`
 	Method  string            `yaml:"method,omitempty"` // POST

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -237,10 +238,9 @@ func validateEngine(engine EngineConfig) []string {
 func validateCustomEngine(custom *CustomEngineConfig) []string {
 	var errs []string
 
-	// Both the local and http transports are implemented. The http transport
-	// currently supports JSON request/response only; multipart file upload
-	// (engine.custom.http.files) and URL artifact download are follow-ups, so
-	// they are rejected here rather than silently ignored.
+	// Both the local and http transports are implemented (JSON request/response
+	// and multipart file upload). URL artifact download in the result is a
+	// follow-up.
 	switch custom.Transport {
 	case "":
 		errs = append(errs, "engine.custom.transport is required (local or http)")
@@ -276,9 +276,9 @@ func validateCustomEngine(custom *CustomEngineConfig) []string {
 	return errs
 }
 
-// validateCustomHTTP validates the engine.custom.http block. The http transport
-// supports JSON request/response today; file upload and URL artifact download
-// are follow-ups, so a non-empty files list is rejected as not-yet-implemented.
+// validateCustomHTTP validates the engine.custom.http block: url is required,
+// method must be POST, and each files[].path must be a workspace-relative path
+// or glob. URL artifact download in the result is a follow-up.
 func validateCustomHTTP(h *CustomHTTPConfig) []string {
 	if h == nil {
 		return []string{"engine.custom.http.url is required when transport is http"}
@@ -290,10 +290,21 @@ func validateCustomHTTP(h *CustomHTTPConfig) []string {
 	if h.Method != "" && !strings.EqualFold(h.Method, "POST") {
 		errs = append(errs, fmt.Sprintf("engine.custom.http.method must be POST (got %q)", h.Method))
 	}
-	if len(h.Files) > 0 {
-		errs = append(errs, "engine.custom.http.files (file upload) is not yet implemented")
+	for i := range h.Files {
+		if p := h.Files[i].Path; !WorkspaceRelPathSafe(p) {
+			errs = append(errs, fmt.Sprintf(
+				"engine.custom.http.files[%d].path %q must be a non-empty relative path inside the workspace (no leading / or ..)", i, p))
+		}
 	}
 	return errs
+}
+
+// WorkspaceRelPathSafe reports whether p is a non-empty, workspace-relative
+// path or glob: not absolute and with no ".." segment. It is shared by config
+// validation and the http transport's file expansion so both apply the same
+// rule (agent imports config).
+func WorkspaceRelPathSafe(p string) bool {
+	return p != "" && !strings.HasPrefix(p, "/") && !slices.Contains(strings.Split(p, "/"), "..")
 }
 
 func isValidRuntimeType(t string) bool {


### PR DESCRIPTION
## Summary

Builds on the http JSON core (#99). When `engine.custom.http.files` is declared, the request becomes **`multipart/form-data`** — the rendered JSON body is sent as the `payload` field and each matched workspace file as a `files` part (the part filename is the workspace-relative path). Without files the request stays plain JSON (unchanged).

Refs `docs/design/custom-engine.md` (HTTP file upload). Not `Closes` — URL artifact download in the result is the remaining follow-up (PR-C).

## What's implemented

- **config** (`validator.go`): `validateCustomHTTP` accepts files; each `path` must be a non-empty workspace-relative path (no leading `/` or `..`). The shared `config.WorkspaceRelPathSafe` applies the same rule at config load and in the transport.
- **agent** (`custom_http_files.go`): `expandHTTPFiles` resolves each entry against the workspace file listing — exact path or doublestar glob (`*`, `**`); only **regular files** (the `find -type f` listing excludes directories and `.git`); `required: true` (default) errors on no match, `required: false` skips; results deduped + sorted. `buildMultipartBody`/`addFilePart` stream each file (download → `os.Stat` cap-check → `io.Copy`) with a 256 MiB cumulative cap.
- **agent** (`custom_http.go`): `run` dispatches JSON vs multipart via a new `buildRequest`; the multipart `Content-Type` (with boundary) wins over any user header.

## Security hardening (from self-review)

- **`find -print0`** (NUL-separated) instead of newline-separated: a workspace filename containing a newline can no longer split one listing entry into a bogus absolute path that a `**/*` glob would match and read off-workspace. Listing entries are additionally filtered through `WorkspaceRelPathSafe`. Regression test included.
- **Effective size cap**: the file size is checked via `os.Stat` *before* loading, and content is streamed (`io.Copy`), so a single oversized file is rejected before it is read into memory.
- Invalid glob patterns now surface an error instead of silently matching nothing.

## Known limitations

- The multipart body is assembled in memory bounded by `maxHTTPUploadBytes` (256 MiB); with many parallel cases peak RAM is `N × cap`. A streaming `io.Pipe` body would lower it — a future improvement (noted in code).
- `internal/evaluator/artifacts_collect.go::listWorkspaceFiles` has the **same** pre-existing newline-split issue; out of scope here, flagged for a separate fix.

## Test plan

- [x] `make test` (`go test -race ./...`) — green; new `custom_http_test.go` multipart cases: exact file, glob (excludes dirs + non-matches), required-missing error, optional-missing skip, unsafe-path reject, newline-filename regression, multipart Content-Type, payload carries `SessionInput`.
- [x] `internal/config` http file-path validator cases (valid globs / `..` / absolute).
- [x] `make verify` (fmt + vet + revive + golangci-lint) — **0 issues**.
- [x] `make e2e` custom-engine (local + http JSON) suite — green.

## Notes for reviewers

- `listWorkspaceFiles` mirrors the evaluator's collect-artifacts lister; they stay separate only because `agent` cannot import `evaluator` (a shared leaf package would consolidate them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)