### PR TITLE
fix: restore internal/runtime build after OpenSandbox SDK v1.0.3 bump

### DIFF
--- a/internal/runtime/opensandbox.go
+++ b/internal/runtime/opensandbox.go
@@ -54,7 +54,7 @@ type openSandboxClient interface {
 	Ping(ctx context.Context) error
 	CreateDirectory(ctx context.Context, remotePath string, mode int) error
 	UploadFiles(ctx context.Context, entries []opensandbox.UploadFileEntry) error
-	DownloadFile(ctx context.Context, remotePath, rangeHeader string) (io.ReadCloser, error)
+	DownloadFile(ctx context.Context, remotePath, rangeHeader string, opts ...opensandbox.DownloadFileOptions) (io.ReadCloser, error)
 	SearchFiles(ctx context.Context, dir, pattern string) ([]opensandbox.FileInfo, error)
 	RunCommandWithOpts(ctx context.Context, req opensandbox.RunCommandRequest, handlers *opensandbox.ExecutionHandlers) (*opensandbox.Execution, error)
 }

--- a/internal/runtime/opensandbox_test.go
+++ b/internal/runtime/opensandbox_test.go
@@ -1028,7 +1028,7 @@ func (f *fakeOpenSandbox) UploadFiles(ctx context.Context, entries []opensandbox
 	return nil
 }
 
-func (f *fakeOpenSandbox) DownloadFile(_ context.Context, remotePath, _ string) (io.ReadCloser, error) {
+func (f *fakeOpenSandbox) DownloadFile(_ context.Context, remotePath, _ string, _ ...opensandbox.DownloadFileOptions) (io.ReadCloser, error) {
 	if f.downloadDelay > 0 {
 		f.downloadMu.Lock()
 		f.activeDownloads++


### PR DESCRIPTION
## 问题

main 当前**编译不过**。`chore: bump github.com/alibaba/OpenSandbox/sdks/sandbox/go (#110)` 把 SDK 升到 v1.0.3,新版 `Sandbox.DownloadFile` 增加了可变参数 `...DownloadFileOptions`:

```
have DownloadFile(ctx, string, string, ...opensandbox.DownloadFileOptions) (io.ReadCloser, error)
want DownloadFile(ctx, string, string) (io.ReadCloser, error)
```

本地 `openSandboxClient` interface 仍是旧的三参签名,导致 `*opensandbox.Sandbox` 不再满足该接口,整个 `internal/runtime` 包编译失败——`go build ./...` 在最新 main（c536610）上直接报错,进而 Build/Test/E2E/Lint/GoReleaser 全红。

## 改动

给 interface 方法和测试里的 `fakeOpenSandbox` mock 同步加上 variadic 参数(SDK 的 `DownloadFile` 变参可选,现有调用点 `DownloadFile(ctx, source, "")` 不受影响):

- `internal/runtime/opensandbox.go` — `openSandboxClient.DownloadFile`
- `internal/runtime/opensandbox_test.go` — `fakeOpenSandbox.DownloadFile`

## 验证

- `go build ./...` ✅
- `go vet ./internal/runtime/` ✅
- `go test ./internal/runtime/` ✅ (`ok 10.7s`)
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)