### PR TITLE
docs: correct the action's uses: ref (v0.1.0 was a nonexistent tag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,17 +314,29 @@ jobs:
     runs-on: ubuntu-latest          # Docker container action — Linux only
     steps:
       - uses: actions/checkout@v4
-      - uses: alibaba/skill-up@v0.1.0
+      - uses: alibaba/skill-up@main  # see "Versioning" below
         with:
           engine: claude_code        # or codex / qodercli; empty = let eval.yaml decide
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          base-url: https://api.anthropic.com   # your model endpoint
           skill-target: evals/eval.yaml
 ```
+
+Requirements for the caller: a **Linux** runner (it's a Docker container action),
+and your model credential stored as a repo secret. The runner image is public, so
+no extra registry auth is needed.
 
 Key inputs: `engine`, `model`, `provider`, `api-key`, `base-url`, `skill-target`,
 `parallelism`. The action prebuilds skill-up + the three engine CLIs into its
 runner image, so a run is just "pull image, eval". See [`action.yml`](action.yml)
 for the full input/output reference.
+
+### Versioning
+
+`uses:` points at any git ref that contains `action.yml`. Pin a **release tag**
+(the first release that includes the action onward) or a commit SHA for stability;
+`@main` always tracks the latest. Release tags published **before** the action was
+added do not contain `action.yml` and cannot be used as the ref.
 
 ## License
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -238,16 +238,26 @@ jobs:
     runs-on: ubuntu-latest          # Docker 容器 action —— 仅 Linux
     steps:
       - uses: actions/checkout@v4
-      - uses: alibaba/skill-up@v0.1.0
+      - uses: alibaba/skill-up@main  # 见下方「版本引用」
         with:
           engine: claude_code        # 或 codex / qodercli;留空则由 eval.yaml 自行声明
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          base-url: https://api.anthropic.com   # 你的模型端点
           skill-target: evals/eval.yaml
 ```
+
+调用方前提:**Linux** runner(这是 Docker 容器 action),以及把模型凭据存为仓库
+secret。runner 镜像是 public 的,无需额外 registry 鉴权。
 
 主要入参:`engine`、`model`、`provider`、`api-key`、`base-url`、`skill-target`、
 `parallelism`。action 预先把 skill-up 和三个引擎 CLI 烤进 runner 镜像,跑一次
 就是「拉镜像、评测」。完整入参/产出见 [`action.yml`](action.yml)。
+
+### 版本引用
+
+`uses:` 可以指向任何**包含 `action.yml`** 的 git ref。生产建议 pin 一个**含本
+action 的 release tag**(从引入 action 的那个 release 起)或 commit SHA;`@main`
+则始终跟随最新。**早于** action 引入的 release tag 里没有 `action.yml`,不能用作 ref。
 
 ## 许可证
 


### PR DESCRIPTION
## What

The GitHub Action usage examples in `README.md` / `README.zh.md` referenced `uses: alibaba/skill-up@v0.1.0`. That is wrong:

- `v0.1.0` is the runner **image** tag (`ghcr.io/alibaba/skill-up-runner:v0.1.0`), **not a git tag** — no such release/tag exists.
- Release tags published **before** the action was merged (≤ `v0.2.4`) don't contain `action.yml`, so they can't be used as the ref either.

A consumer copy-pasting the example would hit a "can't find action.yml" error.

## Change

- Point the examples at `@main` (works today).
- Add a **Versioning** note: pin a release tag that includes the action (or a commit SHA) for stability; `@main` tracks latest; pre-action tags don't work.
- Add the caller requirements (Linux runner + a model-key secret; the runner image is public so no extra registry auth).

Docs-only; `action.yml`'s image reference (`:v0.1.0`) is unchanged.

> Note: the action is fully usable via `uses: alibaba/skill-up@<ref>` regardless of a Marketplace listing — Marketplace is discoverability only, and publishing it is currently gated on the org accepting the Marketplace Developer Agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)