### PR TITLE
feat(cli): validate only selected cases in run (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `skill-up run` now validates only the cases left after
+  `--include-case-name` / `--exclude-case-name` filters (plus the eval-level
+  config), so an invalid case that is filtered out no longer blocks a filtered
+  run — a shared eval can hold a quick `smoke` subset alongside heavier cases.
+  `skill-up validate` is unchanged and still validates the whole suite (every
+  case) regardless of filters.
+
 ### Added
 - Config validation now rejects duplicate case IDs and duplicate `cases.files`
   references. Since reports and artifacts are keyed by case ID and one case runs

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -34,6 +34,13 @@ skill-up run [path] [flags]
 | `--api-key`            | —                             | Pass an API key (higher precedence than env vars)                                                                                                          |
 | `-v, --verbose`        | `0`                           | Increase log verbosity. Default `info`; `-v` / `--verbose` / `--verbose=true` → `debug`; `-vv` / `--verbose=2` → `trace`; `--verbose=false` disables extra detail |
 
+> **Validation scope.** `run` validates the eval-level config plus **only the
+> cases selected** after `--include-case-name` / `--exclude-case-name` filters.
+> An invalid case that is filtered out does not block the run — so a shared
+> eval can hold both a quick `smoke` subset and heavier cases without the latter
+> blocking a filtered smoke run. Use [`skill-up validate`](#skill-up-validate)
+> to validate the **whole** suite (every case) regardless of filters.
+
 ### Examples
 
 ```bash
@@ -94,6 +101,9 @@ You can also use trace-specific overrides like `OTEL_EXPORTER_OTLP_TRACES_ENDPOI
 ## skill-up validate
 
 Validate the eval config files. Run this before `run` to catch issues early.
+Unlike `run` (which validates only the selected cases), `validate` always
+checks the **whole** suite — the eval config and every referenced case file —
+ignoring any case-name filters.
 
 ```bash
 skill-up validate [path to eval.yaml]

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -80,6 +80,11 @@ The command loads eval.yaml and all case files, validates the configuration,
 executes each case against the configured engine, evaluates outputs using
 the judge module, and generates reports in the specified formats.
 
+Validation scope: run validates the eval-level config plus only the cases
+selected after --include-case-name / --exclude-case-name filters, so an invalid
+case that is filtered out does not block the run. Use 'skill-up validate' to
+validate the whole suite (every case) regardless of filters.
+
 If no path is given, the current directory and its parents are searched for
 SKILL.md together with evals/eval.yaml (skill layout); the first match wins.
 
@@ -179,6 +184,13 @@ func loadAndPrepareConfig(ctx context.Context, cmd *cobra.Command, args []string
 	}
 	if len(cases) == 0 {
 		return nil, nil, nil, errors.New("no cases matched the filter")
+	}
+
+	// Validate only the selected cases (after filters). Full-suite per-case
+	// validation is the job of `skill-up validate`; here an invalid case that
+	// was filtered out must not block the run.
+	if err := config.NewValidator().ValidateCases(cases); err != nil {
+		return nil, nil, nil, fmt.Errorf("validation failed: %w", err)
 	}
 
 	engineName, _ := cmd.Flags().GetString("engine")
@@ -856,8 +868,13 @@ func loadFromEvalYAML(evalPath string) (string, []*config.CaseConfig, *config.Ev
 	}
 	applyImplicitSkills(result.Eval, loader)
 
+	// Validate eval-level (suite-wide) config now, but defer per-case
+	// validation to loadAndPrepareConfig, which runs it only over the cases
+	// left after include/exclude filters — so an invalid unselected case never
+	// blocks a filtered run. `skill-up validate` still validates the whole
+	// suite (eval + every case) via ValidateAll.
 	validator := config.NewValidator()
-	if err := validator.ValidateAll(result); err != nil {
+	if err := validator.ValidateEvalConfig(result.Eval); err != nil {
 		return "", nil, nil, nil, fmt.Errorf("validation failed: %w", err)
 	}
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -111,6 +111,43 @@ func TestRunEvalDryRunLoadsFiltersAndSkipsAgentSetup(t *testing.T) {
 	}
 }
 
+func TestRunEvalValidatesOnlySelectedCases(t *testing.T) {
+	root := t.TempDir()
+	writeAutoModeSkill(t, root)
+	writeSmokeAndFullEval(t, root)
+
+	dryRunCmd := func() *cobra.Command {
+		cmd := newRunPhaseTestCommand(t)
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		for name, val := range map[string]string{"dry-run": testFlagBoolTrue, runtimeFlagName: "none"} {
+			if err := cmd.Flags().Set(name, val); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return cmd
+	}
+
+	// Filtering to the valid smoke case must succeed even though the full case
+	// is invalid — run validates only the selected cases.
+	okCmd := dryRunCmd()
+	if err := okCmd.Flags().Set("include-case-name", "smoke"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureStdout(t, func() error { return runEval(okCmd, []string{root}) }); err != nil {
+		t.Fatalf("filtered run over the valid smoke case should succeed, got %v", err)
+	}
+
+	// An unfiltered run selects the invalid full case and must fail validation.
+	_, err := captureStdout(t, func() error { return runEval(dryRunCmd(), []string{root}) })
+	if err == nil {
+		t.Fatal("unfiltered run should fail validation on the invalid full case")
+	}
+	if !strings.Contains(err.Error(), "script_path") {
+		t.Fatalf("error = %v, want script_path validation failure", err)
+	}
+}
+
 func TestRunPhaseHelpers(t *testing.T) {
 	var out bytes.Buffer
 	observer := &uiProgressObserver{}
@@ -607,6 +644,42 @@ cases:
 	caseYAML := fmt.Sprintf("id: %s\ninput:\n  prompt: Say hi\n", caseID)
 	if err := os.WriteFile(filepath.Join(casesDir, caseID+".yaml"), []byte(caseYAML), 0o600); err != nil {
 		t.Fatalf("failed to write case yaml: %v", err)
+	}
+}
+
+// writeSmokeAndFullEval writes a skill whose eval lists two cases: a valid
+// `smoke` case and a `full` case that is intentionally invalid (a script judge
+// with no script_path). Used to verify that a filtered run validates only the
+// selected cases while an unfiltered run (and `skill-up validate`) still fails.
+func writeSmokeAndFullEval(t *testing.T, root string) {
+	t.Helper()
+	evalsDir := filepath.Join(root, "evals")
+	casesDir := filepath.Join(evalsDir, "cases")
+	if err := os.MkdirAll(casesDir, 0o755); err != nil {
+		t.Fatalf("failed to create evals/cases: %v", err)
+	}
+	evalYAML := `schema_version: v1alpha1
+environment:
+  type: none
+engine:
+  name: claude_code
+  model:
+    provider: dashscope
+    name: qwen3.6-plus
+cases:
+  files:
+    - evals/cases/smoke.yaml
+    - evals/cases/full.yaml
+`
+	if err := os.WriteFile(filepath.Join(evalsDir, "eval.yaml"), []byte(evalYAML), 0o600); err != nil {
+		t.Fatalf("failed to write eval.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(casesDir, "smoke.yaml"), []byte("id: smoke\ninput:\n  prompt: Say hi\n"), 0o600); err != nil {
+		t.Fatalf("failed to write smoke.yaml: %v", err)
+	}
+	// script judge without script_path ⇒ ValidateCaseConfig rejects this case.
+	if err := os.WriteFile(filepath.Join(casesDir, "full.yaml"), []byte("id: full\ninput:\n  prompt: Do full\njudge:\n  type: script\n"), 0o600); err != nil {
+		t.Fatalf("failed to write full.yaml: %v", err)
 	}
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -125,6 +125,10 @@ func (l *Loader) LoadCaseConfig(casePath string) (*CaseConfig, error) {
 		cfg.ID = stripExt(filepath.Base(casePath))
 	}
 
+	// Record the source path (as listed in cases.files) so duplicate-case
+	// validation can name the offending file even for a filtered subset.
+	cfg.SourceFile = casePath
+
 	return &cfg, nil
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -253,6 +253,13 @@ type CaseConfig struct {
 	// (union, de-duplicated) with cases.defaults.collect_artifacts. See
 	// CaseDefaults.CollectArtifacts for the download layout and semantics.
 	CollectArtifacts []string `yaml:"collect_artifacts,omitempty"`
+
+	// SourceFile is the cases.files entry this case was loaded from (the raw
+	// path as written in eval.yaml). The loader populates it; it is not part
+	// of the YAML document and is excluded from marshalling. Duplicate-case
+	// validation keys off it so the check is correct for any case subset (e.g.
+	// the filtered set `skill-up run` executes), not only the full suite.
+	SourceFile string `json:"-" yaml:"-"`
 }
 
 // Input describes the agent input (prompt or turns).

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -209,12 +209,24 @@ func (v *Validator) ValidateAll(result *EvalResult) error {
 	if err := v.ValidateEvalConfig(result.Eval); err != nil {
 		return err
 	}
+	return v.ValidateCases(result.Cases)
+}
 
-	if errs := validateUniqueCases(result); len(errs) > 0 {
+// ValidateCases validates a set of cases: it rejects duplicate effective IDs
+// and duplicate source-file references within the set, then validates each case
+// document.
+//
+// `skill-up run` calls this with only the cases left after include/exclude
+// filters, so an invalid unselected case never blocks a filtered run;
+// `skill-up validate` passes every case (via ValidateAll) for full-suite
+// validation. Duplicate detection keys off each case's ID and loader-populated
+// SourceFile, so it is correct for any subset, not only the full in-order suite.
+func (v *Validator) ValidateCases(cases []*CaseConfig) error {
+	if errs := duplicateCaseErrors(cases); len(errs) > 0 {
 		return fmt.Errorf("validation errors:\n  - %s", strings.Join(errs, "\n  - "))
 	}
 
-	for _, c := range result.Cases {
+	for _, c := range cases {
 		if err := v.ValidateCaseConfig(c); err != nil {
 			return fmt.Errorf("case %s: %w", c.ID, err)
 		}
@@ -223,32 +235,36 @@ func (v *Validator) ValidateAll(result *EvalResult) error {
 	return nil
 }
 
-// validateUniqueCases rejects duplicate case-file references and duplicate
-// effective case IDs. skill-up writes reports and artifacts keyed by case ID
-// and runs one case per cases.files entry, so a collision would silently
-// overwrite results or double-run a case. LoadAllCases appends one case per
-// cases.files entry in order, so result.Cases is index-aligned with
-// result.Eval.Cases.Files; that lets each error name the offending source file.
-func validateUniqueCases(result *EvalResult) []string {
-	files := result.Eval.Cases.Files
+// duplicateCaseErrors reports duplicate source-file references and duplicate
+// effective case IDs within the given case set. skill-up writes reports and
+// artifacts keyed by case ID and runs one case per cases.files entry, so a
+// collision would silently overwrite results or double-run a case.
+func duplicateCaseErrors(cases []*CaseConfig) []string {
 	var errs []string
-	errs = append(errs, duplicateCaseFileErrors(files)...)
-	errs = append(errs, duplicateCaseIDErrors(result.Cases, files)...)
+	errs = append(errs, duplicateCaseFileErrors(cases)...)
+	errs = append(errs, duplicateCaseIDErrors(cases)...)
 	return errs
 }
 
-// duplicateCaseFileErrors reports cases.files entries that resolve to the same
-// path after normalization (e.g. "cases/a.yaml" vs "./cases/a.yaml"). Each
-// duplicate is reported once, in first-seen order for deterministic messages.
-func duplicateCaseFileErrors(files []string) []string {
-	counts := make(map[string]int, len(files))
-	for _, f := range files {
-		counts[path.Clean(f)]++
+// duplicateCaseFileErrors reports cases loaded from the same source file after
+// path normalization (e.g. "cases/a.yaml" vs "./cases/a.yaml"). Cases with no
+// SourceFile (e.g. loaded from an Anthropic evals.json rather than cases.files)
+// are skipped. Each duplicate is reported once, in first-seen order.
+func duplicateCaseFileErrors(cases []*CaseConfig) []string {
+	counts := make(map[string]int, len(cases))
+	for _, c := range cases {
+		if c.SourceFile == "" {
+			continue
+		}
+		counts[path.Clean(c.SourceFile)]++
 	}
 	var errs []string
 	reported := make(map[string]bool)
-	for _, f := range files {
-		norm := path.Clean(f)
+	for _, c := range cases {
+		if c.SourceFile == "" {
+			continue
+		}
+		norm := path.Clean(c.SourceFile)
 		if counts[norm] > 1 && !reported[norm] {
 			errs = append(errs, fmt.Sprintf("cases.files lists %q %d times (after path normalization); each case file must appear once", norm, counts[norm]))
 			reported[norm] = true
@@ -258,15 +274,15 @@ func duplicateCaseFileErrors(files []string) []string {
 }
 
 // duplicateCaseIDErrors reports effective case IDs shared by more than one case,
-// covering both explicit `id:` fields and filename-derived IDs. files is
-// index-aligned with cases so the message can list the conflicting source files.
-func duplicateCaseIDErrors(cases []*CaseConfig, files []string) []string {
+// covering both explicit `id:` fields and filename-derived IDs. Each case's
+// SourceFile (when known) names the offending file in the message.
+func duplicateCaseIDErrors(cases []*CaseConfig) []string {
 	idFiles := make(map[string][]string, len(cases))
 	var order []string
-	for i, c := range cases {
-		src := "<unknown source>"
-		if i < len(files) {
-			src = files[i]
+	for _, c := range cases {
+		src := c.SourceFile
+		if src == "" {
+			src = "<unknown source>"
 		}
 		if _, seen := idFiles[c.ID]; !seen {
 			order = append(order, c.ID)

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -890,59 +890,53 @@ func TestValidator_ValidateAll(t *testing.T) {
 	})
 }
 
-// TestValidator_ValidateAll_Duplicates covers rejection of duplicate case IDs
-// (explicit and filename-derived) and duplicate cases.files references. files
-// and ids are index-aligned, mirroring LoadAllCases' one-case-per-entry order.
-func TestValidator_ValidateAll_Duplicates(t *testing.T) {
+// caseIDSrc pairs an effective case ID with the cases.files entry it was
+// loaded from, as the loader populates CaseConfig.ID / CaseConfig.SourceFile.
+type caseIDSrc struct {
+	id  string
+	src string
+}
+
+// TestValidator_ValidateCases_Duplicates covers rejection of duplicate case IDs
+// (explicit and filename-derived) and duplicate cases.files references, keyed
+// off each case's ID and SourceFile so it holds for any subset.
+func TestValidator_ValidateCases_Duplicates(t *testing.T) {
 	t.Parallel()
 	validator := NewValidator()
 
-	evalWithFiles := func(files ...string) *EvalConfig {
-		return &EvalConfig{
-			SchemaVersion: "v1alpha1",
-			Environment:   Environment{Type: "none"},
-			Engine:        EngineConfig{Name: "claude_code"},
-			Cases:         CasesConfig{Files: files},
-		}
-	}
-	casesWithIDs := func(ids ...string) []*CaseConfig {
-		cases := make([]*CaseConfig, len(ids))
-		for i, id := range ids {
-			cases[i] = &CaseConfig{ID: id, Input: Input{Prompt: "x"}}
+	buildCases := func(pairs ...caseIDSrc) []*CaseConfig {
+		cases := make([]*CaseConfig, len(pairs))
+		for i, p := range pairs {
+			cases[i] = &CaseConfig{ID: p.id, SourceFile: p.src, Input: Input{Prompt: "x"}}
 		}
 		return cases
 	}
 
 	tests := []struct {
 		name      string
-		files     []string
-		ids       []string
+		cases     []caseIDSrc
 		wantParts []string // non-empty ⇒ expect an error containing every part
 	}{
 		{
 			name:      "duplicate explicit id names both files",
-			files:     []string{"evals/cases/a.yaml", "evals/cases/b.yaml"},
-			ids:       []string{"dup", "dup"},
+			cases:     []caseIDSrc{{"dup", "evals/cases/a.yaml"}, {"dup", "evals/cases/b.yaml"}},
 			wantParts: []string{`duplicate case id "dup"`, "evals/cases/a.yaml", "evals/cases/b.yaml"},
 		},
 		{
 			// Files in different dirs with colliding basenames ⇒ same implicit ID.
 			name:      "duplicate filename-derived id",
-			files:     []string{"evals/cases/smoke.yaml", "evals/full/smoke.yaml"},
-			ids:       []string{"smoke", "smoke"},
+			cases:     []caseIDSrc{{"smoke", "evals/cases/smoke.yaml"}, {"smoke", "evals/full/smoke.yaml"}},
 			wantParts: []string{`duplicate case id "smoke"`},
 		},
 		{
 			// Same file, differently spelled; normalization must collapse them.
 			name:      "duplicate file reference after normalization",
-			files:     []string{"evals/cases/a.yaml", "./evals/cases/a.yaml"},
-			ids:       []string{"a", "a"},
+			cases:     []caseIDSrc{{"a", "evals/cases/a.yaml"}, {"a", "./evals/cases/a.yaml"}},
 			wantParts: []string{"cases.files lists"},
 		},
 		{
 			name:      "unique ids and files pass",
-			files:     []string{"evals/cases/a.yaml", "evals/cases/b.yaml"},
-			ids:       []string{"a", "b"},
+			cases:     []caseIDSrc{{"a", "evals/cases/a.yaml"}, {"b", "evals/cases/b.yaml"}},
 			wantParts: nil,
 		},
 	}
@@ -950,11 +944,10 @@ func TestValidator_ValidateAll_Duplicates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := &EvalResult{Eval: evalWithFiles(tt.files...), Cases: casesWithIDs(tt.ids...)}
-			err := validator.ValidateAll(result)
+			err := validator.ValidateCases(buildCases(tt.cases...))
 			if len(tt.wantParts) == 0 {
 				if err != nil {
-					t.Fatalf("ValidateAll() error = %v, want nil", err)
+					t.Fatalf("ValidateCases() error = %v, want nil", err)
 				}
 				return
 			}
@@ -967,6 +960,25 @@ func TestValidator_ValidateAll_Duplicates(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestValidator_ValidateCases_OnlyChecksGivenCases confirms ValidateCases
+// validates just the cases passed to it: an invalid case omitted from the slice
+// (e.g. filtered out by `skill-up run`) does not cause a failure, while
+// ValidateAll over the full set still catches it.
+func TestValidator_ValidateCases_OnlyChecksGivenCases(t *testing.T) {
+	t.Parallel()
+	validator := NewValidator()
+
+	valid := &CaseConfig{ID: "smoke", SourceFile: "evals/cases/smoke.yaml", Input: Input{Prompt: "hi"}}
+	invalid := &CaseConfig{ID: "full", SourceFile: "evals/cases/full.yaml"} // missing prompt and turns
+
+	if err := validator.ValidateCases([]*CaseConfig{valid}); err != nil {
+		t.Fatalf("ValidateCases([valid]) = %v, want nil", err)
+	}
+	if err := validator.ValidateCases([]*CaseConfig{valid, invalid}); err == nil {
+		t.Fatal("ValidateCases([valid, invalid]) = nil, want error for the invalid case")
 	}
 }
 


### PR DESCRIPTION
Fixes #121.

## Problem

`skill-up run` validated the **whole** suite (eval config + every case) *before* applying `--include-case-name` / `--exclude-case-name` filters. So one invalid unselected case blocked a filtered run — forcing teams to split smoke and full suites into separate eval files even when they share the same skill/environment/engine/fixtures.

## Change

- `run` now validates the **eval-level** config at load, then validates **only the cases left after filtering**. An invalid case that is filtered out no longer blocks the run.
- `skill-up validate` is unchanged and still validates the **whole** suite (every case) regardless of filters.

### Implementation

- Split `Validator.ValidateAll` into `ValidateEvalConfig` (suite-level) + new **`ValidateCases(cases)`** (duplicate-ID / duplicate-file + per-case checks over whatever set is passed). `ValidateAll = ValidateEvalConfig + ValidateCases(all)`, so `validate` behavior is identical.
- Add **`CaseConfig.SourceFile`** (loader-populated, `yaml:"-" json:"-"`). Duplicate-case detection now keys off `ID` + `SourceFile`, so it is correct for any subset — and this removes the fragile `result.Cases ↔ Eval.Cases.Files` index-alignment the #123 check relied on.
- `run.go`: eval-level validation in `loadFromEvalYAML`; `ValidateCases` over the filtered set in `loadAndPrepareConfig`.
- Docs: `run`-vs-`validate` validation scope documented in the command help and `cli-reference.md`.

Note: the `--auto` / `evals.json` run path now also validates its cases (previously unvalidated). This is safe — converted cases carry prompts, and their empty `SourceFile` skips the file-duplicate check.

## Verify (matches the issue's steps)

- New `internal/cli` test: an eval with a valid `smoke` case + an invalid `full` case (script judge, no `script_path`). `run --include-case-name smoke` succeeds; unfiltered `run` fails with the `script_path` error.
- New validator tests: `ValidateCases` scoped duplicate detection; `ValidateCases([valid])` passes while `ValidateCases([valid, invalid])` fails.
- `go test -race ./...` green; `gofmt` / `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)