### PR TITLE
ci: cut shared-runner queueing on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ on:
       - '*.md'
       - '.github/workflows/docs.yml'
 
+# Cancel superseded runs for the same PR so a new push does not leave the
+# previous run occupying a shared GitHub-hosted runner slot. Pushes to main
+# are never cancelled (cancel-in-progress only on pull_request) so the
+# coverage-badge commit job always runs to completion.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Default the workflow token to read-only. Jobs that execute PR-supplied
 # code (build/test, e2e, lint) must never be able to push to the repo, even
 # on same-repository PRs where GITHUB_TOKEN would otherwise be writable.
@@ -30,7 +38,10 @@ jobs:
       # whole matrix when one runner fails.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # Windows runners sit in a smaller, longer-queuing pool. PRs run
+        # Linux-only to keep the shared-runner queue short; the full matrix
+        # (including windows-latest) still runs on pushes to main.
+        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "windows-latest"]') }}
         go-version: ["1.25.x"]
 
     steps:
@@ -143,6 +154,9 @@ jobs:
     # dispatch — through the full CLI pipeline. Real-LLM coverage stays on
     # the Linux e2e job below.
     name: E2E (none runtime, Windows)
+    # Skip on PRs to avoid the longer-queuing Windows runner pool; the
+    # Windows-specific code paths are still exercised on every push to main.
+    if: github.event_name != 'pull_request'
     runs-on: windows-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,13 @@ on:
 
 # Cancel superseded runs for the same PR so a new push does not leave the
 # previous run occupying a shared GitHub-hosted runner slot. Pushes to main
-# are never cancelled (cancel-in-progress only on pull_request) so the
-# coverage-badge commit job always runs to completion.
+# fall back to the unique run_id, giving every main run its own group so it is
+# never cancelled — not while executing (cancel-in-progress is false off PRs)
+# and not while queued (a shared group drops an older pending run when a newer
+# one lands, regardless of cancel-in-progress), so the full matrix and the
+# coverage-badge commit job always run to completion.
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default the workflow token to read-only. Jobs that execute PR-supplied

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,11 @@ on:
 # never cancelled — not while executing (cancel-in-progress is false off PRs)
 # and not while queued (a shared group drops an older pending run when a newer
 # one lands, regardless of cancel-in-progress), so the full matrix and the
-# coverage-badge commit job always run to completion.
+# coverage-badge commit job always run to completion. The group is prefixed
+# with github.workflow because concurrency groups are repo-wide, not scoped to
+# a single workflow.
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default the workflow token to read-only. Jobs that execute PR-supplied


### PR DESCRIPTION
## 背景

`alibaba/skill-up` 是公开仓库,GitHub 托管 runner 的**分钟数免费无限**——PR 排队几小时不是 quota 超限,而是在等一个空闲的**并发 runner 名额**。而 GitHub 托管 runner 的并发上限是**按整个 org 共享**的,skill-up 的 job 和 alibaba 名下所有其他仓库抢同一个池子,池子满了就排队。

这个 PR 减少每个 PR 占用的 runner 名额,缩短排队(org 级并发上限仍需管理员提升,是另一条线)。

## 改动

- **top-level `concurrency`**:同一 PR 有新 push 时取消旧 run,不再让它继续占名额排队。`cancel-in-progress` 仅对 `pull_request` 生效,push main 不取消,保证 coverage-badge 提交 job 跑完。
- **Build & Test matrix**:PR 上只跑 Linux;push main 仍跑完整 matrix(含 `windows-latest`)。
- **Windows e2e job**:PR 上跳过(Windows runner 池更小、排队更久),Windows 专有代码路径仍在每次 push main 时覆盖。

## 影响

- 每个 PR 少占 2 个 Windows runner 名额(build + e2e-windows),Windows 排队最久,收益明显。
- 无 branch protection required checks,不会卡 merge。
- Windows 覆盖回归到 push main 时才验证,是排队时间和即时覆盖的取舍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)