### PR TITLE
Implement per-case MCP overrides and related documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   case) regardless of filters.
 
 ### Added
+- Per-case mocked MCP response overrides (SUP-0003): a case file may now declare
+  its own `mcp.servers` to vary the mocked fixture while keeping the same MCP
+  server and tool names. Servers merge with eval-level `mcp.servers` by `name`
+  (whole-entry replacement; unmatched names are appended), and a case without
+  `mcp` inherits the eval-level config unchanged. Case-level servers must use
+  `mode: mocked` in this MVP, `config_ref` stays relative to the Skill
+  directory, and each case provisions its own mocked server so fixtures remain
+  isolated under `cases.parallelism > 1`.
 - Config validation now rejects duplicate case IDs and duplicate `cases.files`
   references. Since reports and artifacts are keyed by case ID and one case runs
   per `cases.files` entry, a collision would silently overwrite results or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-07-16
+
+### Added
+- Per-case mocked MCP response overrides (SUP-0003): a case file may now declare
+  its own `mcp.servers` to vary mocked fixtures while keeping the same MCP
+  server and tool names. Servers merge with eval-level `mcp.servers` by `name`
+  (whole-entry replacement; unmatched names are appended), and a case without
+  `mcp` inherits the eval-level config unchanged. Case-level servers must use
+  `mode: mocked` in this MVP, non-built-in mocked servers must provide
+  `config_ref`, `config_ref` stays relative to the Skill directory, and each
+  case provisions its own mocked server so fixtures remain isolated under
+  `cases.parallelism > 1`.
+
 ## [0.6.0] - 2026-07-14
 
 ### Added
@@ -68,14 +81,6 @@ The `v0.5.0` release tag is available at
   case) regardless of filters.
 
 ### Added
-- Per-case mocked MCP response overrides (SUP-0003): a case file may now declare
-  its own `mcp.servers` to vary the mocked fixture while keeping the same MCP
-  server and tool names. Servers merge with eval-level `mcp.servers` by `name`
-  (whole-entry replacement; unmatched names are appended), and a case without
-  `mcp` inherits the eval-level config unchanged. Case-level servers must use
-  `mode: mocked` in this MVP, `config_ref` stays relative to the Skill
-  directory, and each case provisions its own mocked server so fixtures remain
-  isolated under `cases.parallelism > 1`.
 - Config validation now rejects duplicate case IDs and duplicate `cases.files`
   references. Since reports and artifacts are keyed by case ID and one case runs
   per `cases.files` entry, a collision would silently overwrite results or

--- a/docs/guide/writing-evals.md
+++ b/docs/guide/writing-evals.md
@@ -307,6 +307,39 @@ tool_responses:
 
 Environment-variable references support both `${VAR}` and full-value `$VAR` forms; the variable name must match `[A-Za-z_][A-Za-z0-9_]*`. Variables listed in `required_env` are injected into the Agent process; full env-var references inside `headers` are also recorded by name so the Agent can pick the right transport mechanism when installing the MCP server.
 
+#### Per-case mocked MCP overrides
+
+Eval-level `mcp.servers` is the default for every case. A case may declare its own `mcp.servers` to vary the mocked fixture while keeping the same server and tool names (introduced by SUP-0003). Servers are merged by `name`: a case-level entry with a matching name replaces that whole eval-level server, and a new name is appended. A case without `mcp` inherits the eval-level config unchanged.
+
+```yaml
+# eval.yaml — default fixture shared by all cases
+mcp:
+  servers:
+    - name: project-mgmt
+      mode: mocked
+      config_ref: evals/fixtures/mcp/project-default.yaml
+```
+
+```yaml
+# cases/project-open.yaml — same server/tool, different fixture
+id: project-open
+input:
+  prompt: Check the project status and continue the publish plan.
+
+mcp:
+  servers:
+    - name: project-mgmt
+      mode: mocked
+      config_ref: evals/fixtures/mcp/project-open.yaml
+```
+
+Rules and constraints:
+
+- Case-level servers must use `mode: mocked` in the current MVP; real MCP per-case overrides are not yet supported.
+- Replacement is whole-entry, not a field-level merge: provide the full server entry (`name`, `mode`, `config_ref`).
+- `config_ref` is resolved relative to the Skill directory (where `SKILL.md` lives), **not** the case file directory — the same rule as eval-level MCP.
+- Each case provisions and installs its own mocked server, so fixtures stay isolated even when `cases.parallelism > 1`.
+
 ### Choosing a runtime environment
 
 | Environment   | When to use                                       | Example Skills                              |

--- a/docs/zh/guide/writing-evals.md
+++ b/docs/zh/guide/writing-evals.md
@@ -289,6 +289,39 @@ tool_responses:
 
 环境变量引用支持 `${VAR}` 和完整值 `$VAR` 两种形式，变量名必须匹配 `[A-Za-z_][A-Za-z0-9_]*`。`required_env` 会把变量注入 Agent 运行环境；`headers` 中完整的环境变量引用会额外记录变量名，供 Agent 安装 MCP 时选择合适的传递方式。
 
+#### 用例级 mocked MCP 覆盖
+
+eval 级的 `mcp.servers` 是所有用例的默认配置。用例（case）可以声明自己的 `mcp.servers`，在保持相同 MCP Server 名称和工具名称的前提下切换 mocked fixture（由 SUP-0003 引入）。Server 按 `name` 合并：用例级中与 eval 级同名的条目会整体替换该 eval 级 Server，未出现的新名称则追加到末尾。未声明 `mcp` 的用例继承 eval 级配置，行为不变。
+
+```yaml
+# eval.yaml —— 所有用例共享的默认 fixture
+mcp:
+  servers:
+    - name: project-mgmt
+      mode: mocked
+      config_ref: evals/fixtures/mcp/project-default.yaml
+```
+
+```yaml
+# cases/project-open.yaml —— 相同的 Server/工具，不同的 fixture
+id: project-open
+input:
+  prompt: 检查项目状态并继续发布计划。
+
+mcp:
+  servers:
+    - name: project-mgmt
+      mode: mocked
+      config_ref: evals/fixtures/mcp/project-open.yaml
+```
+
+规则与约束：
+
+- 当前 MVP 下用例级 Server 必须使用 `mode: mocked`；暂不支持用例级 real MCP 覆盖。
+- 替换为整条替换，而非字段级合并：需提供完整的 Server 条目（`name`、`mode`、`config_ref`）。
+- `config_ref` 相对于 Skill 目录（`SKILL.md` 所在目录）解析，**不是**相对于用例文件所在目录 —— 与 eval 级 MCP 规则一致。
+- 每个用例独立生成并安装自己的 mocked Server，因此即使 `cases.parallelism > 1`，各用例的 fixture 也彼此隔离。
+
 ### 运行环境选择指南
 
 | 环境类型      | 适用场景                       | 示例 Skill                       |

--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -111,6 +111,45 @@ func TestMCP_MockedMarkerAgents(t *testing.T) {
 	}
 }
 
+// TestMCP_CaseMockOverrides drives two cases that share the same mocked MCP
+// server name (project-mgmt) and tool (get_project) but override the fixture
+// per case (SUP-0003). The eval-level default fixture returns UNKNOWN, while
+// the open/closed cases override it to OPEN/CLOSED. This verifies case-level
+// mocked overrides route the correct fixture end-to-end.
+func TestMCP_CaseMockOverrides(t *testing.T) {
+	skipIfNotFullE2E(t)
+
+	evalPath := filepath.Join(getProjectRoot(), "e2e", "testdata", "mcp-case-overrides", "evals", "eval.yaml")
+	for _, tc := range []struct {
+		name   string
+		engine string
+		model  string
+	}{
+		{name: "claude_code", engine: "claude_code", model: "anthropic/qwen3.6-plus"},
+		{name: "qodercli", engine: "qodercli", model: "qoder/auto"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.engine == "claude_code" {
+				skipIfClaudeUnavailable(t)
+				skipClaudeCodeIfIncompatibleEndpoint(t)
+			}
+			if tc.engine == "qodercli" {
+				skipIfQoderCLIUnavailable(t)
+			}
+
+			runEvalWithRetries(t, mcpEvalRun{
+				evalPath:   evalPath,
+				engine:     tc.engine,
+				model:      tc.model,
+				outputRoot: e2eOutputDir(t),
+				outputName: "mcp-case-overrides-" + tc.name,
+				attempts:   2,
+				timeout:    240 * time.Second,
+			})
+		})
+	}
+}
+
 func skipIfSandboxMCPUnavailable(t *testing.T) {
 	t.Helper()
 	var missing []string

--- a/e2e/testdata/mcp-case-overrides/SKILL.md
+++ b/e2e/testdata/mcp-case-overrides/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: mcp-case-overrides
+description: Per-case mocked MCP override smoke skill used by skill-up e2e tests.
+---
+
+# MCP case overrides
+
+Use the configured MCP `project-mgmt` server's `get_project` tool when asked.

--- a/e2e/testdata/mcp-case-overrides/evals/cases/project-closed.yaml
+++ b/e2e/testdata/mcp-case-overrides/evals/cases/project-closed.yaml
@@ -1,0 +1,18 @@
+id: project-closed
+title: Report the project status when the project is closed
+
+input:
+  prompt: |
+    Call the MCP tool named get_project on the project-mgmt server.
+    Return only the value of the status field from that MCP tool result.
+    Do not guess the answer.
+
+mcp:
+  servers:
+    - name: project-mgmt
+      mode: mocked
+      config_ref: evals/fixtures/mcp/project-closed.yaml
+
+expect:
+  must_contain:
+    - CLOSED

--- a/e2e/testdata/mcp-case-overrides/evals/cases/project-open.yaml
+++ b/e2e/testdata/mcp-case-overrides/evals/cases/project-open.yaml
@@ -1,0 +1,18 @@
+id: project-open
+title: Report the project status when the project is open
+
+input:
+  prompt: |
+    Call the MCP tool named get_project on the project-mgmt server.
+    Return only the value of the status field from that MCP tool result.
+    Do not guess the answer.
+
+mcp:
+  servers:
+    - name: project-mgmt
+      mode: mocked
+      config_ref: evals/fixtures/mcp/project-open.yaml
+
+expect:
+  must_contain:
+    - OPEN

--- a/e2e/testdata/mcp-case-overrides/evals/eval.yaml
+++ b/e2e/testdata/mcp-case-overrides/evals/eval.yaml
@@ -1,0 +1,32 @@
+schema_version: v1alpha1
+
+environment:
+  type: none
+
+mcp:
+  servers:
+    - name: project-mgmt
+      mode: mocked
+      config_ref: evals/fixtures/mcp/project-default.yaml
+
+skills: []
+
+engine:
+  name: claude_code
+  model:
+    provider: anthropic
+    name: qwen3.6-plus
+
+cases:
+  files:
+    - evals/cases/project-open.yaml
+    - evals/cases/project-closed.yaml
+  defaults:
+    timeout_seconds: 180
+    max_turns: 1
+  parallelism: 1
+
+report:
+  formats: [json]
+  artifacts:
+    - transcript

--- a/e2e/testdata/mcp-case-overrides/evals/fixtures/mcp/project-closed.yaml
+++ b/e2e/testdata/mcp-case-overrides/evals/fixtures/mcp/project-closed.yaml
@@ -1,0 +1,5 @@
+tool_responses:
+  get_project:
+    default:
+      id: p-001
+      status: CLOSED

--- a/e2e/testdata/mcp-case-overrides/evals/fixtures/mcp/project-default.yaml
+++ b/e2e/testdata/mcp-case-overrides/evals/fixtures/mcp/project-default.yaml
@@ -1,0 +1,5 @@
+tool_responses:
+  get_project:
+    default:
+      id: p-001
+      status: UNKNOWN

--- a/e2e/testdata/mcp-case-overrides/evals/fixtures/mcp/project-open.yaml
+++ b/e2e/testdata/mcp-case-overrides/evals/fixtures/mcp/project-open.yaml
@@ -1,0 +1,5 @@
+tool_responses:
+  get_project:
+    default:
+      id: p-001
+      status: OPEN

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -501,6 +501,87 @@ expect:
 	}
 }
 
+func TestLoader_LoadCaseConfig_MCPOverrides(t *testing.T) {
+	t.Parallel()
+	content := `id: project-open
+input:
+  prompt: Check the project status.
+
+mcp:
+  servers:
+    - name: project-mgmt
+      mode: mocked
+      config_ref: evals/fixtures/mcp/project-open.yaml
+`
+
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "my-skill")
+	casesDir := filepath.Join(skillDir, "evals", "cases")
+	if err := os.MkdirAll(casesDir, 0o755); err != nil {
+		t.Fatalf("failed to create cases dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# skill\n"), 0o600); err != nil {
+		t.Fatalf("failed to write SKILL.md: %v", err)
+	}
+	evalPath := filepath.Join(skillDir, "evals", "eval.yaml")
+	if err := os.WriteFile(evalPath, []byte("schema_version: v1alpha1\n"), 0o600); err != nil {
+		t.Fatalf("failed to write eval.yaml: %v", err)
+	}
+	casePath := filepath.Join(casesDir, "project-open.yaml")
+	if err := os.WriteFile(casePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write case file: %v", err)
+	}
+
+	loader := NewLoader(evalPath)
+	cfg, err := loader.LoadCaseConfig("evals/cases/project-open.yaml")
+	if err != nil {
+		t.Fatalf("LoadCaseConfig failed: %v", err)
+	}
+
+	if len(cfg.MCP.Servers) != 1 {
+		t.Fatalf("expected 1 mcp server, got %d", len(cfg.MCP.Servers))
+	}
+	srv := cfg.MCP.Servers[0]
+	if srv.Name != "project-mgmt" || srv.Mode != "mocked" || srv.ConfigRef != "evals/fixtures/mcp/project-open.yaml" {
+		t.Errorf("unexpected mcp server: %+v", srv)
+	}
+}
+
+func TestLoader_LoadCaseConfig_NoMCPLeavesServersEmpty(t *testing.T) {
+	t.Parallel()
+	content := `id: plain-case
+input:
+  prompt: Say hello.
+`
+
+	tmpDir := t.TempDir()
+	skillDir := filepath.Join(tmpDir, "my-skill")
+	casesDir := filepath.Join(skillDir, "evals", "cases")
+	if err := os.MkdirAll(casesDir, 0o755); err != nil {
+		t.Fatalf("failed to create cases dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# skill\n"), 0o600); err != nil {
+		t.Fatalf("failed to write SKILL.md: %v", err)
+	}
+	evalPath := filepath.Join(skillDir, "evals", "eval.yaml")
+	if err := os.WriteFile(evalPath, []byte("schema_version: v1alpha1\n"), 0o600); err != nil {
+		t.Fatalf("failed to write eval.yaml: %v", err)
+	}
+	casePath := filepath.Join(casesDir, "plain-case.yaml")
+	if err := os.WriteFile(casePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write case file: %v", err)
+	}
+
+	loader := NewLoader(evalPath)
+	cfg, err := loader.LoadCaseConfig("evals/cases/plain-case.yaml")
+	if err != nil {
+		t.Fatalf("LoadCaseConfig failed: %v", err)
+	}
+	if len(cfg.MCP.Servers) != 0 {
+		t.Errorf("expected no mcp servers, got %d", len(cfg.MCP.Servers))
+	}
+}
+
 func TestLoader_LoadAllCases(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/internal/config/mcp_merge.go
+++ b/internal/config/mcp_merge.go
@@ -3,6 +3,12 @@ package config
 import (
 	"errors"
 	"fmt"
+	"strings"
+)
+
+const (
+	mcpModeMocked              = "mocked"
+	builtinFilesystemMCPServer = "filesystem"
 )
 
 // MergeCaseMCP computes the effective MCP configuration for a case by merging
@@ -29,6 +35,9 @@ func MergeCaseMCP(evalMCP MCPConfig, caseMCP MCPConfig) (MCPConfig, error) {
 
 	indexByName := make(map[string]int, len(merged.Servers))
 	for i, server := range merged.Servers {
+		if strings.TrimSpace(server.Name) == "" {
+			return MCPConfig{}, errors.New("eval-level mcp server name is required")
+		}
 		if _, exists := indexByName[server.Name]; exists {
 			return MCPConfig{}, fmt.Errorf("duplicate eval-level mcp server name %q", server.Name)
 		}
@@ -45,8 +54,11 @@ func MergeCaseMCP(evalMCP MCPConfig, caseMCP MCPConfig) (MCPConfig, error) {
 		}
 		seenCaseNames[server.Name] = struct{}{}
 
-		if server.Mode != "mocked" {
+		if server.Mode != mcpModeMocked {
 			return MCPConfig{}, fmt.Errorf("case-level mcp server %q must use mode: mocked", server.Name)
+		}
+		if server.Name != builtinFilesystemMCPServer && strings.TrimSpace(server.ConfigRef) == "" {
+			return MCPConfig{}, fmt.Errorf("case-level mcp server %q mocked mode requires config_ref", server.Name)
 		}
 
 		cloned := cloneMCPServer(server)

--- a/internal/config/mcp_merge.go
+++ b/internal/config/mcp_merge.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+)
+
+// MergeCaseMCP computes the effective MCP configuration for a case by merging
+// case-level overrides on top of the eval-level MCP config.
+//
+// Merge semantics (SUP-0003):
+//  1. If the case declares no servers, the eval-level config is returned as a
+//     deep copy (inheritance, unchanged behavior).
+//  2. Servers are merged by name while preserving eval-level order: a case-level
+//     entry whose name matches an eval-level server replaces that entire entry;
+//     a new name is appended to the end.
+//  3. Replacement is whole-entry, not a field-level deep merge.
+//  4. Duplicate server names within either level are rejected.
+//  5. In the MVP, every case-level server must use mode: mocked.
+//
+// The returned MCPConfig is a fresh value; callers cannot mutate the original
+// eval or case configuration through it.
+func MergeCaseMCP(evalMCP MCPConfig, caseMCP MCPConfig) (MCPConfig, error) {
+	if len(caseMCP.Servers) == 0 {
+		return cloneMCPConfig(evalMCP), nil
+	}
+
+	merged := cloneMCPConfig(evalMCP)
+
+	indexByName := make(map[string]int, len(merged.Servers))
+	for i, server := range merged.Servers {
+		if _, exists := indexByName[server.Name]; exists {
+			return MCPConfig{}, fmt.Errorf("duplicate eval-level mcp server name %q", server.Name)
+		}
+		indexByName[server.Name] = i
+	}
+
+	seenCaseNames := make(map[string]struct{}, len(caseMCP.Servers))
+	for _, server := range caseMCP.Servers {
+		if server.Name == "" {
+			return MCPConfig{}, errors.New("case-level mcp server name is required")
+		}
+		if _, exists := seenCaseNames[server.Name]; exists {
+			return MCPConfig{}, fmt.Errorf("duplicate case-level mcp server name %q", server.Name)
+		}
+		seenCaseNames[server.Name] = struct{}{}
+
+		if server.Mode != "mocked" {
+			return MCPConfig{}, fmt.Errorf("case-level mcp server %q must use mode: mocked", server.Name)
+		}
+
+		cloned := cloneMCPServer(server)
+		if idx, ok := indexByName[server.Name]; ok {
+			merged.Servers[idx] = cloned
+			continue
+		}
+		merged.Servers = append(merged.Servers, cloned)
+		indexByName[server.Name] = len(merged.Servers) - 1
+	}
+
+	return merged, nil
+}
+
+// cloneMCPConfig returns a deep copy of an MCPConfig so that mutations of the
+// result never affect the source configuration.
+func cloneMCPConfig(cfg MCPConfig) MCPConfig {
+	if cfg.Servers == nil {
+		return MCPConfig{}
+	}
+	servers := make([]MCPServer, len(cfg.Servers))
+	for i, server := range cfg.Servers {
+		servers[i] = cloneMCPServer(server)
+	}
+	return MCPConfig{Servers: servers}
+}
+
+// cloneMCPServer copies an MCPServer, duplicating its slice fields.
+func cloneMCPServer(server MCPServer) MCPServer {
+	cloned := server
+	if server.Args != nil {
+		cloned.Args = append([]string(nil), server.Args...)
+	}
+	return cloned
+}

--- a/internal/config/mcp_merge_test.go
+++ b/internal/config/mcp_merge_test.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeCaseMCP_InheritsWhenNoCaseServers(t *testing.T) {
+	t.Parallel()
+	evalMCP := MCPConfig{Servers: []MCPServer{
+		{Name: "project-mgmt", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/default.yaml"},
+	}}
+
+	got, err := MergeCaseMCP(evalMCP, MCPConfig{})
+	if err != nil {
+		t.Fatalf("MergeCaseMCP returned error: %v", err)
+	}
+	if !reflect.DeepEqual(got, evalMCP) {
+		t.Errorf("expected inherited eval MCP %+v, got %+v", evalMCP, got)
+	}
+}
+
+func TestMergeCaseMCP_ReplacesSameNameWholeEntryPreservingOrder(t *testing.T) {
+	t.Parallel()
+	evalMCP := MCPConfig{Servers: []MCPServer{
+		{Name: "project-mgmt", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/default.yaml"},
+		{Name: "filesystem", Mode: "mocked"},
+	}}
+	caseMCP := MCPConfig{Servers: []MCPServer{
+		{Name: "project-mgmt", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/open.yaml"},
+	}}
+
+	got, err := MergeCaseMCP(evalMCP, caseMCP)
+	if err != nil {
+		t.Fatalf("MergeCaseMCP returned error: %v", err)
+	}
+
+	want := MCPConfig{Servers: []MCPServer{
+		{Name: "project-mgmt", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/open.yaml"},
+		{Name: "filesystem", Mode: "mocked"},
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("merge result mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+func TestMergeCaseMCP_AppendsNewServer(t *testing.T) {
+	t.Parallel()
+	evalMCP := MCPConfig{Servers: []MCPServer{
+		{Name: "project-mgmt", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/default.yaml"},
+	}}
+	caseMCP := MCPConfig{Servers: []MCPServer{
+		{Name: "extra-tool", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/extra.yaml"},
+	}}
+
+	got, err := MergeCaseMCP(evalMCP, caseMCP)
+	if err != nil {
+		t.Fatalf("MergeCaseMCP returned error: %v", err)
+	}
+	if len(got.Servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d (%+v)", len(got.Servers), got.Servers)
+	}
+	if got.Servers[1].Name != "extra-tool" {
+		t.Errorf("expected appended server 'extra-tool' at end, got %q", got.Servers[1].Name)
+	}
+}
+
+func TestMergeCaseMCP_DoesNotMutateInputs(t *testing.T) {
+	t.Parallel()
+	evalMCP := MCPConfig{Servers: []MCPServer{
+		{Name: "project-mgmt", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/default.yaml", Args: []string{"a"}},
+	}}
+	caseMCP := MCPConfig{Servers: []MCPServer{
+		{Name: "project-mgmt", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/open.yaml"},
+	}}
+	evalSnapshot := MCPConfig{Servers: []MCPServer{
+		{Name: "project-mgmt", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/default.yaml", Args: []string{"a"}},
+	}}
+
+	got, err := MergeCaseMCP(evalMCP, caseMCP)
+	if err != nil {
+		t.Fatalf("MergeCaseMCP returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(evalMCP, evalSnapshot) {
+		t.Errorf("eval MCP was mutated: got %+v want %+v", evalMCP, evalSnapshot)
+	}
+	// Mutating the result must not affect the original eval config.
+	got.Servers[0].ConfigRef = "changed"
+	if evalMCP.Servers[0].ConfigRef != "evals/fixtures/mcp/default.yaml" {
+		t.Errorf("mutating result leaked into eval config: %q", evalMCP.Servers[0].ConfigRef)
+	}
+}
+
+func TestMergeCaseMCP_Errors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		evalMCP MCPConfig
+		caseMCP MCPConfig
+		errMsg  string
+	}{
+		{
+			name:    "empty case server name",
+			evalMCP: MCPConfig{},
+			caseMCP: MCPConfig{Servers: []MCPServer{{Mode: "mocked"}}},
+			errMsg:  "name is required",
+		},
+		{
+			name:    "duplicate case server names",
+			evalMCP: MCPConfig{},
+			caseMCP: MCPConfig{Servers: []MCPServer{
+				{Name: "svc", Mode: "mocked"},
+				{Name: "svc", Mode: "mocked"},
+			}},
+			errMsg: "duplicate case-level mcp server name",
+		},
+		{
+			name:    "case server not mocked",
+			evalMCP: MCPConfig{},
+			caseMCP: MCPConfig{Servers: []MCPServer{{Name: "svc", Mode: "real"}}},
+			errMsg:  "must use mode: mocked",
+		},
+		{
+			name: "duplicate eval server names",
+			evalMCP: MCPConfig{Servers: []MCPServer{
+				{Name: "svc", Mode: "mocked"},
+				{Name: "svc", Mode: "mocked"},
+			}},
+			caseMCP: MCPConfig{Servers: []MCPServer{{Name: "svc", Mode: "mocked"}}},
+			errMsg:  "duplicate eval-level mcp server name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := MergeCaseMCP(tt.evalMCP, tt.caseMCP)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errMsg)
+			}
+			if !contains(err.Error(), tt.errMsg) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}

--- a/internal/config/mcp_merge_test.go
+++ b/internal/config/mcp_merge_test.go
@@ -110,8 +110,8 @@ func TestMergeCaseMCP_Errors(t *testing.T) {
 			name:    "duplicate case server names",
 			evalMCP: MCPConfig{},
 			caseMCP: MCPConfig{Servers: []MCPServer{
-				{Name: "svc", Mode: "mocked"},
-				{Name: "svc", Mode: "mocked"},
+				{Name: "svc", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/open.yaml"},
+				{Name: "svc", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/closed.yaml"},
 			}},
 			errMsg: "duplicate case-level mcp server name",
 		},
@@ -122,12 +122,26 @@ func TestMergeCaseMCP_Errors(t *testing.T) {
 			errMsg:  "must use mode: mocked",
 		},
 		{
+			name:    "case server missing config ref",
+			evalMCP: MCPConfig{},
+			caseMCP: MCPConfig{Servers: []MCPServer{{Name: "svc", Mode: "mocked"}}},
+			errMsg:  "mocked mode requires config_ref",
+		},
+		{
+			name: "empty eval server name",
+			evalMCP: MCPConfig{Servers: []MCPServer{
+				{Mode: "mocked", ConfigRef: "evals/fixtures/mcp/default.yaml"},
+			}},
+			caseMCP: MCPConfig{Servers: []MCPServer{{Name: "svc", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/open.yaml"}}},
+			errMsg:  "eval-level mcp server name is required",
+		},
+		{
 			name: "duplicate eval server names",
 			evalMCP: MCPConfig{Servers: []MCPServer{
 				{Name: "svc", Mode: "mocked"},
 				{Name: "svc", Mode: "mocked"},
 			}},
-			caseMCP: MCPConfig{Servers: []MCPServer{{Name: "svc", Mode: "mocked"}}},
+			caseMCP: MCPConfig{Servers: []MCPServer{{Name: "svc", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/open.yaml"}}},
 			errMsg:  "duplicate eval-level mcp server name",
 		},
 	}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -248,6 +248,12 @@ type CaseConfig struct {
 	Constraints Constraints `yaml:"constraints"`
 	Expect      Expect      `yaml:"expect"`
 	Judge       JudgeConfig `yaml:"judge,omitempty"`
+	// MCP declares case-level MCP server overrides. Servers are merged with
+	// eval-level mcp.servers by name: a same-name entry replaces the whole
+	// eval-level server, and a new name is appended. In the MVP, case-level
+	// servers must use mode: mocked. A case without mcp inherits the eval-level
+	// MCP config unchanged. See internal/config.MergeCaseMCP for the semantics.
+	MCP MCPConfig `yaml:"mcp,omitempty"`
 	// CollectArtifacts lists glob patterns (doublestar syntax) selecting
 	// workspace files to download as artifacts for this case. It is merged
 	// (union, de-duplicated) with cases.defaults.collect_artifacts. See

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -180,8 +180,11 @@ func validateCaseMCP(mcpCfg MCPConfig) []string {
 		}
 		seen[server.Name] = struct{}{}
 
-		if server.Mode != "mocked" {
+		if server.Mode != mcpModeMocked {
 			errs = append(errs, fmt.Sprintf("mcp.servers[%d] (%q) must use mode: mocked at case level", i, server.Name))
+		}
+		if server.Mode == mcpModeMocked && server.Name != builtinFilesystemMCPServer && strings.TrimSpace(server.ConfigRef) == "" {
+			errs = append(errs, fmt.Sprintf("mcp.servers[%d] (%q) mocked mode requires config_ref", i, server.Name))
 		}
 		if server.Transport != "" && server.Transport != "stdio" {
 			errs = append(errs, fmt.Sprintf("mcp.servers[%d] (%q) mocked mode only supports stdio transport", i, server.Name))

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -132,11 +132,47 @@ func (v *Validator) ValidateCaseConfig(cfg *CaseConfig) error {
 
 	errs = append(errs, validateCollectArtifacts("collect_artifacts", cfg.CollectArtifacts)...)
 
+	errs = append(errs, validateCaseMCP(cfg.MCP)...)
+
 	if len(errs) > 0 {
 		return fmt.Errorf("validation errors:\n  - %s", strings.Join(errs, "\n  - "))
 	}
 
 	return nil
+}
+
+// validateCaseMCP validates case-level MCP overrides. The MVP restricts
+// case-level servers to mocked fixture variation: every server needs a name,
+// must use mode: mocked, must be unique within the case, and must not declare
+// real-server transport fields (transport: http, endpoint, command, args).
+func validateCaseMCP(mcpCfg MCPConfig) []string {
+	var errs []string
+	seen := make(map[string]struct{}, len(mcpCfg.Servers))
+	for i, server := range mcpCfg.Servers {
+		if server.Name == "" {
+			errs = append(errs, fmt.Sprintf("mcp.servers[%d].name is required", i))
+			continue
+		}
+		if _, dup := seen[server.Name]; dup {
+			errs = append(errs, fmt.Sprintf("mcp.servers[%d].name %q is duplicated", i, server.Name))
+			continue
+		}
+		seen[server.Name] = struct{}{}
+
+		if server.Mode != "mocked" {
+			errs = append(errs, fmt.Sprintf("mcp.servers[%d] (%q) must use mode: mocked at case level", i, server.Name))
+		}
+		if server.Transport != "" && server.Transport != "stdio" {
+			errs = append(errs, fmt.Sprintf("mcp.servers[%d] (%q) mocked mode only supports stdio transport", i, server.Name))
+		}
+		if server.Endpoint != "" {
+			errs = append(errs, fmt.Sprintf("mcp.servers[%d] (%q) mocked mode does not support endpoint", i, server.Name))
+		}
+		if server.Command != "" || len(server.Args) > 0 {
+			errs = append(errs, fmt.Sprintf("mcp.servers[%d] (%q) mocked mode does not support command/args", i, server.Name))
+		}
+	}
+	return errs
 }
 
 // validateJudgeTypeAndFields validates judge type and its conditional fields.

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -821,6 +821,66 @@ func TestValidator_ValidateCaseConfig(t *testing.T) {
 			wantErr: true,
 			errMsg:  "judge.timeout_seconds must be non-negative",
 		},
+		{
+			name: "valid case-level mocked MCP override",
+			cfg: &CaseConfig{
+				ID:    "test-case",
+				Input: Input{Prompt: "Say hello"},
+				MCP: MCPConfig{Servers: []MCPServer{
+					{Name: "project-mgmt", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/open.yaml"},
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "case-level real MCP rejected",
+			cfg: &CaseConfig{
+				ID:    "test-case",
+				Input: Input{Prompt: "Say hello"},
+				MCP: MCPConfig{Servers: []MCPServer{
+					{Name: "project-mgmt", Mode: "real"},
+				}},
+			},
+			wantErr: true,
+			errMsg:  "must use mode: mocked",
+		},
+		{
+			name: "case-level MCP missing name",
+			cfg: &CaseConfig{
+				ID:    "test-case",
+				Input: Input{Prompt: "Say hello"},
+				MCP: MCPConfig{Servers: []MCPServer{
+					{Mode: "mocked"},
+				}},
+			},
+			wantErr: true,
+			errMsg:  "mcp.servers[0].name is required",
+		},
+		{
+			name: "case-level MCP duplicate names",
+			cfg: &CaseConfig{
+				ID:    "test-case",
+				Input: Input{Prompt: "Say hello"},
+				MCP: MCPConfig{Servers: []MCPServer{
+					{Name: "svc", Mode: "mocked"},
+					{Name: "svc", Mode: "mocked"},
+				}},
+			},
+			wantErr: true,
+			errMsg:  "is duplicated",
+		},
+		{
+			name: "case-level MCP with endpoint rejected",
+			cfg: &CaseConfig{
+				ID:    "test-case",
+				Input: Input{Prompt: "Say hello"},
+				MCP: MCPConfig{Servers: []MCPServer{
+					{Name: "svc", Mode: "mocked", Endpoint: "http://localhost:1234"},
+				}},
+			},
+			wantErr: true,
+			errMsg:  "does not support endpoint",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -921,6 +921,17 @@ func TestValidator_ValidateCaseConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid case-level filesystem mocked MCP override without config_ref",
+			cfg: &CaseConfig{
+				ID:    "test-case",
+				Input: Input{Prompt: "Say hello"},
+				MCP: MCPConfig{Servers: []MCPServer{
+					{Name: "filesystem", Mode: "mocked"},
+				}},
+			},
+			wantErr: false,
+		},
+		{
 			name: "case-level agent_judge with valid context",
 			cfg: &CaseConfig{
 				ID: "test-case",
@@ -969,13 +980,25 @@ func TestValidator_ValidateCaseConfig(t *testing.T) {
 			errMsg:  "mcp.servers[0].name is required",
 		},
 		{
-			name: "case-level MCP duplicate names",
+			name: "case-level MCP missing config_ref",
 			cfg: &CaseConfig{
 				ID:    "test-case",
 				Input: Input{Prompt: "Say hello"},
 				MCP: MCPConfig{Servers: []MCPServer{
 					{Name: "svc", Mode: "mocked"},
-					{Name: "svc", Mode: "mocked"},
+				}},
+			},
+			wantErr: true,
+			errMsg:  "mocked mode requires config_ref",
+		},
+		{
+			name: "case-level MCP duplicate names",
+			cfg: &CaseConfig{
+				ID:    "test-case",
+				Input: Input{Prompt: "Say hello"},
+				MCP: MCPConfig{Servers: []MCPServer{
+					{Name: "svc", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/open.yaml"},
+					{Name: "svc", Mode: "mocked", ConfigRef: "evals/fixtures/mcp/closed.yaml"},
 				}},
 			},
 			wantErr: true,

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -812,7 +812,7 @@ func resolveExpectConfig(expectCfg *config.Expect) *config.Expect {
 func (e *defaultEvaluator) prepareRuntimeForCase(ctx context.Context, caseCfg *config.CaseConfig, configName string, ag agent.Agent) (runtime.Runtime, error) {
 	rtCfg := e.evalCfg.Environment.ToRuntimeConfig()
 	rtCfg.Delete = e.deleteWorkspace
-	mcpCfg, mcpEnv, err := e.provisionMCPConfig()
+	mcpCfg, mcpEnv, err := e.provisionMCPConfigForCase(caseCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -895,6 +895,32 @@ func (e *defaultEvaluator) provisionMCPConfig() (runtime.MCPConfig, map[string]s
 		return runtime.MCPConfig{}, nil, e.mcpErr
 	}
 	return cloneMCPConfig(e.mcpCfg), maps.Clone(e.mcpEnv), nil
+}
+
+// provisionMCPConfigForCase computes and provisions the effective MCP config
+// for a single case. Cases without case-level overrides reuse the eval-only
+// sync.Once fast path; cases with overrides merge eval- and case-level servers
+// and provision fresh so each case installs isolated mocked fixtures.
+func (e *defaultEvaluator) provisionMCPConfigForCase(caseCfg *config.CaseConfig) (runtime.MCPConfig, map[string]string, error) {
+	if caseCfg == nil || len(caseCfg.MCP.Servers) == 0 {
+		return e.provisionMCPConfig()
+	}
+
+	effectiveMCP, err := config.MergeCaseMCP(e.evalCfg.MCP, caseCfg.MCP)
+	if err != nil {
+		return runtime.MCPConfig{}, nil, fmt.Errorf("case %s: %w", caseCfg.ID, err)
+	}
+
+	skillDir := e.skillDir
+	if e.loader != nil {
+		skillDir = e.loader.SkillDir()
+	}
+	provisioner := mcp.Provisioner{SkillDir: skillDir}
+	mcpCfg, mcpEnv, err := provisioner.Provision(effectiveMCP)
+	if err != nil {
+		return runtime.MCPConfig{}, nil, fmt.Errorf("case %s: failed to provision MCP servers: %w", caseCfg.ID, err)
+	}
+	return mcpCfg, mcpEnv, nil
 }
 
 func mergeEnvMaps(base, override map[string]string) map[string]string {

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -249,6 +249,93 @@ func TestProvisionMCPConfigCachesResolvedConfig(t *testing.T) {
 	}
 }
 
+func TestProvisionMCPConfigForCaseAppliesOverrides(t *testing.T) {
+	t.Parallel()
+
+	skillDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(skillDir, "default.yaml"), []byte("tool_responses:\n  get_project:\n    default:\n      status: DEFAULT\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "open.yaml"), []byte("tool_responses:\n  get_project:\n    default:\n      status: OPEN\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "closed.yaml"), []byte("tool_responses:\n  get_project:\n    default:\n      status: CLOSED\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	e := newTestEvaluator(EvalOptions{
+		SkillDir: skillDir,
+		EvalCfg: &config.EvalConfig{
+			MCP: config.MCPConfig{
+				Servers: []config.MCPServer{{Name: "project-mgmt", Mode: "mocked", ConfigRef: "default.yaml"}},
+			},
+		},
+	})
+
+	openCase := &config.CaseConfig{
+		ID: "project-open",
+		MCP: config.MCPConfig{
+			Servers: []config.MCPServer{{Name: "project-mgmt", Mode: "mocked", ConfigRef: "open.yaml"}},
+		},
+	}
+	closedCase := &config.CaseConfig{
+		ID: "project-closed",
+		MCP: config.MCPConfig{
+			Servers: []config.MCPServer{{Name: "project-mgmt", Mode: "mocked", ConfigRef: "closed.yaml"}},
+		},
+	}
+	plainCase := &config.CaseConfig{ID: "plain"}
+
+	openCfg, _, err := e.provisionMCPConfigForCase(openCase)
+	if err != nil {
+		t.Fatalf("provision open case failed: %v", err)
+	}
+	closedCfg, _, err := e.provisionMCPConfigForCase(closedCase)
+	if err != nil {
+		t.Fatalf("provision closed case failed: %v", err)
+	}
+	plainCfg, _, err := e.provisionMCPConfigForCase(plainCase)
+	if err != nil {
+		t.Fatalf("provision plain case failed: %v", err)
+	}
+
+	openScript := openCfg.Servers[0].Args[1]
+	closedScript := closedCfg.Servers[0].Args[1]
+	plainScript := plainCfg.Servers[0].Args[1]
+
+	if !strings.Contains(openScript, "OPEN") {
+		t.Errorf("open case script missing OPEN fixture")
+	}
+	if !strings.Contains(closedScript, "CLOSED") {
+		t.Errorf("closed case script missing CLOSED fixture")
+	}
+	if !strings.Contains(plainScript, "DEFAULT") {
+		t.Errorf("plain case should inherit eval-level DEFAULT fixture")
+	}
+	if openScript == closedScript {
+		t.Error("same server name with different config_ref must yield different runtime MCP config")
+	}
+}
+
+func TestProvisionMCPConfigForCaseRejectsRealOverride(t *testing.T) {
+	t.Parallel()
+
+	e := newTestEvaluator(EvalOptions{
+		SkillDir: t.TempDir(),
+		EvalCfg:  &config.EvalConfig{},
+	})
+	badCase := &config.CaseConfig{
+		ID: "bad-case",
+		MCP: config.MCPConfig{
+			Servers: []config.MCPServer{{Name: "svc", Mode: "real"}},
+		},
+	}
+	_, _, err := e.provisionMCPConfigForCase(badCase)
+	if err == nil || !strings.Contains(err.Error(), "bad-case") {
+		t.Fatalf("expected error mentioning case ID, got %v", err)
+	}
+}
+
 func TestEvaluatorInputHelpers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mcp/provisioner_test.go
+++ b/internal/mcp/provisioner_test.go
@@ -280,6 +280,49 @@ func TestProvisioner_MockedServerFromConfigRefUsesToolResponses(t *testing.T) {
 	}
 }
 
+func TestProvisioner_SameNameMockedServersDifferentFixtures(t *testing.T) {
+	t.Parallel()
+
+	skillDir := t.TempDir()
+	openPath := filepath.Join(skillDir, "project-open.yaml")
+	closedPath := filepath.Join(skillDir, "project-closed.yaml")
+	if err := os.WriteFile(openPath, []byte("tool_responses:\n  get_project:\n    default:\n      status: OPEN\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(closedPath, []byte("tool_responses:\n  get_project:\n    default:\n      status: CLOSED\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	provisioner := Provisioner{SkillDir: skillDir}
+	openCfg, _, err := provisioner.Provision(config.MCPConfig{
+		Servers: []config.MCPServer{{Name: "project-mgmt", Mode: "mocked", ConfigRef: "project-open.yaml"}},
+	})
+	if err != nil {
+		t.Fatalf("Provision(open) failed: %v", err)
+	}
+	closedCfg, _, err := provisioner.Provision(config.MCPConfig{
+		Servers: []config.MCPServer{{Name: "project-mgmt", Mode: "mocked", ConfigRef: "project-closed.yaml"}},
+	})
+	if err != nil {
+		t.Fatalf("Provision(closed) failed: %v", err)
+	}
+
+	openScript := openCfg.Servers[0].Args[1]
+	closedScript := closedCfg.Servers[0].Args[1]
+
+	// Case-level config_ref resolves relative to SkillDir.
+	if openCfg.Servers[0].ConfigRef != openPath {
+		t.Errorf("open ConfigRef = %q, want %q", openCfg.Servers[0].ConfigRef, openPath)
+	}
+	// The same server name must yield distinct embedded fixture JSON.
+	if openScript == closedScript {
+		t.Fatal("expected different generated scripts for different fixtures")
+	}
+	if !strings.Contains(openScript, "OPEN") || !strings.Contains(closedScript, "CLOSED") {
+		t.Errorf("scripts do not embed their respective fixture status values")
+	}
+}
+
 func TestProvisionerValidationAndTransportErrors(t *testing.T) {
 	t.Parallel()
 

--- a/skills/skill-upper/references/eval-yaml.md
+++ b/skills/skill-upper/references/eval-yaml.md
@@ -102,6 +102,7 @@ environment:
 - HTTP MCP 可 inline 或 `config_ref` 指向 `evals/fixtures/mcp/*.yaml`。
 - stdio MCP 可配置 `command` / `args`。
 - 环境变量引用：`${VAR}` 或整值 `$VAR`；`required_env` 会注入 Agent 环境。
+- eval 级 `mcp` 是默认配置；用例可在 `cases/*.yaml` 里声明自己的 `mcp.servers`（MVP 仅 `mode: mocked`）按 `name` 整条覆盖同名 Server，从而在相同 Server/工具名下切换 mocked fixture。`config_ref` 仍相对 Skill 目录解析。
 
 ## Engine 与模型
 


### PR DESCRIPTION
This pull request introduces support for per-case mocked MCP server overrides, allowing each test case to specify its own mocked MCP fixture while keeping server and tool names consistent. This enables more flexible and isolated testing scenarios, especially when running cases in parallel. The implementation includes configuration merging logic, schema and validation updates, documentation, and comprehensive tests.

### Per-case mocked MCP server overrides

* Added support for case-level `mcp.servers` overrides in test case YAML files. Case-level servers merge with eval-level servers by name: a matching name replaces the eval-level entry, and new names are appended. Each case can now specify its own mocked fixture, with strict validation to ensure isolation and correctness. [[1]](diffhunk://#diff-6ce4492e0bee2a1d74bb8f1d23c10364bca5b6023ca2dd0678250352a6641643R1-R84) [[2]](diffhunk://#diff-4fd940e67ba4534f34987a05fbd8441a28238c9c75262926abc9400a4b7346e2R307-R312) [[3]](diffhunk://#diff-7fe758126a3f253e89ec95caa490c26b049eaf40e48e9e9e8284a0265e3c94c8R156-R198)

* Documented the new per-case MCP override feature in both the English and Chinese guides, including configuration examples, merging rules, and constraints. [[1]](diffhunk://#diff-1a1380c1c92b82c1f22f857331dc97d6773a683da3c61ff97bb0f00afe9586c7R310-R342) [[2]](diffhunk://#diff-81d5324f2a1f13473a737f897d6ec898186e8b8daa1e4de8a89c5aaf3be3d913R292-R324)

### Testing and validation

* Added end-to-end and unit tests to verify that per-case MCP overrides work as intended, including config merging, error handling, and that the correct fixture is used for each case. [[1]](diffhunk://#diff-c969c7ecf1c5814181861900e85730aacff0735b18d8b612f20581f1f718946eR114-R152) [[2]](diffhunk://#diff-5534db7f416d5e2003712f55881ecf97cc01936f620133564318ca3243a08434R552-R632) [[3]](diffhunk://#diff-d5038910098d734d973e540dec883269342a2a99173b8732f0af3627e701d824R1-R147)

### Example and fixture files

* Provided example skills, evals, case files, and fixture YAMLs to demonstrate and test per-case MCP override behavior. These include cases for "project-open" and "project-closed" that each use a different mocked fixture. [[1]](diffhunk://#diff-206ecc5fa38c7c3691a0feb4e20693a76cf83a5060eefbb2f215949c36a0d937R1-R8) [[2]](diffhunk://#diff-39b9714851d509cfdf98a41d5a9a1c9c7fd48461af5e650e67c30f1d6b0f8956R1-R32) [[3]](diffhunk://#diff-0784d2097d607c5ea4843f135e715d497c37d91a4e4bbc5988114c5c2ee2bc0eR1-R18) [[4]](diffhunk://#diff-a7ba6e8034da4f9cb9d5d5bc354eb50104fc92db60ffaa968b8d62d0b6ed6e37R1-R18) [[5]](diffhunk://#diff-2ff918ff8712d22b479cd5886b61dcb38d13fde5bef9671c34ef11afe22eb05eR1-R5) [[6]](diffhunk://#diff-d5c3265b6e84ffa4468ffde3e80750e94993457e630f6571406bcb5f54aa5a4dR1-R5) [[7]](diffhunk://#diff-e23f010791a3e1f73a43329105136ab5e8fcf07250dc07a4faedd43c9c9136d9R1-R5)

### Changelog

* Added a changelog entry describing the new per-case mocked MCP override feature and its merging semantics.