### PR TITLE
docs: cut CHANGELOG for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-03
+
 ### Added
 - Built-in `qwen_code` engine (aliases `qwen-code`, `qwen`), backed by the
   [Qwen Code](https://github.com/QwenLM/qwen-code) CLI (`@qwen-code/qwen-code`).
@@ -311,6 +313,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project and delivers the end-to-end capability to declare eval environments,
   run cases and emit structured reports as described in [README.md](README.md).
 
+[0.3.0]: https://github.com/alibaba/skill-up/releases/tag/v0.3.0
 [0.2.4]: https://github.com/alibaba/skill-up/releases/tag/v0.2.4
 [0.2.3]: https://github.com/alibaba/skill-up/releases/tag/v0.2.3
 [0.2.2]: https://github.com/alibaba/skill-up/releases/tag/v0.2.2


### PR DESCRIPTION
## 目的

发布 **v0.3.0** 前定版 CHANGELOG。把累积的 `[Unreleased]` 条目归入 `## [0.3.0] - 2026-07-03`,顶部保留空的 `[Unreleased]`,底部补 compare 链接。

## 版本依据

自 v0.2.4 起 34 个 commit(30 条 changelog 条目),含多个向后兼容的新特性、无破坏性改动,按 semver 走 **minor bump**:

- 内置 `qwen_code` engine(#116/#117)
- Agent Skill Eval GitHub Action(#100）
- Custom Engine `http` transport:JSON 核心(#99）、multipart 文件上传(#102）、artifact url 下载(#103）
- 一等 Windows 支持(#33）

## 发布流程(本 PR 合并后)

1. 合并本 PR 到 main。
2. 在 main HEAD 打 tag `v0.3.0` 并推送 → `.github/workflows/release.yml` 触发 GoReleaser 自动出版本、生成 GitHub Release notes(`changelog: use: github`,已排除 chore/style/docs）。

> GitHub Release 正文由 GoReleaser 自动从 commit 生成;本文件是项目手动维护的变更记录,二者并存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)