### PR TITLE
fix: gracefully terminate none-runtime process group on cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicit `id:` fields and filename-derived IDs, and collapses
   differently-spelled paths (e.g. `cases/a.yaml` vs `./cases/a.yaml`).
 
+### Changed
+- The `none` runtime now terminates a canceled or timed-out command's whole
+  process group gracefully before force-killing it. On Unix it sends `SIGTERM`
+  to the group first, giving children ~1s (`noneExecKillGrace`) to run trap
+  handlers, release locks, and exit, then escalates to `SIGKILL` if the group
+  is still alive. The grace fits inside the existing 2s `WaitDelay`, so a
+  timed-out `Exec` still returns within its deadline and keeps the
+  `context.DeadlineExceeded` / exit-code `-1` contract. Previously the group
+  got an immediate `SIGKILL`, so a helper holding a lock could leave stale
+  state and stall a later command. No-op on non-Unix platforms.
+
 ### Fixed
 - Skill installation preserves source file permissions, notably the executable
   bit on scripts. The `none` runtime's per-file upload previously wrote every

--- a/internal/runtime/none.go
+++ b/internal/runtime/none.go
@@ -206,9 +206,11 @@ func (r *NoneRuntime) Exec(ctx context.Context, command string, opts ExecOptions
 	shell := platform.Host()
 	cmd := shell.Cmd(ctx, command)
 	// Run in a dedicated process group (POSIX only — no-op on Windows) and
-	// kill the whole group on cancellation, so a timed-out command's
-	// descendants do not outlive it.
-	configureProcessGroup(cmd)
+	// terminate the whole group on cancellation, so a timed-out command's
+	// descendants do not outlive it. done is closed once Wait returns so the
+	// SIGTERM→SIGKILL escalation timer stops before the PID can be recycled.
+	done := make(chan struct{})
+	configureProcessGroup(cmd, done)
 	// Bound how long Wait blocks after ctx-cancel so a child holding the
 	// stdio pipes can't pin Exec past the deadline. See noneExecWaitDelay
 	// above for the per-OS reasoning.
@@ -234,7 +236,7 @@ func (r *NoneRuntime) Exec(ctx context.Context, command string, opts ExecOptions
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	exitCode, execErr := classifyExecError(ctx, cmd.Run())
+	exitCode, execErr := classifyExecError(ctx, runCmd(cmd, done))
 	result := ExecResult{
 		Stdout:   stdout.String(),
 		Stderr:   stderr.String(),
@@ -279,6 +281,18 @@ func (r *NoneRuntime) Exec(ctx context.Context, command string, opts ExecOptions
 	}
 
 	return result, execErr
+}
+
+// runCmd starts cmd and waits for it, closing done once Wait returns so the
+// process-group escalation goroutine (see configureProcessGroup) stops before
+// the child's PID can be recycled. It mirrors cmd.Run() but exposes that
+// completion signal. A Start failure leaves done closed and returns the error.
+func runCmd(cmd *exec.Cmd, done chan<- struct{}) error {
+	defer close(done)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Wait()
 }
 
 // classifyExecError translates a *exec.Cmd Run error into the (exitCode, error)

--- a/internal/runtime/none_exec_other.go
+++ b/internal/runtime/none_exec_other.go
@@ -5,4 +5,4 @@ package runtime
 import "os/exec"
 
 // configureProcessGroup is a no-op on platforms without POSIX process groups.
-func configureProcessGroup(_ *exec.Cmd) {}
+func configureProcessGroup(_ *exec.Cmd, _ <-chan struct{}) {}

--- a/internal/runtime/none_exec_unix.go
+++ b/internal/runtime/none_exec_unix.go
@@ -5,24 +5,63 @@ package runtime
 import (
 	"os/exec"
 	"syscall"
+	"time"
 )
 
+// noneExecKillGrace is how long a canceled process group is given to exit after
+// SIGTERM before it is escalated to SIGKILL. It must stay comfortably below
+// noneExecWaitDelay (2s) so the escalation fires — and the group is gone —
+// before Exec's WaitDelay force-closes the stdio pipes and returns. One second
+// is enough for a shell and its children to run their trap handlers, release
+// locks, and exit, while still keeping a timed-out Exec well within its
+// deadline.
+const noneExecKillGrace = 1 * time.Second
+
 // configureProcessGroup starts cmd in its own process group and overrides the
-// context-cancellation handler to kill the whole group. Without this,
+// context-cancellation handler to gracefully terminate the whole group, then
+// escalate to a hard kill if it does not exit promptly. Without the group,
 // exec.CommandContext only kills the direct child, so a timed-out command's
 // descendants could keep running and mutate the workspace after the agent was
 // supposed to have stopped.
-func configureProcessGroup(cmd *exec.Cmd) {
+//
+// On cancellation the group is signaled with SIGTERM first, giving children a
+// chance to release locks and clean up, then SIGKILL after noneExecKillGrace if
+// the group has not exited. done must be closed by the caller once cmd.Wait has
+// returned so the escalation timer can be stopped before the PID is recycled.
+func configureProcessGroup(cmd *exec.Cmd, done <-chan struct{}) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil
 		}
+		pid := cmd.Process.Pid
 		// The process is a group leader (Setpgid), so a negative PID signals
-		// the whole group. Fall back to killing just the process on failure.
-		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
-			return cmd.Process.Kill()
+		// the whole group. Fall back to signaling just the process on failure.
+		if err := signalGroupOrProcess(cmd, pid, syscall.SIGTERM); err != nil {
+			return err
 		}
+		// Escalate to SIGKILL out of band so Cancel returns immediately and
+		// os/exec can start its WaitDelay timer. The goroutine exits as soon as
+		// the process is reaped (done closed), so it cannot signal a recycled
+		// PID.
+		go func() {
+			timer := time.NewTimer(noneExecKillGrace)
+			defer timer.Stop()
+			select {
+			case <-done:
+			case <-timer.C:
+				_ = signalGroupOrProcess(cmd, pid, syscall.SIGKILL)
+			}
+		}()
 		return nil
 	}
+}
+
+// signalGroupOrProcess sends sig to the whole process group (negative PID),
+// falling back to signaling just the process if the group signal fails.
+func signalGroupOrProcess(cmd *exec.Cmd, pid int, sig syscall.Signal) error {
+	if err := syscall.Kill(-pid, sig); err != nil {
+		return cmd.Process.Signal(sig)
+	}
+	return nil
 }

--- a/internal/runtime/none_test.go
+++ b/internal/runtime/none_test.go
@@ -359,6 +359,87 @@ func TestNoneRuntime_ExecKillsDescendantsOnTimeout(t *testing.T) {
 	}
 }
 
+// TestNoneRuntime_ExecTerminatesGracefullyThenEscalates verifies the
+// SIGTERM-first escalation path: a command that installs a SIGTERM trap gets a
+// chance to run it (writing a marker) before the group is force-killed. This
+// exercises the graceful half of the contract — children can release locks and
+// clean up rather than being torn down by an immediate SIGKILL.
+func TestNoneRuntime_ExecTerminatesGracefullyThenEscalates(t *testing.T) {
+	if goruntime.GOOS == osWindows {
+		t.Skip("POSIX signal-trap semantics; no Windows equivalent")
+	}
+	t.Parallel()
+
+	rt := &NoneRuntime{}
+	if err := rt.Create(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	// The shell traps SIGTERM, writes a marker, and exits. If cancellation used
+	// an immediate SIGKILL the trap would never run and the marker would be
+	// absent; with SIGTERM-first it is written before the process exits.
+	_, err := rt.Exec(ctx, "trap 'touch cleaned.txt; exit 0' TERM; sleep 10", ExecOptions{})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(rt.Workspace(), "cleaned.txt")); statErr != nil {
+		t.Fatalf("SIGTERM trap did not run before termination: %v", statErr)
+	}
+}
+
+// TestNoneRuntime_ExecStaleLockDoesNotHangNextCommand is the issue's lock-file
+// regression: a first command times out while a background child holds a lock
+// (a live process whose PID is recorded in a lock file). After the timeout the
+// child's process group must be gone, so a second command that checks the lock
+// sees a dead PID and does not block on the stale child.
+func TestNoneRuntime_ExecStaleLockDoesNotHangNextCommand(t *testing.T) {
+	if goruntime.GOOS == osWindows {
+		t.Skip("POSIX process-group kill semantics; no Windows equivalent")
+	}
+	t.Parallel()
+
+	rt := &NoneRuntime{}
+	if err := rt.Create(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close() }()
+
+	// First command: spawn a long-lived background child, record its PID as a
+	// lock, then block past the deadline. On timeout the whole group (including
+	// the child) must be terminated.
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel1()
+	_, err := rt.Exec(ctx1, "sleep 60 & echo $! > lock.pid; sleep 30", ExecOptions{})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first command: expected context deadline exceeded, got %v", err)
+	}
+
+	// Give the group a moment to be reaped after the SIGTERM→SIGKILL path.
+	time.Sleep(noneExecKillGrace + 500*time.Millisecond)
+
+	// Second command: read the recorded PID and check whether that process is
+	// still alive (kill -0). A stale-but-dead lock must not hold anything up;
+	// the command completes promptly and reports the child as gone.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+	start := time.Now()
+	result, err := rt.Exec(ctx2, `pid=$(cat lock.pid); if kill -0 "$pid" 2>/dev/null; then echo ALIVE; else echo DEAD; fi`, ExecOptions{})
+	if err != nil {
+		t.Fatalf("second command errored: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("second command hung on stale child for %s", elapsed)
+	}
+	if !strings.Contains(result.Stdout, "DEAD") {
+		t.Fatalf("stale lock child survived timeout; second command saw %q", result.Stdout)
+	}
+}
+
 func TestNoneRuntime_ExecAddsSpanCommandAttrs(t *testing.T) {
 	rt := &NoneRuntime{}
 	if err := rt.Create(context.Background()); err != nil {


### PR DESCRIPTION
## Summary

The `none` runtime already starts commands in their own process group and kills the whole group on cancellation, but it did so with an **immediate SIGKILL**. Children never got a chance to run trap handlers, release locks, or clean up — the exact failure mode the issue describes, where a helper holding a lock left stale state that stalled a later command.

This adds a graceful escalation path:

- On cancel/timeout, the process group is signaled with **SIGTERM first**, giving children a chance to clean up.
- If the group is still alive after a short grace (`noneExecKillGrace = 1s`), it escalates to **SIGKILL**.
- The grace fits inside the existing 2s `WaitDelay`, so a timed-out `Exec` still returns within its deadline and preserves the `context.DeadlineExceeded` / exit-code `-1` contract.
- Whole-group semantics (negative PID) and the single-process fallback are kept. Escalation runs out of band (goroutine) so `cmd.Cancel` returns immediately and `os/exec` can start its `WaitDelay` timer; a `done` channel closed once `Wait` returns stops the escalation timer before the PID can be recycled.
- No-op on non-Unix platforms (`none_exec_other.go`, guarded by the same build tags).

## Tests

- `TestNoneRuntime_ExecTerminatesGracefullyThenEscalates` — a SIGTERM trap writes a marker before exit, proving the graceful path runs cleanup rather than an immediate SIGKILL (verified: fails under immediate-SIGKILL, passes with SIGTERM-first).
- `TestNoneRuntime_ExecStaleLockDoesNotHangNextCommand` — the issue's lock-file regression: a first command times out while a background child records its PID as a lock; after the timeout the child's group is gone, and a second command sees a dead PID (`kill -0`) and does not hang.
- Existing `TestNoneRuntime_ExecKillsDescendantsOnTimeout` and the deadline/cancel contract tests still pass.

`go build ./...`, `go vet ./...`, `gofmt -l` clean, and `go test -race ./...` green.

Fixes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)