### PR TITLE
fix(evaluator): select agent_judge engine from judge model protocol (#104)

### DIFF
--- a/internal/agentkind/agentkind.go
+++ b/internal/agentkind/agentkind.go
@@ -33,3 +33,65 @@ func IsBuiltin(name string) bool {
 	_, ok := builtinNames[name]
 	return ok
 }
+
+// Wire protocols spoken by built-in engines and model-provider namespaces.
+// They decide whether an engine can drive a given judge model: an
+// Anthropic-protocol model needs an Anthropic-protocol engine and vice
+// versa.
+const (
+	ProtocolAnthropic = "anthropic"
+	ProtocolOpenAI    = "openai"
+)
+
+// engineProtocols maps each built-in engine (including aliases) to the wire
+// protocol it speaks. claude_code and qodercli are Anthropic-protocol agents
+// (qodercli is Claude-compatible); codex speaks the OpenAI protocol.
+var engineProtocols = map[string]string{
+	ClaudeCode:      ProtocolAnthropic,
+	ClaudeCodeAlias: ProtocolAnthropic,
+	QoderCLI:        ProtocolAnthropic,
+	QoderAlias:      ProtocolAnthropic,
+	QoderCLIAlias:   ProtocolAnthropic,
+	Codex:           ProtocolOpenAI,
+}
+
+// providerProtocols maps a model-provider namespace (the prefix in
+// `provider/model`) to its wire protocol.
+var providerProtocols = map[string]string{
+	ProtocolAnthropic: ProtocolAnthropic,
+	ProtocolOpenAI:    ProtocolOpenAI,
+}
+
+// canonicalEngineForProtocol is the default built-in engine for each
+// protocol — used to pick a judge engine when the case engine cannot speak
+// the judge model's protocol.
+var canonicalEngineForProtocol = map[string]string{
+	ProtocolAnthropic: ClaudeCode,
+	ProtocolOpenAI:    Codex,
+}
+
+// ProtocolForEngine returns the wire protocol spoken by a built-in engine.
+// The second return value is false for unknown (e.g. custom) engines.
+func ProtocolForEngine(engine string) (string, bool) {
+	p, ok := engineProtocols[engine]
+	return p, ok
+}
+
+// ProtocolForProvider returns the wire protocol implied by a model-provider
+// namespace. The second return value is false for unknown providers.
+func ProtocolForProvider(provider string) (string, bool) {
+	p, ok := providerProtocols[provider]
+	return p, ok
+}
+
+// EngineForProvider returns the canonical built-in engine that speaks the
+// protocol implied by the given model provider (anthropic/* → claude_code,
+// openai/* → codex). The second return value is false for unknown providers.
+func EngineForProvider(provider string) (string, bool) {
+	protocol, ok := providerProtocols[provider]
+	if !ok {
+		return "", false
+	}
+	engine, ok := canonicalEngineForProtocol[protocol]
+	return engine, ok
+}

--- a/internal/credential/agent_init.go
+++ b/internal/credential/agent_init.go
@@ -88,7 +88,7 @@ func ResolveRunnerInitParams(engine string, modelCfg config.ModelConfig, custom 
 
 // ResolveJudgeInitParams resolves the final init params for the judge agent.
 func ResolveJudgeInitParams(engine string, judgeCfg config.JudgeConfig, runner AgentInitParams, resolver *Resolver) AgentInitParams {
-	provider, model := parseJudgeModel(judgeCfg.Model)
+	provider, model := ParseJudgeModel(judgeCfg.Model)
 	var fallback *AgentInitParams
 	if runner.Provider != "" || runner.Model != "" || runner.APIKey != "" || runner.BaseURL != "" {
 		fallback = &runner
@@ -106,7 +106,11 @@ func ResolveJudgeInitParams(engine string, judgeCfg config.JudgeConfig, runner A
 	})
 }
 
-func parseJudgeModel(value string) (provider, model string) {
+// ParseJudgeModel splits a judge model identifier into its provider prefix
+// and bare model name. A value of the form `provider/model` (both parts
+// non-empty) yields that pair; anything else is treated as a bare model with
+// no provider.
+func ParseJudgeModel(value string) (provider, model string) {
 	parts := strings.SplitN(value, "/", 2)
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1]

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/alibaba/skill-up/internal/agent"
+	"github.com/alibaba/skill-up/internal/agentkind"
 	"github.com/alibaba/skill-up/internal/config"
 	"github.com/alibaba/skill-up/internal/credential"
 	"github.com/alibaba/skill-up/internal/judge"
@@ -656,9 +657,10 @@ func (e *defaultEvaluator) resolveJudgeAgent(ctx context.Context, judgeCfg confi
 
 	judgeAgent := runAgent
 	if e.evalCfg.Engine.Name != "" {
-		judgeParams := credential.ResolveJudgeInitParams(e.evalCfg.Engine.Name, judgeCfg, e.runnerParams, e.resolver)
+		judgeEngine := e.resolveJudgeEngine(judgeCfg)
+		judgeParams := credential.ResolveJudgeInitParams(judgeEngine, judgeCfg, e.runnerParams, e.resolver)
 		var err error
-		judgeAgent, err = agentDetectWithInitParams(e.evalCfg.Engine.Name, judgeParams, e.evalCfg.Engine.Kwargs)
+		judgeAgent, err = agentDetectWithInitParams(judgeEngine, judgeParams, e.evalCfg.Engine.Kwargs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create judge agent: %w", err)
 		}
@@ -668,6 +670,34 @@ func (e *defaultEvaluator) resolveJudgeAgent(ctx context.Context, judgeCfg confi
 	}
 
 	return judgeAgent, nil
+}
+
+// resolveJudgeEngine selects the engine that should drive the agent_judge.
+// The judge is meant to be a fixed, strong model independent of the agent
+// under test, so its engine follows the judge model's provider rather than
+// blindly inheriting the case engine: an `anthropic/*` judge must run on an
+// Anthropic-protocol engine and an `openai/*` judge on an OpenAI-protocol one.
+//
+// The case engine is kept whenever it can already speak the judge model's
+// protocol (e.g. claude_code or qodercli with an anthropic judge, codex with
+// an openai judge) so this only diverges on a genuine protocol mismatch — the
+// codex + anthropic-judge case that previously failed with `codex run failed`.
+// When the judge model carries no provider, or a provider with no known
+// protocol (e.g. a custom proxy namespace), the case engine is preserved.
+func (e *defaultEvaluator) resolveJudgeEngine(judgeCfg config.JudgeConfig) string {
+	caseEngine := e.evalCfg.Engine.Name
+	judgeProvider, _ := credential.ParseJudgeModel(judgeCfg.Model)
+	judgeProtocol, ok := agentkind.ProtocolForProvider(judgeProvider)
+	if !ok {
+		return caseEngine
+	}
+	if caseProtocol, ok := agentkind.ProtocolForEngine(caseEngine); ok && caseProtocol == judgeProtocol {
+		return caseEngine
+	}
+	if engine, ok := agentkind.EngineForProvider(judgeProvider); ok {
+		return engine
+	}
+	return caseEngine
 }
 
 func (e *defaultEvaluator) judgeScriptBaseDir() string {

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -2724,3 +2724,78 @@ func absoluteSecretPath() string {
 	}
 	return "/tmp/secret.txt"
 }
+
+func TestResolveJudgeEngine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		caseEngine string
+		judgeModel string
+		want       string
+	}{
+		{
+			name:       "anthropic judge on anthropic-protocol case engine keeps case engine",
+			caseEngine: "claude_code",
+			judgeModel: "anthropic/claude-sonnet-4-6",
+			want:       "claude_code",
+		},
+		{
+			name:       "anthropic judge on qodercli keeps qodercli (also anthropic protocol)",
+			caseEngine: "qodercli",
+			judgeModel: "anthropic/claude-sonnet-4-6",
+			want:       "qodercli",
+		},
+		{
+			name:       "anthropic judge on codex switches to claude_code (the bug)",
+			caseEngine: "codex",
+			judgeModel: "anthropic/claude-sonnet-4-6",
+			want:       "claude_code",
+		},
+		{
+			name:       "openai judge on codex keeps codex",
+			caseEngine: "codex",
+			judgeModel: "openai/gpt-5.5",
+			want:       "codex",
+		},
+		{
+			name:       "openai judge on claude_code switches to codex",
+			caseEngine: "claude_code",
+			judgeModel: "openai/gpt-5.5",
+			want:       "codex",
+		},
+		{
+			name:       "model without provider keeps case engine",
+			caseEngine: "codex",
+			judgeModel: "gpt-5.5",
+			want:       "codex",
+		},
+		{
+			name:       "unknown provider namespace keeps case engine",
+			caseEngine: "codex",
+			judgeModel: "anthropic_modelscope/deepseek-v4-pro",
+			want:       "codex",
+		},
+		{
+			name:       "empty judge model keeps case engine",
+			caseEngine: "claude_code",
+			judgeModel: "",
+			want:       "claude_code",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := &defaultEvaluator{
+				evalCfg: &config.EvalConfig{
+					Engine: config.EngineConfig{Name: tt.caseEngine},
+				},
+			}
+			got := e.resolveJudgeEngine(config.JudgeConfig{Type: "agent_judge", Model: tt.judgeModel})
+			if got != tt.want {
+				t.Fatalf("resolveJudgeEngine(case=%s, judge=%s) = %s, want %s", tt.caseEngine, tt.judgeModel, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #104. `agent_judge` always ran on the eval's **case engine**, ignoring the protocol implied by the judge model's own provider. A `codex` (OpenAI-protocol) eval with an `anthropic/...` judge model asked codex to drive an Anthropic model → `codex run failed`. Semantically the judge is meant to be a fixed, strong model independent of the agent under test.

## What changed

New `resolveJudgeEngine` (in `internal/evaluator/evaluator.go`) selects the judge engine from the judge model's **provider protocol** instead of blindly inheriting the case engine:

1. No provider, or an unknown provider namespace (e.g. a custom proxy like `anthropic_modelscope/...`) → keep the case engine.
2. Case engine already speaks the judge model's protocol → keep it. **Preserves** `claude_code` + anthropic judge and `qodercli` + anthropic judge (qodercli is Claude-compatible / anthropic-protocol).
3. Genuine protocol mismatch (`codex` + `anthropic/*` judge) → switch to the canonical engine for that protocol (`claude_code`). **This is the bug fix.**

Keying the decision on *protocol* rather than a blunt provider→engine map avoids regressing the qodercli row — a blunt map would have wrongly forced it onto `claude_code`.

### Files
- `internal/agentkind/agentkind.go` — protocol/engine mapping (`ProtocolForEngine`, `ProtocolForProvider`, `EngineForProvider`) in the dependency-free leaf package.
- `internal/credential/agent_init.go` — export `parseJudgeModel` → `ParseJudgeModel` for reuse by the evaluator.
- `internal/evaluator/evaluator.go` — `resolveJudgeEngine`, wired into `resolveJudgeAgent`.

## Test plan

- New `TestResolveJudgeEngine` covers all 8 combinations: the three table rows from the issue, both protocol-match directions, no-provider, unknown-namespace, and empty model.
- `go build ./...`, `go vet`, and the full `evaluator` + `credential` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)