### PR TITLE
feat(custom-engine): download artifacts.files[].url artifacts into the report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   injected as a JSON structure rather than a string. A non-2xx status is treated
   as an engine execution error, and the API key is rejected in the URL (use a
   header or the request body instead) and masked in responses. This is the JSON
-  request/response core; multipart file upload (`http.files`) and URL artifact
-  download are follow-ups and are currently rejected as not-yet-implemented.
+  request/response core; multipart file upload (`http.files`) is a follow-up and
+  is currently rejected as not-yet-implemented.
+- Custom Engine: download `artifacts.files[].url` artifacts into the report. A
+  result that declares a downloadable `url` is fetched (http/https only) and
+  written into the case artifact directory under `name`. The download is
+  best-effort and bounded (256 MB cap, request timeout): a non-2xx status,
+  transport error, non-http(s) scheme, or over-cap body is logged and skipped
+  without failing the run. A URL embedding the configured API key is refused, and
+  logged errors are scrubbed of the configured `api_key` / `engine.custom.env`
+  secrets.
 
 ## [0.2.4] - 2026-06-03
 

--- a/docs/design/custom-engine.md
+++ b/docs/design/custom-engine.md
@@ -338,7 +338,15 @@ Every file that needs to enter the report directory must be explicitly declared 
 - Built-in agents and Custom Agents follow the same rule.
 - An agent running inside the runtime may declare a `path` inside the runtime
   workspace.
-- An HTTP or other remote agent may declare a downloadable `url`.
+- An HTTP or other remote agent may declare a downloadable `url`. `skill-up`
+  GETs the exact declared URL (http/https only) and writes the body into the
+  report's artifact directory under `name`. The download is best-effort and
+  bounded (256 MB cap, request timeout): a non-2xx status, transport error, or
+  over-cap body is logged and skipped without failing the run. A URL embedding
+  the configured API key is refused up front, and logged error strings are
+  scrubbed of the configured `api_key` and `engine.custom.env` secrets. Only the
+  declared URL is fetched — SSRF is the engine/operator's responsibility, the
+  same trust posture as the HTTP transport.
 - Any agent may declare `content` or `content_base64` for small files.
 
 Undeclared files are not detected, downloaded, or written into the report directory by
@@ -802,6 +810,11 @@ The hardening below is enforced in code; treat each item as part of the contract
   in aggregate** per `SessionResult`. The pre-decode estimate uses
   `len(content_base64) * 3 / 4`; an exact post-decode check enforces the cap if the
   estimate was off.
+- `artifacts.files[].url` downloads are read through an `io.LimitReader` capped at
+  **256 MB** and a per-download timeout; an over-cap body, a non-2xx status, a
+  non-http(s) scheme, or a transport error is logged and skipped without failing
+  the run. The download writes to the report's artifact directory, not the
+  workspace, so it bypasses the `f.Path` workspace confinement by construction.
 
 ### Process and time bounds
 

--- a/docs/design/custom-engine.md
+++ b/docs/design/custom-engine.md
@@ -345,8 +345,10 @@ Every file that needs to enter the report directory must be explicitly declared 
   over-cap body is logged and skipped without failing the run. A URL embedding
   the configured API key is refused up front, and logged error strings are
   scrubbed of the configured `api_key` and `engine.custom.env` secrets. Only the
-  declared URL is fetched — SSRF is the engine/operator's responsibility, the
-  same trust posture as the HTTP transport.
+  declared URL is fetched and **redirects are not followed** (a 3xx is skipped),
+  so the artifact host cannot redirect the fetch to a different endpoint — SSRF
+  is otherwise the engine/operator's responsibility, the same trust posture as
+  the HTTP transport.
 - Any agent may declare `content` or `content_base64` for small files.
 
 Undeclared files are not detected, downloaded, or written into the report directory by
@@ -811,10 +813,11 @@ The hardening below is enforced in code; treat each item as part of the contract
   `len(content_base64) * 3 / 4`; an exact post-decode check enforces the cap if the
   estimate was off.
 - `artifacts.files[].url` downloads are read through an `io.LimitReader` capped at
-  **256 MB** and a per-download timeout; an over-cap body, a non-2xx status, a
-  non-http(s) scheme, or a transport error is logged and skipped without failing
-  the run. The download writes to the report's artifact directory, not the
-  workspace, so it bypasses the `f.Path` workspace confinement by construction.
+  **256 MB** and a per-download timeout; an over-cap body, a non-2xx status (3xx
+  redirects are not followed), a non-http(s) scheme, or a transport error is
+  logged and skipped without failing the run. The download writes to the report's
+  artifact directory, not the workspace, so it bypasses the `f.Path` workspace
+  confinement by construction.
 
 ### Process and time bounds
 

--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -858,8 +858,18 @@ func (a *CustomAgent) downloadURLArtifact(ctx context.Context, opts ExecOptions,
 
 	// url is engine-declared (SessionResult.artifacts.files[].url); fetching the
 	// exact declared endpoint is the documented contract and the engine/operator
-	// is the trust boundary, the same posture as the http transport.
-	client := &http.Client{Timeout: customArtifactDownloadTimeout}
+	// is the trust boundary, the same posture as the http transport. Redirects
+	// are NOT followed: a 3xx would let the artifact host (or the engine) swap
+	// the archived bytes for a Location pointing at a different — possibly
+	// internal — endpoint, breaking the "exact declared URL" boundary and the
+	// up-front api-key/scheme checks. ErrUseLastResponse returns the 3xx as-is so
+	// it falls through to the non-2xx skip path below.
+	client := &http.Client{
+		Timeout: customArtifactDownloadTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	resp, err := client.Do(req) //nolint:gosec // intentional engine-declared dynamic URL
 	if err != nil {
 		// The net/http error embeds the request URL; mask it so a credential a

--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -45,12 +48,25 @@ const (
 	// read, so a misbehaving or malicious agent service cannot exhaust memory
 	// with an unbounded SessionResult payload.
 	maxHTTPResponseBytes = 64 * 1024 * 1024
+	// customArtifactDownloadTimeout bounds a single best-effort url artifact
+	// download so a slow or hung remote cannot stall report assembly.
+	customArtifactDownloadTimeout = 60 * time.Second
 )
+
+// maxArtifactDownloadBytes caps how many bytes are read from a declared
+// artifacts.files[].url before the download is abandoned. Sized larger than
+// maxHTTPResponseBytes (a single JSON SessionResult) because a downloadable
+// artifact may be a whole report or archive, while still bounding what a
+// misbehaving engine can pull into the report directory. It is a var, not a
+// const, only so the size-cap test can lower it without transferring hundreds
+// of megabytes.
+var maxArtifactDownloadBytes int64 = 256 * 1024 * 1024
 
 // CustomAgent implements Agent for user-defined engines configured via
 // engine.custom. The local transport is fully supported; the http transport
-// supports JSON request/response, with multipart file upload and URL artifact
-// download still pending. See docs/design/custom-engine.md.
+// supports JSON request/response, with multipart file upload still pending.
+// Result artifacts declared via a `url` are downloaded for any transport. See
+// docs/design/custom-engine.md.
 //
 // CustomAgent embeds BaseAgent directly (not CLIAgent) so it inherits only
 // shared agent infrastructure — Name, credential helpers, exec-options merge,
@@ -684,8 +700,8 @@ func validateArtifactSize(i int, f ArtifactFile, runningTotal int64) (int64, err
 // pipeline: path entries register the original workspace path (so the
 // workspace-diff collector excludes it) and, when the declared name differs
 // from the basename, additionally archive a copy under that name; inline
-// content is written to the case artifact directory. url-based artifacts are
-// deferred to the http phase.
+// content is written to the case artifact directory; url-based artifacts are
+// downloaded into the case artifact directory (best-effort).
 func (a *CustomAgent) collectArtifacts(ctx context.Context, rt Runtime, opts ExecOptions, artifacts *SessionArtifacts) {
 	// Drop any engine-supplied generated_files paths that escape the
 	// workspace. On the none runtime an absolute path is the host path, so an
@@ -714,7 +730,9 @@ func (a *CustomAgent) collectArtifacts(ctx context.Context, rt Runtime, opts Exe
 				artifacts.GeneratedFiles = append(artifacts.GeneratedFiles, path)
 			}
 		case f.URL != "":
-			logging.DebugContextf(ctx, "CustomAgent: artifact %q url is not downloaded in the local transport", f.Name)
+			if path := a.downloadURLArtifact(ctx, opts, f); path != "" {
+				artifacts.GeneratedFiles = append(artifacts.GeneratedFiles, path)
+			}
 		}
 	}
 }
@@ -789,6 +807,87 @@ func (a *CustomAgent) writeInlineArtifact(ctx context.Context, opts ExecOptions,
 	path, err := writeLocalArtifact(opts.ArtifactDir, f.Name, content)
 	if err != nil {
 		logging.WarnContextf(ctx, "CustomAgent: cannot write inline artifact %q: %v", f.Name, err)
+		return ""
+	}
+	return path
+}
+
+// downloadURLArtifact fetches a declared artifacts.files[].url and writes the
+// body into the case artifact directory under f.Name, returning the local path.
+//
+// It is best-effort, mirroring the rest of artifact handling: a non-http(s)
+// scheme, a transport error, a non-2xx status, or an over-cap body is logged as
+// a warning and yields an empty string so the run still succeeds. Only the exact
+// URL the engine declared is fetched — SSRF is out of scope by the same posture
+// as the http transport, where the engine/operator is the trust boundary. A URL
+// that embeds the configured API key is refused up front (it would otherwise be
+// transmitted to the engine-declared endpoint and its proxies), and every error
+// string — which net/http builds with the request URL — is passed through
+// maskAPIKey so the configured api_key and engine.custom.env secrets cannot
+// survive into the log. The download writes to the artifact output dir, never
+// the workspace, so it bypasses the workspacePath confinement used for f.Path.
+func (a *CustomAgent) downloadURLArtifact(ctx context.Context, opts ExecOptions, f ArtifactFile) string {
+	if opts.ArtifactDir == "" || f.Name == "" {
+		return ""
+	}
+	parsed, err := url.Parse(f.URL)
+	if err != nil {
+		logging.WarnContextf(ctx, "CustomAgent: artifact %q has an invalid url: %v", f.Name, a.maskAPIKey(err.Error()))
+		return ""
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		logging.WarnContextf(ctx, "CustomAgent: artifact %q url scheme %q is not http(s); skipping", f.Name, parsed.Scheme)
+		return ""
+	}
+	// A URL embedding the configured API key would transmit it to the
+	// engine-declared endpoint (and into its request logs and proxies), the
+	// same leak errSecretInURL guards against for the http transport. The engine
+	// is untrusted, so refuse rather than fetch.
+	if a.containsAPIKey(f.URL) {
+		logging.WarnContextf(ctx, "CustomAgent: artifact %q url embeds the API key; skipping download", f.Name)
+		return ""
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, customArtifactDownloadTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, f.URL, nil)
+	if err != nil {
+		logging.WarnContextf(ctx, "CustomAgent: cannot build request for artifact %q: %v", f.Name, a.maskAPIKey(err.Error()))
+		return ""
+	}
+
+	// url is engine-declared (SessionResult.artifacts.files[].url); fetching the
+	// exact declared endpoint is the documented contract and the engine/operator
+	// is the trust boundary, the same posture as the http transport.
+	client := &http.Client{Timeout: customArtifactDownloadTimeout}
+	resp, err := client.Do(req) //nolint:gosec // intentional engine-declared dynamic URL
+	if err != nil {
+		// The net/http error embeds the request URL; mask it so a credential a
+		// user mistakenly put in the URL cannot leak into the warning log.
+		logging.WarnContextf(ctx, "CustomAgent: cannot download artifact %q: %v", f.Name, a.maskAPIKey(err.Error()))
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		logging.WarnContextf(ctx, "CustomAgent: artifact %q url returned status %d; skipping", f.Name, resp.StatusCode)
+		return ""
+	}
+
+	// Read one byte past the cap so an over-limit body is rejected rather than
+	// silently truncated into the report.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxArtifactDownloadBytes+1))
+	if err != nil {
+		logging.WarnContextf(ctx, "CustomAgent: cannot read artifact %q body: %v", f.Name, a.maskAPIKey(err.Error()))
+		return ""
+	}
+	if int64(len(body)) > maxArtifactDownloadBytes {
+		logging.WarnContextf(ctx, "CustomAgent: artifact %q exceeds download size limit %d bytes; dropping", f.Name, maxArtifactDownloadBytes)
+		return ""
+	}
+
+	path, err := writeLocalArtifact(opts.ArtifactDir, f.Name, string(body))
+	if err != nil {
+		logging.WarnContextf(ctx, "CustomAgent: cannot write downloaded artifact %q: %v", f.Name, err)
 		return ""
 	}
 	return path

--- a/internal/agent/custom_artifact_url_test.go
+++ b/internal/agent/custom_artifact_url_test.go
@@ -110,6 +110,46 @@ func TestCustomAgent_CollectArtifacts_URLUnreachableSkipped(t *testing.T) {
 	}
 }
 
+// TestCustomAgent_CollectArtifacts_URLRedirectNotFollowed ensures a 3xx from the
+// declared url is not followed: the redirect target's bytes must not be
+// archived, so the artifact host cannot swap the content for a different
+// (possibly internal) endpoint. The 3xx falls through to the non-2xx skip path.
+func TestCustomAgent_CollectArtifacts_URLRedirectNotFollowed(t *testing.T) {
+	t.Parallel()
+	var targetHit bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetHit = true
+		_, _ = io.WriteString(w, "internal-secret-body")
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	rt := newCustomTestRuntime(t)
+	artifactDir := t.TempDir()
+	ag := customLocalAgent(&config.CustomEngineConfig{Transport: "http"})
+	artifacts := &SessionArtifacts{Files: []ArtifactFile{{Name: "r.txt", URL: redirector.URL}}}
+
+	out := captureStdout(t, func() {
+		ag.collectArtifacts(context.Background(), rt, ExecOptions{ArtifactDir: artifactDir}, artifacts)
+	})
+	if targetHit {
+		t.Fatal("redirect target was fetched; redirects must not be followed")
+	}
+	if containsBasename(artifacts.GeneratedFiles, "r.txt") {
+		t.Fatalf("generated_files = %v, want the redirect skipped", artifacts.GeneratedFiles)
+	}
+	if _, err := os.Stat(filepath.Join(artifactDir, "r.txt")); !os.IsNotExist(err) {
+		t.Fatalf("r.txt should not have been written (stat err = %v)", err)
+	}
+	if !strings.Contains(out, "returned status 302") {
+		t.Fatalf("logs = %q, want a 3xx skip warning", out)
+	}
+}
+
 // TestCustomAgent_CollectArtifacts_URLNonHTTPSchemeSkipped rejects a non-http(s)
 // scheme (e.g. file://) before any request is made.
 func TestCustomAgent_CollectArtifacts_URLNonHTTPSchemeSkipped(t *testing.T) {

--- a/internal/agent/custom_artifact_url_test.go
+++ b/internal/agent/custom_artifact_url_test.go
@@ -1,0 +1,221 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/skill-up/internal/config"
+)
+
+// TestCustomAgent_CollectArtifacts_URLDownloaded exercises the happy path: a
+// declared artifacts.files[].url is fetched and written into the artifact dir,
+// then registered in GeneratedFiles with the served content.
+func TestCustomAgent_CollectArtifacts_URLDownloaded(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "remote-body")
+	}))
+	defer srv.Close()
+
+	rt := newCustomTestRuntime(t)
+	artifactDir := t.TempDir()
+	ag := customLocalAgent(&config.CustomEngineConfig{Transport: "http"})
+	artifacts := &SessionArtifacts{
+		Files: []ArtifactFile{{Name: "remote-report.html", URL: srv.URL}},
+	}
+	ag.collectArtifacts(context.Background(), rt, ExecOptions{ArtifactDir: artifactDir}, artifacts)
+
+	if !containsBasename(artifacts.GeneratedFiles, "remote-report.html") {
+		t.Fatalf("generated_files = %v, want the downloaded artifact registered", artifacts.GeneratedFiles)
+	}
+	data, err := os.ReadFile(filepath.Join(artifactDir, "remote-report.html"))
+	if err != nil || string(data) != "remote-body" {
+		t.Fatalf("downloaded artifact = %q (err %v), want remote-body", data, err)
+	}
+}
+
+// TestCustomAgent_RunHTTP_URLArtifactNon2xxSucceeds proves artifact download is
+// best-effort end to end: the engine returns a successful SessionResult that
+// declares a url pointing at a 500 endpoint; the run still succeeds and the
+// artifact is simply skipped.
+func TestCustomAgent_RunHTTP_URLArtifactNon2xxSucceeds(t *testing.T) {
+	t.Parallel()
+	artSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	defer artSrv.Close()
+
+	runSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, fmt.Sprintf(
+			`{"exit_code":0,"final_message":"ok","artifacts":{"files":[{"name":"a.txt","url":%q}]}}`,
+			artSrv.URL,
+		))
+	}))
+	defer runSrv.Close()
+
+	rt := newCustomTestRuntime(t)
+	artifactDir := t.TempDir()
+
+	out := captureStdout(t, func() {
+		res, err := httpAgent(httpEngine(runSrv.URL), "").Run(
+			context.Background(), rt, ExecOptions{ArtifactDir: artifactDir}, userMessages())
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if res.ExitCode != 0 || res.FinalMessage != "ok" {
+			t.Fatalf("unexpected result: %#v", res)
+		}
+		if containsBasename(res.Artifacts.GeneratedFiles, "a.txt") {
+			t.Fatalf("generated_files = %v, want the failed download skipped", res.Artifacts.GeneratedFiles)
+		}
+	})
+	if !strings.Contains(out, "returned status 500") {
+		t.Fatalf("logs = %q, want a non-2xx warning", out)
+	}
+	if _, err := os.Stat(filepath.Join(artifactDir, "a.txt")); !os.IsNotExist(err) {
+		t.Fatalf("a.txt should not have been written (stat err = %v)", err)
+	}
+}
+
+// TestCustomAgent_CollectArtifacts_URLUnreachableSkipped covers a transport
+// error: the url's host is unreachable (server already closed). The artifact is
+// dropped with a warning and the run is unaffected.
+func TestCustomAgent_CollectArtifacts_URLUnreachableSkipped(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := srv.URL
+	srv.Close() // nothing listens on deadURL now
+
+	rt := newCustomTestRuntime(t)
+	artifactDir := t.TempDir()
+	ag := customLocalAgent(&config.CustomEngineConfig{Transport: "http"})
+	artifacts := &SessionArtifacts{Files: []ArtifactFile{{Name: "gone.txt", URL: deadURL}}}
+
+	out := captureStdout(t, func() {
+		ag.collectArtifacts(context.Background(), rt, ExecOptions{ArtifactDir: artifactDir}, artifacts)
+	})
+	if containsBasename(artifacts.GeneratedFiles, "gone.txt") {
+		t.Fatalf("generated_files = %v, want the unreachable url skipped", artifacts.GeneratedFiles)
+	}
+	if !strings.Contains(out, "cannot download artifact") {
+		t.Fatalf("logs = %q, want a download-failure warning", out)
+	}
+}
+
+// TestCustomAgent_CollectArtifacts_URLNonHTTPSchemeSkipped rejects a non-http(s)
+// scheme (e.g. file://) before any request is made.
+func TestCustomAgent_CollectArtifacts_URLNonHTTPSchemeSkipped(t *testing.T) {
+	t.Parallel()
+	rt := newCustomTestRuntime(t)
+	artifactDir := t.TempDir()
+	ag := customLocalAgent(&config.CustomEngineConfig{Transport: "http"})
+	artifacts := &SessionArtifacts{Files: []ArtifactFile{{Name: "p.txt", URL: "file:///etc/passwd"}}}
+
+	out := captureStdout(t, func() {
+		ag.collectArtifacts(context.Background(), rt, ExecOptions{ArtifactDir: artifactDir}, artifacts)
+	})
+	if containsBasename(artifacts.GeneratedFiles, "p.txt") {
+		t.Fatalf("generated_files = %v, want the file:// url skipped", artifacts.GeneratedFiles)
+	}
+	if !strings.Contains(out, "is not http(s)") {
+		t.Fatalf("logs = %q, want a scheme-rejection warning", out)
+	}
+}
+
+// TestCustomAgent_CollectArtifacts_URLSizeCapEnforced lowers the download cap so
+// an over-limit body is rejected rather than written into the report.
+func TestCustomAgent_CollectArtifacts_URLSizeCapEnforced(t *testing.T) {
+	// Not parallel: mutates the package-level cap.
+	orig := maxArtifactDownloadBytes
+	maxArtifactDownloadBytes = 8
+	defer func() { maxArtifactDownloadBytes = orig }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, strings.Repeat("z", 64)) // 64 > 8-byte cap
+	}))
+	defer srv.Close()
+
+	rt := newCustomTestRuntime(t)
+	artifactDir := t.TempDir()
+	ag := customLocalAgent(&config.CustomEngineConfig{Transport: "http"})
+	artifacts := &SessionArtifacts{Files: []ArtifactFile{{Name: "big.bin", URL: srv.URL}}}
+
+	out := captureStdout(t, func() {
+		ag.collectArtifacts(context.Background(), rt, ExecOptions{ArtifactDir: artifactDir}, artifacts)
+	})
+	if containsBasename(artifacts.GeneratedFiles, "big.bin") {
+		t.Fatalf("generated_files = %v, want the oversize download dropped", artifacts.GeneratedFiles)
+	}
+	if !strings.Contains(out, "exceeds download size limit") {
+		t.Fatalf("logs = %q, want a size-cap warning", out)
+	}
+	if _, err := os.Stat(filepath.Join(artifactDir, "big.bin")); !os.IsNotExist(err) {
+		t.Fatalf("big.bin should not have been written (stat err = %v)", err)
+	}
+}
+
+// TestCustomAgent_CollectArtifacts_URLWithAPIKeyRefused ensures a url that
+// embeds the configured API key is refused before any request is made, so the
+// key is never transmitted to the engine-declared endpoint, and the refusal
+// warning does not leak the key.
+func TestCustomAgent_CollectArtifacts_URLWithAPIKeyRefused(t *testing.T) {
+	t.Parallel()
+	const secret = "sk-super-secret-token-value"
+	rt := newCustomTestRuntime(t)
+	artifactDir := t.TempDir()
+	ag := NewCustomAgent(Config{Name: "my-agent", APIKey: secret, Custom: &config.CustomEngineConfig{Transport: "http"}})
+	artifacts := &SessionArtifacts{
+		Files: []ArtifactFile{{Name: "x.txt", URL: "http://example.com/?token=" + secret}},
+	}
+
+	out := captureStdout(t, func() {
+		ag.collectArtifacts(context.Background(), rt, ExecOptions{ArtifactDir: artifactDir}, artifacts)
+	})
+	if containsBasename(artifacts.GeneratedFiles, "x.txt") {
+		t.Fatalf("generated_files = %v, want the api-key url refused", artifacts.GeneratedFiles)
+	}
+	if strings.Contains(out, secret) {
+		t.Fatalf("logs leaked the api key: %q", out)
+	}
+	if !strings.Contains(out, "embeds the API key") {
+		t.Fatalf("logs = %q, want an api-key refusal warning", out)
+	}
+}
+
+// TestCustomAgent_CollectArtifacts_URLSecretMaskedInLog ensures an
+// engine.custom.env secret a user embeds in the artifact url (which, unlike the
+// api_key, is not refused up front) is scrubbed from the transport-error
+// warning, which net/http builds with the full request URL.
+func TestCustomAgent_CollectArtifacts_URLSecretMaskedInLog(t *testing.T) {
+	// Not parallel: relies on the shared log-capture mutex via captureStdout.
+	const secret = "env-super-secret-token-value"
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := srv.URL + "/?token=" + secret
+	srv.Close() // force a transport error whose message embeds the url
+
+	rt := newCustomTestRuntime(t)
+	artifactDir := t.TempDir()
+	ag := NewCustomAgent(Config{Name: "my-agent", Custom: &config.CustomEngineConfig{
+		Transport: "http",
+		Env:       map[string]string{"MY_TOKEN": secret},
+	}})
+	artifacts := &SessionArtifacts{Files: []ArtifactFile{{Name: "x.txt", URL: deadURL}}}
+
+	out := captureStdout(t, func() {
+		ag.collectArtifacts(context.Background(), rt, ExecOptions{ArtifactDir: artifactDir}, artifacts)
+	})
+	if strings.Contains(out, secret) {
+		t.Fatalf("logs leaked the env secret: %q", out)
+	}
+	if !strings.Contains(out, "***REDACTED***") {
+		t.Fatalf("logs = %q, want the masked url in the warning", out)
+	}
+}

--- a/internal/agent/custom_http.go
+++ b/internal/agent/custom_http.go
@@ -20,8 +20,9 @@ import (
 // back-reference.
 //
 // This transport currently supports JSON request/response only. Multipart file
-// upload (engine.custom.http.files) and URL artifact download are follow-ups; a
-// non-empty files list is rejected as not-yet-implemented.
+// upload (engine.custom.http.files) is a follow-up; a non-empty files list is
+// rejected as not-yet-implemented. Downloading result artifacts declared via a
+// `url` is handled transport-agnostically in CustomAgent.collectArtifacts.
 type httpTransport struct {
 	a *CustomAgent
 }


### PR DESCRIPTION
## What

This is **PR-C** of the Custom Engine HTTP rollout (after [#99](https://github.com/alibaba/skill-up/pull/99) JSON core and [#102](https://github.com/alibaba/skill-up/pull/102) multipart upload). It implements downloading `SessionResult.artifacts.files[].url` artifacts into the report — the last unimplemented piece of the custom-engine artifact contract.

Previously the `case f.URL != ""` branch in `collectArtifacts` only logged a debug stub (`"... url is not downloaded in the local transport"`). It now performs a real, best-effort HTTP download.

## How

- **`downloadURLArtifact`** (new, in `custom.go`): GETs the declared URL and writes the body into the case artifact directory (`opts.ArtifactDir`) under `f.Name` via the existing `writeLocalArtifact`, then registers the local path in `artifacts.GeneratedFiles`. Wired into `collectArtifacts`.
- **Bounded**: 256 MiB cap via `io.LimitReader` (`maxArtifactDownloadBytes`) and a per-download timeout via context (`customArtifactDownloadTimeout`). Mirrors the `maxHTTPResponseBytes` / `io.LimitReader` / `maskAPIKey` style introduced in #99's `custom_http.go`.
- **Best-effort**: a non-2xx status, transport error, non-http(s) scheme, or over-cap body is logged as a warning and skipped — the run still succeeds, consistent with the rest of artifact handling.
- **Security**: only the exact declared URL is fetched (SSRF stays the engine/operator's responsibility, same posture as the http transport). Non-http(s) schemes are rejected. A URL embedding the configured API key is refused up front (mirrors `errSecretInURL`), and error strings are scrubbed via `maskAPIKey`. The download writes to the artifact output dir, never the workspace, so it bypasses `f.Path` workspace confinement by construction (`writeLocalArtifact` confines the name to the dir basename).

It is handled transport-agnostically in `collectArtifacts` (per the design contract, *any* engine may declare a `url`), not in the transport layer.

## Independent of #102

This PR touches a **different code region** (`collectArtifacts` in `custom.go`) than the in-flight multipart PR #102 (`custom_http.go`). The only overlap is the trivial CHANGELOG `[Unreleased]` entry; rebase that line if #102 lands first.

## Docs

- `docs/design/custom-engine.md` — "Agent artifact archiving boundary" and "Result bounds" sections updated; the `url` row is no longer "pending".
- `CHANGELOG.md` `[Unreleased]` — adds the URL-download entry and drops "URL artifact download" from the #99 follow-up list.

Refs the custom-engine HTTP transport design (`docs/design/custom-engine.md`).

## Tests

New `internal/agent/custom_artifact_url_test.go` (httptest-driven, reuses `newCustomTestRuntime` etc.):
- url declared → downloaded and registered in `GeneratedFiles` with the right content
- end-to-end Run where the artifact url returns 500 → run still succeeds, artifact skipped (with warning)
- unreachable url → skipped with warning
- non-http(s) scheme (`file://`) → skipped
- size cap enforced (cap lowered via the test-overridable `var`)
- url embedding the configured API key → refused, no leak
- `engine.custom.env` secret embedded in the url → masked in the failure warning

`make test` (race), `make verify` (0 issues), and the `make e2e` custom-engine subset all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)