### PR TITLE
refactor(custom-engine): extract leaf config package

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/alibaba/skill-up/internal/config"
 	"github.com/alibaba/skill-up/internal/credential"
+	"github.com/alibaba/skill-up/internal/customengine"
 	"github.com/alibaba/skill-up/internal/logging"
 	"github.com/alibaba/skill-up/internal/observability"
 	"github.com/alibaba/skill-up/internal/platform"
@@ -117,7 +117,7 @@ type Config struct {
 	Kwargs map[string]string
 	// Custom carries the custom engine configuration when Name does not match
 	// a built-in agent. It is nil for built-in agents.
-	Custom *config.CustomEngineConfig
+	Custom *customengine.Config
 }
 
 // Runtime is an alias for runtime.Runtime for agent package convenience.

--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alibaba/skill-up/internal/config"
+	"github.com/alibaba/skill-up/internal/customengine"
 	"github.com/alibaba/skill-up/internal/logging"
 	"github.com/alibaba/skill-up/internal/runtime"
 	"github.com/alibaba/skill-up/pkg/transcript"
@@ -64,8 +64,8 @@ var maxArtifactDownloadBytes int64 = 256 * 1024 * 1024
 
 // CustomAgent implements Agent for user-defined engines configured via
 // engine.custom. The local transport is fully supported; the http transport
-// supports JSON request/response, with multipart file upload still pending.
-// Result artifacts declared via a `url` are downloaded for any transport. See
+// supports JSON request/response and multipart file upload. Result artifacts
+// declared via a `url` are downloaded for any transport. See
 // docs/design/custom-engine.md.
 //
 // CustomAgent embeds BaseAgent directly (not CLIAgent) so it inherits only
@@ -134,7 +134,7 @@ type customTransport interface {
 // session input and template variable set. start is captured at preparation
 // time so the reported duration spans preparation through result assembly.
 type customRunPrep struct {
-	custom     *config.CustomEngineConfig
+	custom     *customengine.Config
 	vars       map[string]string
 	sessJSON   []byte
 	timeoutSec int
@@ -185,7 +185,7 @@ func (a *CustomAgent) Run(ctx context.Context, rt Runtime, opts ExecOptions, mes
 // local transport runs a command in the runtime, the http transport calls a
 // remote agent service. Both produce a transportOutcome that CustomAgent.Run
 // hands to the shared assembleResult.
-func (a *CustomAgent) selectTransport(custom *config.CustomEngineConfig) (customTransport, error) {
+func (a *CustomAgent) selectTransport(custom *customengine.Config) (customTransport, error) {
 	switch custom.Transport {
 	case customTransportLocal:
 		return &localTransport{a: a}, nil
@@ -200,7 +200,7 @@ func (a *CustomAgent) selectTransport(custom *config.CustomEngineConfig) (custom
 // full template variable set, and the marshaled SessionInput. start is captured
 // here so the reported duration spans preparation through result assembly,
 // matching the pre-refactor behavior.
-func (a *CustomAgent) prepareRun(rt Runtime, opts ExecOptions, messages []transcript.Message, custom *config.CustomEngineConfig) (*customRunPrep, error) {
+func (a *CustomAgent) prepareRun(rt Runtime, opts ExecOptions, messages []transcript.Message, custom *customengine.Config) (*customRunPrep, error) {
 	start := time.Now()
 	// engine.custom.timeout_seconds is the per-engine deadline; opts.TimeoutSec
 	// is the outer case deadline (the evaluator already wraps ctx with it).
@@ -279,7 +279,7 @@ func (a *CustomAgent) clearStaleOutputFile(ctx context.Context, rt Runtime, outp
 }
 
 // buildLocalExec renders the command, args and exec options for the local run.
-func (a *CustomAgent) buildLocalExec(ctx context.Context, rt Runtime, opts ExecOptions, custom *config.CustomEngineConfig, vars map[string]string, timeoutSec int) (string, ExecOptions, error) {
+func (a *CustomAgent) buildLocalExec(ctx context.Context, rt Runtime, opts ExecOptions, custom *customengine.Config, vars map[string]string, timeoutSec int) (string, ExecOptions, error) {
 	local := custom.Local
 	command, err := renderTemplate(local.Command, vars)
 	if err != nil {
@@ -391,7 +391,7 @@ func (a *CustomAgent) assembleResult(ctx context.Context, rt Runtime, opts ExecO
 // configured response_format. The text format never errors and always grades
 // stdout (never the output file); session_result returns a parse error when
 // the payload is missing or malformed.
-func (a *CustomAgent) buildResult(ctx context.Context, rt Runtime, opts ExecOptions, custom *config.CustomEngineConfig, raw, stdout string, exitCode int, stderr string, durationMs int64, messages []transcript.Message) (*SessionResult, error) {
+func (a *CustomAgent) buildResult(ctx context.Context, rt Runtime, opts ExecOptions, custom *customengine.Config, raw, stdout string, exitCode int, stderr string, durationMs int64, messages []transcript.Message) (*SessionResult, error) {
 	if customResponseFormat(custom) == customResponseText {
 		// Per the contract, text responses come from stdout; an output file
 		// produced for bookkeeping must not be graded as the final answer.
@@ -430,7 +430,7 @@ func (a *CustomAgent) appendFrameworkFiles(res *SessionResult, files []string) {
 // input). The boolean reports whether the configured output file was produced
 // (exists in the runtime) — independent of whether it supplied the payload —
 // so an empty produced file is still excluded from workspace diffs.
-func (a *CustomAgent) readRawResult(ctx context.Context, rt Runtime, custom *config.CustomEngineConfig, result ExecResult, outputFile string) (raw string, produced bool) {
+func (a *CustomAgent) readRawResult(ctx context.Context, rt Runtime, custom *customengine.Config, result ExecResult, outputFile string) (raw string, produced bool) {
 	// Re-resolve symlinks now that the engine has run. workspacePath was
 	// called pre-run, but the engine could have created a not-yet-existing
 	// parent (e.g. outputs/newdir) as a symlink pointing outside the
@@ -1076,7 +1076,7 @@ func (a *CustomAgent) completeTemplateVars(baseVars, renderedKwargs map[string]s
 // A non-absolute configured path is resolved against the runtime workspace so
 // it is consistent regardless of local.cwd (the command sees the same path the
 // runtime upload/download APIs key on).
-func resolveCustomIOFiles(rt Runtime, custom *config.CustomEngineConfig, vars map[string]string) (inputFile, outputFile string, err error) {
+func resolveCustomIOFiles(rt Runtime, custom *customengine.Config, vars map[string]string) (inputFile, outputFile string, err error) {
 	inputFile = filepath.Join(rt.Workspace(), customDefaultInputFile)
 	if custom.Local.InputFile != "" {
 		rendered, rErr := renderTemplate(custom.Local.InputFile, vars)
@@ -1172,7 +1172,7 @@ func resolveExistingPrefix(abs string) string {
 	}
 }
 
-func customResponseFormat(custom *config.CustomEngineConfig) string {
+func customResponseFormat(custom *customengine.Config) string {
 	if custom.ResponseFormat == customResponseText {
 		return customResponseText
 	}
@@ -1252,9 +1252,9 @@ func renderTemplate(s string, vars map[string]string) (string, error) {
 }
 
 func resolveTemplateToken(inner string, vars map[string]string) (string, error) {
-	// Share the ${X} / ${X:-default} / ${X?msg} grammar with the config-load-time
-	// resolver (config.resolveEnvToken) so the two cannot drift apart.
-	tok := config.ParseTemplateToken(inner)
+	// Share the ${X} / ${X:-default} / ${X?msg} grammar with the config resolver
+	// so the two cannot drift apart.
+	tok := customengine.ParseTemplateToken(inner)
 
 	if v, ok := vars[tok.Name]; ok {
 		// A present-but-empty built-in value (e.g. an unconfigured api_key)

--- a/internal/agent/custom_http_files.go
+++ b/internal/agent/custom_http_files.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 
-	"github.com/alibaba/skill-up/internal/config"
+	"github.com/alibaba/skill-up/internal/customengine"
 )
 
 // maxHTTPUploadBytes caps the total size of files uploaded in a single
@@ -24,7 +24,7 @@ const maxHTTPUploadBytes = 256 * 1024 * 1024
 // carrying the rendered JSON request body, plus one `files` part per matched
 // workspace file (the part filename is the workspace-relative path). It returns
 // the body bytes and the multipart Content-Type (which carries the boundary).
-func (t *httpTransport) buildMultipartBody(ctx context.Context, rt Runtime, h *config.CustomHTTPConfig, payload []byte) ([]byte, string, error) {
+func (t *httpTransport) buildMultipartBody(ctx context.Context, rt Runtime, h *customengine.HTTPConfig, payload []byte) ([]byte, string, error) {
 	relPaths, err := expandHTTPFiles(ctx, rt, h.Files)
 	if err != nil {
 		return nil, "", err
@@ -101,7 +101,7 @@ func addFilePart(ctx context.Context, rt Runtime, mw *multipart.Writer, rel stri
 // and .git). With required (the default), an entry that matches nothing is an
 // error; with required:false it is skipped. Results are deduplicated and sorted
 // for a deterministic request.
-func expandHTTPFiles(ctx context.Context, rt Runtime, files []config.CustomHTTPFile) ([]string, error) {
+func expandHTTPFiles(ctx context.Context, rt Runtime, files []customengine.HTTPFile) ([]string, error) {
 	listing, err := listWorkspaceFiles(ctx, rt)
 	if err != nil {
 		return nil, fmt.Errorf("http.files: list workspace: %w", err)
@@ -114,7 +114,7 @@ func expandHTTPFiles(ctx context.Context, rt Runtime, files []config.CustomHTTPF
 	seen := make(map[string]bool)
 	var out []string
 	for i, f := range files {
-		if !config.WorkspaceRelPathSafe(f.Path) {
+		if !customengine.WorkspaceRelPathSafe(f.Path) {
 			return nil, fmt.Errorf(
 				"engine.custom.http.files[%d].path %q must be a non-empty relative path inside the workspace", i, f.Path)
 		}
@@ -183,7 +183,7 @@ func listWorkspaceFiles(ctx context.Context, rt Runtime) ([]string, error) {
 		// can never reach DownloadFile, regardless of how find behaves. Also drop
 		// names with a CR/LF — they cannot be safely written into a multipart
 		// Content-Disposition filename (header corruption / injection).
-		if rel != "" && config.WorkspaceRelPathSafe(rel) && !strings.ContainsAny(rel, "\r\n") {
+		if rel != "" && customengine.WorkspaceRelPathSafe(rel) && !strings.ContainsAny(rel, "\r\n") {
 			files = append(files, rel)
 		}
 	}

--- a/internal/config/customengine.go
+++ b/internal/config/customengine.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+
+	"github.com/alibaba/skill-up/internal/customengine"
 )
 
 // sensitiveEnvNamePattern matches environment variable names that look like
@@ -269,7 +271,7 @@ func resolveStringMapEnvWith(field string, m map[string]string, resolveFn func(s
 // resolveLocalEnv resolves the engine.custom.local fields. command, args, cwd
 // and the I/O paths all become (or are logged as part of) a command line, so
 // they reject secret-like references.
-func resolveLocalEnv(l *CustomLocalConfig) []string {
+func resolveLocalEnv(l *customengine.LocalConfig) []string {
 	var errs []string
 	errs = append(errs, resolveScalarEnvStrict("local.command", &l.Command)...)
 	errs = append(errs, resolveScalarEnvStrict("local.cwd", &l.Cwd)...)
@@ -287,7 +289,7 @@ func resolveLocalEnv(l *CustomLocalConfig) []string {
 }
 
 // resolveHTTPEnv resolves the engine.custom.http fields.
-func resolveHTTPEnv(h *CustomHTTPConfig) []string {
+func resolveHTTPEnv(h *customengine.HTTPConfig) []string {
 	var errs []string
 	errs = append(errs, resolveScalarEnv("http.url", &h.URL)...)
 	errs = append(errs, resolveScalarEnv("http.method", &h.Method)...)
@@ -475,7 +477,7 @@ func resolveEnvRefsWith(s string, rejectSecrets bool) (string, error) {
 //
 //revive:disable-next-line:flag-parameter
 func resolveEnvToken(inner string, rejectSecrets bool) (value string, leaveIntact bool, err error) {
-	tok := ParseTemplateToken(inner)
+	tok := customengine.ParseTemplateToken(inner)
 
 	if IsBuiltinTemplateVar(tok.Name) {
 		if rejectSecrets && isSensitiveTemplateVar(tok.Name) {

--- a/internal/config/customengine_compat.go
+++ b/internal/config/customengine_compat.go
@@ -1,0 +1,35 @@
+package config
+
+import "github.com/alibaba/skill-up/internal/customengine"
+
+// CustomEngineConfig is retained as a compatibility alias; new code should
+// use customengine.Config.
+type CustomEngineConfig = customengine.Config
+
+// CustomLocalConfig is retained as a compatibility alias; new code should use
+// customengine.LocalConfig.
+type CustomLocalConfig = customengine.LocalConfig
+
+// CustomHTTPConfig is retained as a compatibility alias; new code should use
+// customengine.HTTPConfig.
+type CustomHTTPConfig = customengine.HTTPConfig
+
+// CustomHTTPFile is retained as a compatibility alias; new code should use
+// customengine.HTTPFile.
+type CustomHTTPFile = customengine.HTTPFile
+
+// TemplateToken is retained as a compatibility alias; new code should use
+// customengine.TemplateToken.
+type TemplateToken = customengine.TemplateToken
+
+// ParseTemplateToken forwards to the canonical custom-engine parser. New code
+// should use customengine.ParseTemplateToken.
+func ParseTemplateToken(inner string) TemplateToken {
+	return customengine.ParseTemplateToken(inner)
+}
+
+// WorkspaceRelPathSafe forwards to the canonical custom-engine path check. New
+// code should use customengine.WorkspaceRelPathSafe.
+func WorkspaceRelPathSafe(p string) bool {
+	return customengine.WorkspaceRelPathSafe(p)
+}

--- a/internal/config/customengine_compat_test.go
+++ b/internal/config/customengine_compat_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/alibaba/skill-up/internal/customengine"
+)
+
+func TestCustomEngineCompatibilityAliases(t *testing.T) {
+	legacy := &CustomEngineConfig{
+		Transport: "local",
+		Local:     &CustomLocalConfig{Command: "agent"},
+	}
+	canonical := acceptCanonicalCustomEngineConfig(legacy)
+	if canonical.Local == nil || canonical.Local.Command != "agent" {
+		t.Fatalf("canonical config = %+v", canonical)
+	}
+
+	if got := ParseTemplateToken("FOO:-bar"); got != (customengine.TemplateToken{Name: "FOO", Default: "bar", HasDefault: true}) {
+		t.Fatalf("ParseTemplateToken compatibility wrapper = %+v", got)
+	}
+	if !WorkspaceRelPathSafe("artifacts/*.json") || WorkspaceRelPathSafe("../secret") {
+		t.Fatal("WorkspaceRelPathSafe compatibility wrapper changed behavior")
+	}
+}
+
+func acceptCanonicalCustomEngineConfig(cfg *customengine.Config) *customengine.Config {
+	return cfg
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -3,6 +3,7 @@ package config
 import (
 	"time"
 
+	"github.com/alibaba/skill-up/internal/customengine"
 	"github.com/alibaba/skill-up/internal/runtime"
 )
 
@@ -100,53 +101,8 @@ type EngineConfig struct {
 	// Kwargs carries agent-specific key/value options. Each agent reads only
 	// the keys it understands; unknown keys are ignored. Recognised keys are
 	// documented per agent (e.g. codex honours "bypass_sandbox").
-	Kwargs map[string]string   `yaml:"kwargs,omitempty"`
-	Custom *CustomEngineConfig `yaml:"custom,omitempty"`
-}
-
-// CustomEngineConfig describes a user-defined agent engine that is not a
-// built-in agent. It is read only when engine.name does not match a built-in
-// agent. See docs/design/custom-engine.md for the full contract.
-type CustomEngineConfig struct {
-	Transport      string             `yaml:"transport"` // local, http
-	TimeoutSeconds int                `yaml:"timeout_seconds,omitempty"`
-	ResponseFormat string             `yaml:"response_format,omitempty"` // session_result (default), text
-	Env            map[string]string  `yaml:"env,omitempty"`
-	Kwargs         map[string]string  `yaml:"kwargs,omitempty"`
-	Local          *CustomLocalConfig `yaml:"local,omitempty"`
-	HTTP           *CustomHTTPConfig  `yaml:"http,omitempty"`
-}
-
-// CustomLocalConfig configures the local transport: a command executed inside
-// the current runtime via runtime.Exec.
-type CustomLocalConfig struct {
-	Command    string   `yaml:"command"`
-	Args       []string `yaml:"args,omitempty"`
-	Cwd        string   `yaml:"cwd,omitempty"`
-	InputFile  string   `yaml:"input_file,omitempty"`
-	OutputFile string   `yaml:"output_file,omitempty"`
-}
-
-// CustomHTTPConfig configures the http transport: a remote or local HTTP agent
-// service. JSON request/response and multipart file upload (Files) are
-// implemented; URL artifact download in the result is a follow-up.
-type CustomHTTPConfig struct {
-	URL     string            `yaml:"url"`
-	Method  string            `yaml:"method,omitempty"` // POST
-	Headers map[string]string `yaml:"headers,omitempty"`
-	Files   []CustomHTTPFile  `yaml:"files,omitempty"`
-	// RequestBody is an arbitrary YAML value: a map, a sequence, or a scalar
-	// such as `request_body: ${session_input}`. It is rendered by the http
-	// transport (see renderBodyValue), which injects ${session_input} /
-	// ${messages} / ${kwargs} as JSON structures. Declared as `any` so yaml.v3
-	// can unmarshal a top-level scalar, not only a map.
-	RequestBody any `yaml:"request_body,omitempty"`
-}
-
-// CustomHTTPFile declares a workspace file (or glob) uploaded with an HTTP request.
-type CustomHTTPFile struct {
-	Path     string `yaml:"path"`
-	Required *bool  `yaml:"required,omitempty"` // defaults to true
+	Kwargs map[string]string    `yaml:"kwargs,omitempty"`
+	Custom *customengine.Config `yaml:"custom,omitempty"`
 }
 
 // ModelConfig describes the model to use.

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"path"
 	"regexp"
-	"slices"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 
 	"github.com/alibaba/skill-up/internal/agentkind"
+	"github.com/alibaba/skill-up/internal/customengine"
 )
 
 // Judge type constants.
@@ -398,7 +398,7 @@ func validateEngine(engine EngineConfig) []string {
 	return validateCustomEngine(engine.Custom)
 }
 
-func validateCustomEngine(custom *CustomEngineConfig) []string {
+func validateCustomEngine(custom *customengine.Config) []string {
 	var errs []string
 
 	// Both the local and http transports are implemented (JSON request/response
@@ -441,8 +441,8 @@ func validateCustomEngine(custom *CustomEngineConfig) []string {
 
 // validateCustomHTTP validates the engine.custom.http block: url is required,
 // method must be POST, and each files[].path must be a workspace-relative path
-// or glob. URL artifact download in the result is a follow-up.
-func validateCustomHTTP(h *CustomHTTPConfig) []string {
+// or glob.
+func validateCustomHTTP(h *customengine.HTTPConfig) []string {
 	if h == nil {
 		return []string{"engine.custom.http.url is required when transport is http"}
 	}
@@ -454,20 +454,12 @@ func validateCustomHTTP(h *CustomHTTPConfig) []string {
 		errs = append(errs, fmt.Sprintf("engine.custom.http.method must be POST (got %q)", h.Method))
 	}
 	for i := range h.Files {
-		if p := h.Files[i].Path; !WorkspaceRelPathSafe(p) {
+		if p := h.Files[i].Path; !customengine.WorkspaceRelPathSafe(p) {
 			errs = append(errs, fmt.Sprintf(
 				"engine.custom.http.files[%d].path %q must be a non-empty relative path inside the workspace (no leading / or ..)", i, p))
 		}
 	}
 	return errs
-}
-
-// WorkspaceRelPathSafe reports whether p is a non-empty, workspace-relative
-// path or glob: not absolute and with no ".." segment. It is shared by config
-// validation and the http transport's file expansion so both apply the same
-// rule (agent imports config).
-func WorkspaceRelPathSafe(p string) bool {
-	return p != "" && !strings.HasPrefix(p, "/") && !slices.Contains(strings.Split(p, "/"), "..")
 }
 
 func isValidRuntimeType(t string) bool {

--- a/internal/customengine/config.go
+++ b/internal/customengine/config.go
@@ -1,0 +1,46 @@
+// Package customengine defines dependency-free configuration and parsing
+// primitives shared by the config loader and custom agent transports.
+package customengine
+
+// Config describes a user-defined agent engine that is not a
+// built-in agent. It is read only when engine.name does not match a built-in
+// agent. See docs/design/custom-engine.md for the full contract.
+type Config struct {
+	Transport      string            `yaml:"transport"` // local, http
+	TimeoutSeconds int               `yaml:"timeout_seconds,omitempty"`
+	ResponseFormat string            `yaml:"response_format,omitempty"` // session_result (default), text
+	Env            map[string]string `yaml:"env,omitempty"`
+	Kwargs         map[string]string `yaml:"kwargs,omitempty"`
+	Local          *LocalConfig      `yaml:"local,omitempty"`
+	HTTP           *HTTPConfig       `yaml:"http,omitempty"`
+}
+
+// LocalConfig configures the local transport: a command executed inside
+// the current runtime via runtime.Exec.
+type LocalConfig struct {
+	Command    string   `yaml:"command"`
+	Args       []string `yaml:"args,omitempty"`
+	Cwd        string   `yaml:"cwd,omitempty"`
+	InputFile  string   `yaml:"input_file,omitempty"`
+	OutputFile string   `yaml:"output_file,omitempty"`
+}
+
+// HTTPConfig configures the http transport: a remote or local HTTP agent
+// service with JSON request/response and optional multipart file upload.
+type HTTPConfig struct {
+	URL     string            `yaml:"url"`
+	Method  string            `yaml:"method,omitempty"` // POST
+	Headers map[string]string `yaml:"headers,omitempty"`
+	Files   []HTTPFile        `yaml:"files,omitempty"`
+	// RequestBody is an arbitrary YAML value: a map, a sequence, or a scalar
+	// such as `request_body: ${session_input}`. It is rendered by the http
+	// transport, which injects ${session_input} / ${messages} / ${kwargs} as
+	// JSON structures. Declared as any so yaml.v3 can unmarshal a scalar.
+	RequestBody any `yaml:"request_body,omitempty"`
+}
+
+// HTTPFile declares a workspace file (or glob) uploaded with an HTTP request.
+type HTTPFile struct {
+	Path     string `yaml:"path"`
+	Required *bool  `yaml:"required,omitempty"` // defaults to true
+}

--- a/internal/customengine/customengine_test.go
+++ b/internal/customengine/customengine_test.go
@@ -1,0 +1,105 @@
+package customengine
+
+import (
+	"net/http"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfigPreservesYAMLSchema(t *testing.T) {
+	var cfg Config
+	err := yaml.Unmarshal([]byte(`
+transport: http
+timeout_seconds: 30
+response_format: text
+http:
+  url: https://example.test/agent
+  method: POST
+  files:
+    - path: artifacts/*.json
+      required: false
+  request_body: ${session_input}
+`), &cfg)
+	if err != nil {
+		t.Fatalf("unmarshal Config: %v", err)
+	}
+	if cfg.Transport != "http" || cfg.TimeoutSeconds != 30 || cfg.ResponseFormat != "text" {
+		t.Fatalf("top-level fields = %+v", cfg)
+	}
+	if cfg.HTTP == nil || cfg.HTTP.URL != "https://example.test/agent" || cfg.HTTP.Method != http.MethodPost {
+		t.Fatalf("HTTP = %+v", cfg.HTTP)
+	}
+	if len(cfg.HTTP.Files) != 1 || cfg.HTTP.Files[0].Path != "artifacts/*.json" {
+		t.Fatalf("HTTP.Files = %+v", cfg.HTTP.Files)
+	}
+	if cfg.HTTP.Files[0].Required == nil || *cfg.HTTP.Files[0].Required {
+		t.Fatalf("HTTP.Files[0].Required = %v, want false", cfg.HTTP.Files[0].Required)
+	}
+	if cfg.HTTP.RequestBody != "${session_input}" {
+		t.Fatalf("HTTP.RequestBody = %#v", cfg.HTTP.RequestBody)
+	}
+}
+
+func TestParseTemplateToken(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want TemplateToken
+	}{
+		{name: "plain", in: "FOO", want: TemplateToken{Name: "FOO"}},
+		{name: "default", in: "FOO:-bar", want: TemplateToken{Name: "FOO", Default: "bar", HasDefault: true}},
+		{name: "error", in: "FOO?set FOO", want: TemplateToken{Name: "FOO", ErrMsg: "set FOO", HasErrForm: true}},
+		{name: "default precedence", in: "FOO:-a?b", want: TemplateToken{Name: "FOO", Default: "a?b", HasDefault: true}},
+		{name: "dotted name", in: "kwargs.profile", want: TemplateToken{Name: "kwargs.profile"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseTemplateToken(tt.in); got != tt.want {
+				t.Fatalf("ParseTemplateToken(%q) = %+v, want %+v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTemplateTokenRequiredErr(t *testing.T) {
+	tests := []struct {
+		name string
+		tok  TemplateToken
+		want string
+	}{
+		{name: "explicit", tok: TemplateToken{Name: "FOO", ErrMsg: "set FOO"}, want: "set FOO"},
+		{name: "empty", tok: TemplateToken{Name: "FOO"}, want: "FOO is required"},
+		{name: "whitespace", tok: TemplateToken{Name: "FOO", ErrMsg: "  "}, want: "FOO is required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.tok.RequiredErr(); got == nil || got.Error() != tt.want {
+				t.Fatalf("RequiredErr() = %v, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceRelPathSafe(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "artifact.json", want: true},
+		{path: "artifacts/*.json", want: true},
+		{path: "**/*", want: true},
+		{path: ".", want: true},
+		{path: "", want: false},
+		{path: "/etc/passwd", want: false},
+		{path: "../secret", want: false},
+		{path: "artifacts/../secret", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := WorkspaceRelPathSafe(tt.path); got != tt.want {
+				t.Fatalf("WorkspaceRelPathSafe(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/customengine/path.go
+++ b/internal/customengine/path.go
@@ -1,0 +1,12 @@
+package customengine
+
+import (
+	"slices"
+	"strings"
+)
+
+// WorkspaceRelPathSafe reports whether p is a non-empty, workspace-relative
+// path or glob: not absolute and with no ".." segment.
+func WorkspaceRelPathSafe(p string) bool {
+	return p != "" && !strings.HasPrefix(p, "/") && !slices.Contains(strings.Split(p, "/"), "..")
+}

--- a/internal/customengine/template_token.go
+++ b/internal/customengine/template_token.go
@@ -1,4 +1,4 @@
-package config
+package customengine
 
 import (
 	"errors"
@@ -6,12 +6,8 @@ import (
 )
 
 // TemplateToken is the parsed body of a ${...} reference. It is shared by the
-// config-load-time resolver (resolveEnvToken) and the agent-runtime resolver
-// (agent.resolveTemplateToken) so the ${X} / ${X:-default} / ${X?msg} grammar
-// has a single source of truth and the two resolvers cannot drift apart.
-//
-// Interim home: when the deferred internal/customengine leaf package of #50
-// lands, this type moves there alongside the custom-engine config types.
+// config-load-time resolver and the agent-runtime resolver so the
+// ${X} / ${X:-default} / ${X?msg} grammar has a single source of truth.
 type TemplateToken struct {
 	// Name is the variable name (the part before any :- or ? clause).
 	Name string
@@ -27,8 +23,7 @@ type TemplateToken struct {
 
 // ParseTemplateToken splits a reference body into its variable name plus an
 // optional default-value or error-message clause. `:-` is matched before `?`,
-// so ${X:-a?b} keeps "a?b" as the default — preserving the precedence both
-// resolvers already relied on.
+// so ${X:-a?b} keeps "a?b" as the default.
 func ParseTemplateToken(inner string) TemplateToken {
 	t := TemplateToken{Name: inner}
 	if before, after, found := strings.Cut(inner, ":-"); found {


### PR DESCRIPTION
## Summary

- add a dependency-free `internal/customengine` leaf package for custom-engine config types, template-token grammar, and workspace-relative path checks
- make `internal/config` consume the canonical leaf types while retaining compatibility aliases and explicit wrappers for existing callers
- migrate custom agent transports to the leaf package, removing the `internal/agent -> internal/config` dependency without changing the YAML contract or runtime behavior

This completes the leaf-package extraction proposed in #50. The shared template-token parser landed earlier in #89; this PR moves that parser to its intended final home together with the remaining shared primitives.

## Verification

- `make verify`
- `make test`
- `go test -race ./internal/customengine ./internal/config ./internal/agent`
- `go test -tags e2e -count=1 -v -run '^TestPipeline_CustomEngine_(LocalTransport|HTTPTransport|Validate|RejectsMissingEnvVar)$' ./e2e`\n- import-graph assertion confirming `internal/agent` no longer imports `internal/config`\n\nCloses #50