### PR TITLE
fix(report): exclude without_skill baseline from aggregate stats

### DIFF
--- a/internal/report/junit.go
+++ b/internal/report/junit.go
@@ -114,7 +114,14 @@ func (r *JUnitReporter) buildTestSuite(in Input) junitTestSuites {
 		cases    []junitTestCase
 	)
 
-	for _, cr := range in.CaseResults {
+	// Use PrimaryCaseResults (with_skill preferred) instead of the raw
+	// CaseResults so that a benchmark-mode "without_skill" baseline failure
+	// is not counted as an additional CI failure/test. CI systems that
+	// consume this JUnit XML gate builds on tests/failures/errors, and the
+	// baseline is expected-to-sometimes-fail reference data, not a real
+	// regression. Baseline-only detail remains available in benchmark.json
+	// and the HTML report's per-case "Baseline" section.
+	for _, cr := range in.PrimaryCaseResults() {
 		tc := junitTestCase{
 			Name:      cr.CaseID,
 			ClassName: in.SkillName,
@@ -157,7 +164,7 @@ func (r *JUnitReporter) buildTestSuite(in Input) junitTestSuites {
 
 	suite := junitTestSuite{
 		Name:      in.SkillName,
-		Tests:     len(in.CaseResults),
+		Tests:     len(cases),
 		Failures:  failures,
 		Errors:    errors,
 		Skipped:   skipped,

--- a/internal/report/reporter.go
+++ b/internal/report/reporter.go
@@ -40,17 +40,61 @@ func (in Input) TotalDuration() time.Duration {
 }
 
 // OverallPassRate calculates the overall pass rate across all cases.
+//
+// In benchmark mode (benchmark.enabled: true), CaseResults holds two entries
+// per case: one "with_skill" and one "without_skill" baseline. The baseline
+// is a reference data point, not an independent evaluation outcome, so it
+// must not be double-counted here — otherwise a baseline failure would drag
+// down the overall pass rate even though every with_skill case passed. See
+// PrimaryCaseResults for the de-duplication rule.
 func (in Input) OverallPassRate() float64 {
-	if len(in.CaseResults) == 0 {
+	primary := in.PrimaryCaseResults()
+	if len(primary) == 0 {
 		return 0
 	}
 	passed := 0
-	for _, cr := range in.CaseResults {
+	for _, cr := range primary {
 		if cr.Status == judge.StatusPass {
 			passed++
 		}
 	}
-	return float64(passed) / float64(len(in.CaseResults))
+	return float64(passed) / float64(len(primary))
+}
+
+// PrimaryCaseResults returns one CaseResult per case ID, preferring the
+// "with_skill" result over the "without_skill" baseline when benchmark mode
+// produced both for the same case. Order follows first-seen case ID order in
+// CaseResults. Use this instead of iterating CaseResults directly whenever
+// computing an aggregate (pass rate, counts, CI failure signal) that should
+// reflect one outcome per case rather than one outcome per configuration.
+func (in Input) PrimaryCaseResults() []CaseResult {
+	type slot struct {
+		result   CaseResult
+		hasWith  bool
+		occupied bool
+	}
+	order := make([]string, 0, len(in.CaseResults))
+	byID := make(map[string]slot, len(in.CaseResults))
+
+	for _, cr := range in.CaseResults {
+		s, ok := byID[cr.CaseID]
+		if !ok {
+			order = append(order, cr.CaseID)
+		}
+		if cr.Configuration != "without_skill" {
+			byID[cr.CaseID] = slot{result: cr, hasWith: true, occupied: true}
+			continue
+		}
+		if !s.occupied {
+			byID[cr.CaseID] = slot{result: cr, hasWith: false, occupied: true}
+		}
+	}
+
+	out := make([]CaseResult, 0, len(order))
+	for _, id := range order {
+		out = append(out, byID[id].result)
+	}
+	return out
 }
 
 // CaseResult represents the result of a single case execution.

--- a/internal/report/reporter.go
+++ b/internal/report/reporter.go
@@ -61,16 +61,16 @@ func (in Input) OverallPassRate() float64 {
 	return float64(passed) / float64(len(primary))
 }
 
-// PrimaryCaseResults returns one CaseResult per case ID, preferring the
-// "with_skill" result over the "without_skill" baseline when benchmark mode
-// produced both for the same case. Order follows first-seen case ID order in
-// CaseResults. Use this instead of iterating CaseResults directly whenever
-// computing an aggregate (pass rate, counts, CI failure signal) that should
-// reflect one outcome per case rather than one outcome per configuration.
+// PrimaryCaseResults returns one CaseResult per case ID. It gives an exact
+// "with_skill" result priority, otherwise uses a non-baseline result and
+// falls back to the "without_skill" baseline when that is all that is
+// available. Order follows first-seen case ID order in CaseResults. Use this
+// instead of iterating CaseResults directly whenever computing an aggregate
+// (pass rate, counts, CI failure signal) that should reflect one outcome per
+// case rather than one outcome per configuration.
 func (in Input) PrimaryCaseResults() []CaseResult {
 	type slot struct {
 		result   CaseResult
-		hasWith  bool
 		occupied bool
 	}
 	order := make([]string, 0, len(in.CaseResults))
@@ -81,12 +81,12 @@ func (in Input) PrimaryCaseResults() []CaseResult {
 		if !ok {
 			order = append(order, cr.CaseID)
 		}
-		if cr.Configuration != "without_skill" {
-			byID[cr.CaseID] = slot{result: cr, hasWith: true, occupied: true}
+		if cr.Configuration == "with_skill" {
+			byID[cr.CaseID] = slot{result: cr, occupied: true}
 			continue
 		}
-		if !s.occupied {
-			byID[cr.CaseID] = slot{result: cr, hasWith: false, occupied: true}
+		if !s.occupied || s.result.Configuration == "without_skill" {
+			byID[cr.CaseID] = slot{result: cr, occupied: true}
 		}
 	}
 

--- a/internal/report/reporter_test.go
+++ b/internal/report/reporter_test.go
@@ -3,6 +3,7 @@ package report
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"os"
 	"path/filepath"
 	"strings"
@@ -360,6 +361,24 @@ func TestInput_PrimaryCaseResults_PrefersWithSkill(t *testing.T) {
 	}
 }
 
+func TestInput_PrimaryCaseResults_PrefersExactWithSkill(t *testing.T) {
+	in := Input{
+		CaseResults: []CaseResult{
+			{CaseID: "case-1", Status: judge.StatusFail, Configuration: "unexpected"},
+			{CaseID: "case-1", Status: judge.StatusPass, Configuration: "with_skill"},
+			{CaseID: "case-1", Status: judge.StatusError, Configuration: "another-unexpected"},
+		},
+	}
+
+	primary := in.PrimaryCaseResults()
+	if len(primary) != 1 {
+		t.Fatalf("expected 1 de-duplicated case, got %d", len(primary))
+	}
+	if primary[0].Configuration != "with_skill" {
+		t.Fatalf("expected exact with_skill result to take priority, got %q", primary[0].Configuration)
+	}
+}
+
 func TestInput_PrimaryCaseResults_FallsBackToBaselineWhenNoWithSkill(t *testing.T) {
 	in := Input{
 		CaseResults: []CaseResult{
@@ -385,15 +404,22 @@ func TestJUnitReporter_BenchmarkMode_ExcludesBaselineFromFailures(t *testing.T) 
 	if err != nil {
 		t.Fatalf("read junit file: %v", err)
 	}
-	content := string(data)
+	var suites junitTestSuites
+	if err := xml.Unmarshal(data, &suites); err != nil {
+		t.Fatalf("unmarshal junit XML: %v", err)
+	}
+	if len(suites.Suites) != 1 {
+		t.Fatalf("expected 1 test suite, got %d", len(suites.Suites))
+	}
+	suite := suites.Suites[0]
 
 	// 2 cases, both with_skill passing; without_skill baseline failures must
 	// not inflate tests/failures counts.
-	if !strings.Contains(content, `tests="2"`) {
-		t.Fatalf("expected tests=2 (de-duplicated per case), got: %s", content)
+	if suite.Tests != 2 {
+		t.Fatalf("expected tests=2 (de-duplicated per case), got %d", suite.Tests)
 	}
-	if !strings.Contains(content, `failures="0"`) {
-		t.Fatalf("expected failures=0 (baseline failures excluded), got: %s", content)
+	if suite.Failures != 0 {
+		t.Fatalf("expected failures=0 (baseline failures excluded), got %d", suite.Failures)
 	}
 }
 

--- a/internal/report/reporter_test.go
+++ b/internal/report/reporter_test.go
@@ -320,6 +320,83 @@ func TestInput_OverallPassRate_Empty(t *testing.T) {
 	}
 }
 
+// benchmarkModeInput simulates a benchmark run (benchmark.enabled: true)
+// where every with_skill case passes but the without_skill baseline fails
+// for half of them. Aggregate statistics must reflect only with_skill.
+func benchmarkModeInput() Input {
+	return Input{
+		SkillName: "code-review",
+		CaseResults: []CaseResult{
+			{CaseID: "case-1", Status: judge.StatusPass, Configuration: "with_skill"},
+			{CaseID: "case-1", Status: judge.StatusFail, Configuration: "without_skill"},
+			{CaseID: "case-2", Status: judge.StatusPass, Configuration: "with_skill"},
+			{CaseID: "case-2", Status: judge.StatusFail, Configuration: "without_skill"},
+		},
+	}
+}
+
+func TestInput_OverallPassRate_IgnoresWithoutSkillBaseline(t *testing.T) {
+	in := benchmarkModeInput()
+	// Both with_skill cases passed; the without_skill baseline failures must
+	// not drag the rate below 100%.
+	if rate := in.OverallPassRate(); rate != 1.0 {
+		t.Fatalf("expected OverallPassRate to ignore without_skill baseline failures, got %f", rate)
+	}
+}
+
+func TestInput_PrimaryCaseResults_PrefersWithSkill(t *testing.T) {
+	in := benchmarkModeInput()
+	primary := in.PrimaryCaseResults()
+	if len(primary) != 2 {
+		t.Fatalf("expected 2 de-duplicated cases, got %d", len(primary))
+	}
+	for _, cr := range primary {
+		if cr.Configuration != "with_skill" {
+			t.Fatalf("expected primary result to be with_skill for case %s, got %q", cr.CaseID, cr.Configuration)
+		}
+		if cr.Status != judge.StatusPass {
+			t.Fatalf("expected primary result PASS for case %s, got %s", cr.CaseID, cr.Status)
+		}
+	}
+}
+
+func TestInput_PrimaryCaseResults_FallsBackToBaselineWhenNoWithSkill(t *testing.T) {
+	in := Input{
+		CaseResults: []CaseResult{
+			{CaseID: "case-1", Status: judge.StatusFail, Configuration: "without_skill"},
+		},
+	}
+	primary := in.PrimaryCaseResults()
+	if len(primary) != 1 || primary[0].Configuration != "without_skill" {
+		t.Fatalf("expected fallback to the only available (without_skill) result, got %#v", primary)
+	}
+}
+
+func TestJUnitReporter_BenchmarkMode_ExcludesBaselineFromFailures(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "result.xml")
+	r := &JUnitReporter{OutputPath: path}
+
+	if err := r.Write(context.Background(), benchmarkModeInput()); err != nil {
+		t.Fatalf("JUnitReporter.Write failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read junit file: %v", err)
+	}
+	content := string(data)
+
+	// 2 cases, both with_skill passing; without_skill baseline failures must
+	// not inflate tests/failures counts.
+	if !strings.Contains(content, `tests="2"`) {
+		t.Fatalf("expected tests=2 (de-duplicated per case), got: %s", content)
+	}
+	if !strings.Contains(content, `failures="0"`) {
+		t.Fatalf("expected failures=0 (baseline failures excluded), got: %s", content)
+	}
+}
+
 func TestInput_TotalDuration(t *testing.T) {
 	in := sampleInput()
 	d := in.TotalDuration()


### PR DESCRIPTION
In benchmark mode, CaseResults holds two entries per case: a with_skill run and a without_skill baseline. OverallPassRate and the JUnit reporter previously iterated over the raw CaseResults slice, so a without_skill baseline failure was double-counted into the overall pass rate and JUnit tests/failures/errors totals even though the with_skill result passed.

Add Input.PrimaryCaseResults() to deduplicate by CaseID, preferring the with_skill result (falling back to without_skill only when no with_skill entry exists). OverallPassRate and buildTestSuite now use this helper, and buildTestSuite's Tests count is fixed to use the deduplicated case count instead of len(CaseResults).

## Summary

only use the primary cases to calculate results report.

## Related issues
#161 
[<!-- Closes #<161> -->](https://github.com/alibaba/skill-up/issues/161)

## Changes

<!-- Bullet-point list of notable changes. -->

## Test plan

- [ ] `make test` passes
- [ ] `make verify` passes (fmt + vet + lint)
- [ ] Manual testing steps (if applicable):

## Notes for reviewers

<img width="2990" height="1354" alt="image" src="https://github.com/user-attachments/assets/6e6f2c13-a225-40c3-b728-c5437e8c74fe" />
