### PR TITLE
fix: preserve exec perms on skill install; validate duplicate case IDs (#118, #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Skill installation preserves source file permissions, notably the executable
+  bit on scripts. The `none` runtime's per-file upload previously wrote every
+  file with a fixed `0600` mode, so skills shipping runnable helper scripts
+  installed non-executable and failed without a chmod workaround. The
+  file-transfer contract now documents permission preservation, matching the
+  `opensandbox` and `docker` runtimes which already carried the mode across.
+
 ## [0.3.0] - 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Config validation now rejects duplicate case IDs and duplicate `cases.files`
+  references. Since reports and artifacts are keyed by case ID and one case runs
+  per `cases.files` entry, a collision would silently overwrite results or
+  double-run a case. `skill-up validate` (and the preflight in `skill-up run`)
+  fails with the conflicting ID and the offending source files. Covers both
+  explicit `id:` fields and filename-derived IDs, and collapses
+  differently-spelled paths (e.g. `cases/a.yaml` vs `./cases/a.yaml`).
+
 ### Fixed
 - Skill installation preserves source file permissions, notably the executable
   bit on scripts. The `none` runtime's per-file upload previously wrote every

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/alibaba/skill-up/internal/agentkind"
 	"github.com/alibaba/skill-up/internal/credential"
 	"github.com/alibaba/skill-up/internal/platform"
+	"github.com/alibaba/skill-up/internal/runtime"
 )
 
 // modelAuto is the QoderCLI "auto" model tier, shared across agent tests.
@@ -79,6 +81,44 @@ func TestListSkillFiles_ExcludesEvals(t *testing.T) {
 	}
 	if fileSet[filepath.Join("evals", "nested", "data", "file.txt")] {
 		t.Error("evals/nested/data/file.txt should be excluded")
+	}
+}
+
+func TestInstallSkill_PreservesExecutableScripts(t *testing.T) {
+	t.Parallel()
+	if goruntime.GOOS == "windows" {
+		t.Skip("Unix file modes are not meaningful on Windows")
+	}
+
+	// A skill that ships an executable helper script alongside SKILL.md.
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# Skill"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(src, "scripts", "run.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho ok\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := &runtime.NoneRuntime{}
+	if err := rt.Create(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close() }()
+
+	if err := installSkill(context.Background(), rt, src, "skill"); err != nil {
+		t.Fatalf("installSkill failed: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(rt.Workspace(), "skill", "scripts", "run.sh"))
+	if err != nil {
+		t.Fatalf("installed script should exist: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("installed script lost its executable bit: mode = %o", info.Mode().Perm())
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -99,6 +99,7 @@ func TestInstallSkill_PreservesExecutableScripts(t *testing.T) {
 		t.Fatal(err)
 	}
 	script := filepath.Join(src, "scripts", "run.sh")
+	//nolint:gosec // fixture must be executable to verify permission preservation
 	if err := os.WriteFile(script, []byte("#!/bin/sh\necho ok\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -210,6 +210,10 @@ func (v *Validator) ValidateAll(result *EvalResult) error {
 		return err
 	}
 
+	if errs := validateUniqueCases(result); len(errs) > 0 {
+		return fmt.Errorf("validation errors:\n  - %s", strings.Join(errs, "\n  - "))
+	}
+
 	for _, c := range result.Cases {
 		if err := v.ValidateCaseConfig(c); err != nil {
 			return fmt.Errorf("case %s: %w", c.ID, err)
@@ -217,6 +221,65 @@ func (v *Validator) ValidateAll(result *EvalResult) error {
 	}
 
 	return nil
+}
+
+// validateUniqueCases rejects duplicate case-file references and duplicate
+// effective case IDs. skill-up writes reports and artifacts keyed by case ID
+// and runs one case per cases.files entry, so a collision would silently
+// overwrite results or double-run a case. LoadAllCases appends one case per
+// cases.files entry in order, so result.Cases is index-aligned with
+// result.Eval.Cases.Files; that lets each error name the offending source file.
+func validateUniqueCases(result *EvalResult) []string {
+	files := result.Eval.Cases.Files
+	var errs []string
+	errs = append(errs, duplicateCaseFileErrors(files)...)
+	errs = append(errs, duplicateCaseIDErrors(result.Cases, files)...)
+	return errs
+}
+
+// duplicateCaseFileErrors reports cases.files entries that resolve to the same
+// path after normalization (e.g. "cases/a.yaml" vs "./cases/a.yaml"). Each
+// duplicate is reported once, in first-seen order for deterministic messages.
+func duplicateCaseFileErrors(files []string) []string {
+	counts := make(map[string]int, len(files))
+	for _, f := range files {
+		counts[path.Clean(f)]++
+	}
+	var errs []string
+	reported := make(map[string]bool)
+	for _, f := range files {
+		norm := path.Clean(f)
+		if counts[norm] > 1 && !reported[norm] {
+			errs = append(errs, fmt.Sprintf("cases.files lists %q %d times (after path normalization); each case file must appear once", norm, counts[norm]))
+			reported[norm] = true
+		}
+	}
+	return errs
+}
+
+// duplicateCaseIDErrors reports effective case IDs shared by more than one case,
+// covering both explicit `id:` fields and filename-derived IDs. files is
+// index-aligned with cases so the message can list the conflicting source files.
+func duplicateCaseIDErrors(cases []*CaseConfig, files []string) []string {
+	idFiles := make(map[string][]string, len(cases))
+	var order []string
+	for i, c := range cases {
+		src := "<unknown source>"
+		if i < len(files) {
+			src = files[i]
+		}
+		if _, seen := idFiles[c.ID]; !seen {
+			order = append(order, c.ID)
+		}
+		idFiles[c.ID] = append(idFiles[c.ID], src)
+	}
+	var errs []string
+	for _, id := range order {
+		if srcs := idFiles[id]; len(srcs) > 1 {
+			errs = append(errs, fmt.Sprintf("duplicate case id %q used by %d case files: %s", id, len(srcs), strings.Join(srcs, ", ")))
+		}
+	}
+	return errs
 }
 
 // validateEngine checks engine.custom against the Custom Engine contract.

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -888,94 +888,86 @@ func TestValidator_ValidateAll(t *testing.T) {
 			t.Error("ValidateAll() expected error for invalid case")
 		}
 	})
+}
 
-	t.Run("duplicate explicit case id", func(t *testing.T) {
-		t.Parallel()
-		eval := &EvalConfig{
+// TestValidator_ValidateAll_Duplicates covers rejection of duplicate case IDs
+// (explicit and filename-derived) and duplicate cases.files references. files
+// and ids are index-aligned, mirroring LoadAllCases' one-case-per-entry order.
+func TestValidator_ValidateAll_Duplicates(t *testing.T) {
+	t.Parallel()
+	validator := NewValidator()
+
+	evalWithFiles := func(files ...string) *EvalConfig {
+		return &EvalConfig{
 			SchemaVersion: "v1alpha1",
 			Environment:   Environment{Type: "none"},
 			Engine:        EngineConfig{Name: "claude_code"},
-			Cases:         CasesConfig{Files: []string{"evals/cases/a.yaml", "evals/cases/b.yaml"}},
+			Cases:         CasesConfig{Files: files},
 		}
-		result := &EvalResult{
-			Eval: eval,
-			Cases: []*CaseConfig{
-				{ID: "dup", Input: Input{Prompt: "x"}},
-				{ID: "dup", Input: Input{Prompt: "y"}},
-			},
+	}
+	casesWithIDs := func(ids ...string) []*CaseConfig {
+		cases := make([]*CaseConfig, len(ids))
+		for i, id := range ids {
+			cases[i] = &CaseConfig{ID: id, Input: Input{Prompt: "x"}}
 		}
-		err := validator.ValidateAll(result)
-		if err == nil || !strings.Contains(err.Error(), `duplicate case id "dup"`) {
-			t.Fatalf("expected duplicate-id error naming both files, got %v", err)
-		}
-		if !strings.Contains(err.Error(), "evals/cases/a.yaml") || !strings.Contains(err.Error(), "evals/cases/b.yaml") {
-			t.Errorf("duplicate-id error should list both source files, got %v", err)
-		}
-	})
+		return cases
+	}
 
-	t.Run("duplicate filename-derived case id", func(t *testing.T) {
-		t.Parallel()
-		// Two files in different dirs whose basenames collide; the loader would
-		// derive the same implicit ID "smoke" for both.
-		eval := &EvalConfig{
-			SchemaVersion: "v1alpha1",
-			Environment:   Environment{Type: "none"},
-			Engine:        EngineConfig{Name: "claude_code"},
-			Cases:         CasesConfig{Files: []string{"evals/cases/smoke.yaml", "evals/full/smoke.yaml"}},
-		}
-		result := &EvalResult{
-			Eval: eval,
-			Cases: []*CaseConfig{
-				{ID: "smoke", Input: Input{Prompt: "x"}},
-				{ID: "smoke", Input: Input{Prompt: "y"}},
-			},
-		}
-		if err := validator.ValidateAll(result); err == nil || !strings.Contains(err.Error(), `duplicate case id "smoke"`) {
-			t.Fatalf("expected duplicate implicit-id error, got %v", err)
-		}
-	})
+	tests := []struct {
+		name      string
+		files     []string
+		ids       []string
+		wantParts []string // non-empty ⇒ expect an error containing every part
+	}{
+		{
+			name:      "duplicate explicit id names both files",
+			files:     []string{"evals/cases/a.yaml", "evals/cases/b.yaml"},
+			ids:       []string{"dup", "dup"},
+			wantParts: []string{`duplicate case id "dup"`, "evals/cases/a.yaml", "evals/cases/b.yaml"},
+		},
+		{
+			// Files in different dirs with colliding basenames ⇒ same implicit ID.
+			name:      "duplicate filename-derived id",
+			files:     []string{"evals/cases/smoke.yaml", "evals/full/smoke.yaml"},
+			ids:       []string{"smoke", "smoke"},
+			wantParts: []string{`duplicate case id "smoke"`},
+		},
+		{
+			// Same file, differently spelled; normalization must collapse them.
+			name:      "duplicate file reference after normalization",
+			files:     []string{"evals/cases/a.yaml", "./evals/cases/a.yaml"},
+			ids:       []string{"a", "a"},
+			wantParts: []string{"cases.files lists"},
+		},
+		{
+			name:      "unique ids and files pass",
+			files:     []string{"evals/cases/a.yaml", "evals/cases/b.yaml"},
+			ids:       []string{"a", "b"},
+			wantParts: nil,
+		},
+	}
 
-	t.Run("duplicate file reference", func(t *testing.T) {
-		t.Parallel()
-		eval := &EvalConfig{
-			SchemaVersion: "v1alpha1",
-			Environment:   Environment{Type: "none"},
-			Engine:        EngineConfig{Name: "claude_code"},
-			// Same file listed twice with different spellings; normalization
-			// must collapse them.
-			Cases: CasesConfig{Files: []string{"evals/cases/a.yaml", "./evals/cases/a.yaml"}},
-		}
-		result := &EvalResult{
-			Eval: eval,
-			Cases: []*CaseConfig{
-				{ID: "a", Input: Input{Prompt: "x"}},
-				{ID: "a", Input: Input{Prompt: "x"}},
-			},
-		}
-		if err := validator.ValidateAll(result); err == nil || !strings.Contains(err.Error(), "cases.files lists") {
-			t.Fatalf("expected duplicate file-reference error, got %v", err)
-		}
-	})
-
-	t.Run("unique ids and files pass", func(t *testing.T) {
-		t.Parallel()
-		eval := &EvalConfig{
-			SchemaVersion: "v1alpha1",
-			Environment:   Environment{Type: "none"},
-			Engine:        EngineConfig{Name: "claude_code"},
-			Cases:         CasesConfig{Files: []string{"evals/cases/a.yaml", "evals/cases/b.yaml"}},
-		}
-		result := &EvalResult{
-			Eval: eval,
-			Cases: []*CaseConfig{
-				{ID: "a", Input: Input{Prompt: "x"}},
-				{ID: "b", Input: Input{Prompt: "y"}},
-			},
-		}
-		if err := validator.ValidateAll(result); err != nil {
-			t.Errorf("ValidateAll() error = %v, want nil", err)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := &EvalResult{Eval: evalWithFiles(tt.files...), Cases: casesWithIDs(tt.ids...)}
+			err := validator.ValidateAll(result)
+			if len(tt.wantParts) == 0 {
+				if err != nil {
+					t.Fatalf("ValidateAll() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %v, got nil", tt.wantParts)
+			}
+			for _, part := range tt.wantParts {
+				if !strings.Contains(err.Error(), part) {
+					t.Errorf("error %q missing expected substring %q", err.Error(), part)
+				}
+			}
+		})
+	}
 }
 
 func contains(s, substr string) bool {

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -888,6 +888,94 @@ func TestValidator_ValidateAll(t *testing.T) {
 			t.Error("ValidateAll() expected error for invalid case")
 		}
 	})
+
+	t.Run("duplicate explicit case id", func(t *testing.T) {
+		t.Parallel()
+		eval := &EvalConfig{
+			SchemaVersion: "v1alpha1",
+			Environment:   Environment{Type: "none"},
+			Engine:        EngineConfig{Name: "claude_code"},
+			Cases:         CasesConfig{Files: []string{"evals/cases/a.yaml", "evals/cases/b.yaml"}},
+		}
+		result := &EvalResult{
+			Eval: eval,
+			Cases: []*CaseConfig{
+				{ID: "dup", Input: Input{Prompt: "x"}},
+				{ID: "dup", Input: Input{Prompt: "y"}},
+			},
+		}
+		err := validator.ValidateAll(result)
+		if err == nil || !strings.Contains(err.Error(), `duplicate case id "dup"`) {
+			t.Fatalf("expected duplicate-id error naming both files, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "evals/cases/a.yaml") || !strings.Contains(err.Error(), "evals/cases/b.yaml") {
+			t.Errorf("duplicate-id error should list both source files, got %v", err)
+		}
+	})
+
+	t.Run("duplicate filename-derived case id", func(t *testing.T) {
+		t.Parallel()
+		// Two files in different dirs whose basenames collide; the loader would
+		// derive the same implicit ID "smoke" for both.
+		eval := &EvalConfig{
+			SchemaVersion: "v1alpha1",
+			Environment:   Environment{Type: "none"},
+			Engine:        EngineConfig{Name: "claude_code"},
+			Cases:         CasesConfig{Files: []string{"evals/cases/smoke.yaml", "evals/full/smoke.yaml"}},
+		}
+		result := &EvalResult{
+			Eval: eval,
+			Cases: []*CaseConfig{
+				{ID: "smoke", Input: Input{Prompt: "x"}},
+				{ID: "smoke", Input: Input{Prompt: "y"}},
+			},
+		}
+		if err := validator.ValidateAll(result); err == nil || !strings.Contains(err.Error(), `duplicate case id "smoke"`) {
+			t.Fatalf("expected duplicate implicit-id error, got %v", err)
+		}
+	})
+
+	t.Run("duplicate file reference", func(t *testing.T) {
+		t.Parallel()
+		eval := &EvalConfig{
+			SchemaVersion: "v1alpha1",
+			Environment:   Environment{Type: "none"},
+			Engine:        EngineConfig{Name: "claude_code"},
+			// Same file listed twice with different spellings; normalization
+			// must collapse them.
+			Cases: CasesConfig{Files: []string{"evals/cases/a.yaml", "./evals/cases/a.yaml"}},
+		}
+		result := &EvalResult{
+			Eval: eval,
+			Cases: []*CaseConfig{
+				{ID: "a", Input: Input{Prompt: "x"}},
+				{ID: "a", Input: Input{Prompt: "x"}},
+			},
+		}
+		if err := validator.ValidateAll(result); err == nil || !strings.Contains(err.Error(), "cases.files lists") {
+			t.Fatalf("expected duplicate file-reference error, got %v", err)
+		}
+	})
+
+	t.Run("unique ids and files pass", func(t *testing.T) {
+		t.Parallel()
+		eval := &EvalConfig{
+			SchemaVersion: "v1alpha1",
+			Environment:   Environment{Type: "none"},
+			Engine:        EngineConfig{Name: "claude_code"},
+			Cases:         CasesConfig{Files: []string{"evals/cases/a.yaml", "evals/cases/b.yaml"}},
+		}
+		result := &EvalResult{
+			Eval: eval,
+			Cases: []*CaseConfig{
+				{ID: "a", Input: Input{Prompt: "x"}},
+				{ID: "b", Input: Input{Prompt: "y"}},
+			},
+		}
+		if err := validator.ValidateAll(result); err != nil {
+			t.Errorf("ValidateAll() error = %v, want nil", err)
+		}
+	})
 }
 
 func contains(s, substr string) bool {

--- a/internal/runtime/none.go
+++ b/internal/runtime/none.go
@@ -87,9 +87,19 @@ func (r *NoneRuntime) Stop(ctx context.Context) error {
 	return nil
 }
 
-// UploadFile copies a single file into the runtime workspace.
+// UploadFile copies a single file into the runtime workspace, preserving the
+// source file's permission bits (notably the executable bit on scripts).
 // targetPath may be relative to the workspace or an absolute host path (written as-is).
+//
+// Skill installation uploads helper scripts through this method one file at a
+// time, so a fixed mode here would strip the executable bit and break any skill
+// that ships runnable scripts. This matches UploadDir and the opensandbox
+// runtime, both of which already carry the source mode across.
 func (r *NoneRuntime) UploadFile(ctx context.Context, sourcePath, targetPath string) error {
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return fmt.Errorf("failed to stat source file %s: %w", sourcePath, err)
+	}
 	data, err := os.ReadFile(sourcePath)
 	if err != nil {
 		return fmt.Errorf("failed to read source file %s: %w", sourcePath, err)
@@ -99,8 +109,16 @@ func (r *NoneRuntime) UploadFile(ctx context.Context, sourcePath, targetPath str
 		return fmt.Errorf("failed to create target directory: %w", err)
 	}
 
-	//nolint:gosec // target is joined with workspace, writing within sandbox is expected behavior
-	return os.WriteFile(target, data, noneFileMode)
+	mode := info.Mode().Perm()
+	//nolint:gosec // target is joined with workspace; info.Mode() preserves source permissions
+	if err := os.WriteFile(target, data, mode); err != nil {
+		return err
+	}
+	// WriteFile only applies the mode when it creates the file and is subject to
+	// the process umask; Chmod makes the executable bit deterministic even when
+	// re-installing over an existing file or under a restrictive umask.
+	//nolint:gosec // target is joined with workspace
+	return os.Chmod(target, mode)
 }
 
 // UploadDir recursively copies a directory into the runtime workspace.

--- a/internal/runtime/none_test.go
+++ b/internal/runtime/none_test.go
@@ -122,6 +122,38 @@ func TestNoneRuntime_UploadDownloadFile(t *testing.T) {
 	}
 }
 
+func TestNoneRuntime_UploadFile_PreservesExecutableBit(t *testing.T) {
+	t.Parallel()
+	if goruntime.GOOS == "windows" {
+		t.Skip("Unix file modes are not meaningful on Windows")
+	}
+
+	rt := &NoneRuntime{}
+	if err := rt.Create(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close() }()
+
+	// A skill helper script shipped with the executable bit set.
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "run.sh")
+	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\necho ok\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rt.UploadFile(context.Background(), srcFile, "scripts/run.sh"); err != nil {
+		t.Fatalf("UploadFile failed: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(rt.Workspace(), "scripts", "run.sh"))
+	if err != nil {
+		t.Fatalf("uploaded script should exist: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("installed script lost its executable bit: mode = %o, want executable", info.Mode().Perm())
+	}
+}
+
 func TestNoneRuntime_UploadDownloadDir(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/none_test.go
+++ b/internal/runtime/none_test.go
@@ -20,6 +20,11 @@ import (
 	"github.com/alibaba/skill-up/internal/logging"
 )
 
+// osWindows is the goruntime.GOOS value for Windows, used by tests that skip
+// POSIX-only behavior. Named to satisfy goconst (the literal recurs across
+// several skip guards).
+const osWindows = "windows"
+
 var logCaptureMu sync.Mutex
 
 func TestNoneRuntime_CreateAndClose(t *testing.T) {
@@ -124,7 +129,7 @@ func TestNoneRuntime_UploadDownloadFile(t *testing.T) {
 
 func TestNoneRuntime_UploadFile_PreservesExecutableBit(t *testing.T) {
 	t.Parallel()
-	if goruntime.GOOS == "windows" {
+	if goruntime.GOOS == osWindows {
 		t.Skip("Unix file modes are not meaningful on Windows")
 	}
 
@@ -137,6 +142,7 @@ func TestNoneRuntime_UploadFile_PreservesExecutableBit(t *testing.T) {
 	// A skill helper script shipped with the executable bit set.
 	srcDir := t.TempDir()
 	srcFile := filepath.Join(srcDir, "run.sh")
+	//nolint:gosec // fixture must be executable to verify permission preservation
 	if err := os.WriteFile(srcFile, []byte("#!/bin/sh\necho ok\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +266,7 @@ func TestNoneRuntime_ExecReturnsContextErrorOnTimeout(t *testing.T) {
 	// `sleep 1` is POSIX; on Windows cmd.exe falls back to a long ping
 	// so the process actually outlives the deadline and gets killed.
 	sleepCmd := "sleep 1"
-	if goruntime.GOOS == "windows" {
+	if goruntime.GOOS == osWindows {
 		sleepCmd = "ping -n 3 127.0.0.1 > nul"
 	}
 	result, err := rt.Exec(ctx, sleepCmd, ExecOptions{})
@@ -320,7 +326,7 @@ func TestNoneRuntime_ExecOmitsDeadlineDelta_OnManualCancel(t *testing.T) {
 }
 
 func TestNoneRuntime_ExecKillsDescendantsOnTimeout(t *testing.T) {
-	if goruntime.GOOS == "windows" {
+	if goruntime.GOOS == osWindows {
 		// Windows has no POSIX process-group equivalent: a backgrounded
 		// grandchild spawned by `&` keeps running after its parent shell is
 		// killed by ctx-cancel. configureProcessGroup is a no-op on Windows,
@@ -485,7 +491,7 @@ func TestNoneRuntime_ExecWithEnv(t *testing.T) {
 // shell. If the runtime pre-expanded $CUSTOM_BIN / $PATH the child would
 // see "/agent/bin:..." instead of the literal "$CUSTOM_BIN:$PATH".
 func TestNoneRuntime_ForwardsEnvLiterally(t *testing.T) {
-	if goruntime.GOOS == "windows" {
+	if goruntime.GOOS == osWindows {
 		// printf '%s' "$VAR" is POSIX-shell syntax; cmd.exe (Windows host
 		// shell when no bash is discovered) has no printf and no $VAR
 		// expansion. The behavioural contract (env values forwarded

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -119,6 +119,12 @@ type Runtime interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 
+	// UploadFile and UploadDir copy host files into the runtime workspace.
+	// Implementations MUST preserve the source permission bits — in
+	// particular the executable bit — so skills that ship runnable helper
+	// scripts install without a chmod workaround. This holds for every
+	// runtime whose target filesystem supports Unix file modes (none,
+	// opensandbox, docker).
 	UploadFile(ctx context.Context, sourcePath, targetPath string) error
 	UploadDir(ctx context.Context, sourceDir, targetDir string) error
 	DownloadFile(ctx context.Context, sourcePath, targetPath string) error


### PR DESCRIPTION
Follow-up fixes surfaced by the `app-upgrade-agents` migration. Two independent, low-risk changes bundled into one PR (one commit each).

## #118 — Preserve executable file permissions when installing skills

`Closes #118`

The `none` runtime's per-file `UploadFile` wrote every file with a fixed `0600` mode, so a skill shipping runnable helper scripts (e.g. `scripts/run.sh` at `0755`) installed **non-executable** and failed at runtime without a chmod workaround.

- `UploadFile` now stats the source and writes with its permission bits, then `Chmod`s to make the executable bit deterministic under any umask or on re-install.
- The `Runtime` file-transfer contract now documents permission preservation.
- No behavior change for other callers: `fixtures`/`agent` upload temp files created by `os.CreateTemp` (already `0600`); `opensandbox` (stats each file) and `docker` (`docker cp`) already preserved mode.

## #123 — Validate duplicate case IDs and duplicate file references

`Closes #123`

Reports and artifacts are keyed by case ID and one case runs per `cases.files` entry, so a collision would silently overwrite results or double-run a case.

- `ValidateAll` now rejects duplicate effective case IDs (covering both explicit `id:` and filename-derived IDs) and duplicate `cases.files` entries (collapsing differently-spelled paths via `path.Clean`).
- Each error names the conflicting ID and the offending source files. `result.Cases` is index-aligned with `Eval.Cases.Files`, so no change to `CaseConfig` was needed.

## Testing

- `go test -race ./internal/runtime/ ./internal/config/ ./internal/agent/` — green.
- New tests: runtime + install-level executable-bit preservation; validator subtests for explicit-id / implicit-id / duplicate-file / unique-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)