### PR TITLE
feat(run): summarize multi-iteration stability

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,10 @@ linters:
           - depguard
         path: ^internal/runner/runner\.go$
         text: internal/runner should report progress through callbacks or events
+      - linters:
+          - depguard
+        path: ^internal/runner/workspace_options_test\.go$
+        text: internal/runner should report progress through callbacks or events
   disable:
     # tagliatelle: JSON/YAML struct tags must use snake_case to match external API
     # response formats (GitLab and other upstream services); changing them would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Eval-level default expect checks under `cases.defaults.expect`, with
   append-and-deduplicate semantics for list checks and case-level overrides for
   `exit_code` and `golden_file`.
+- Multi-iteration `skill-up run --iteration N` now prints a per-case
+  stability summary to highlight flaky PASS/FAIL/ERROR/SKIP outcomes.
 
 ### Fixed
 - Claude Code session lookup now normalizes Windows workspace paths to the

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -27,7 +27,7 @@ skill-up run [path] [flags]
 | `--exclude-case-name`  | —                             | Exclude matching cases (glob; can be repeated)                                                                                                             |
 | `--format`             | —                             | Extra report formats: `junit` / `html` (repeatable). `result.json` is always written; `--format junit` produces `report.xml`, `--format html` produces `report.html`; `--format json` is a no-op |
 | `--output-dir`         | `<skill-name>-workspace/` next to the skill dir | Output directory for reports and artifacts                                                                                                 |
-| `--iteration`          | `1`                           | Total run count. Each iteration writes to `iteration-1/` … `iteration-N/`                                                                                  |
+| `--iteration`          | `0` (auto)                    | Repeat selected cases for stability/flakiness sampling. `0` auto-appends one run after the latest `iteration-N/` without summarizing history; positive `N` runs N samples and writes `iteration-1/` … `iteration-N/`; when `N > 1`, the terminal summary covers only samples from the current command |
 | `--engine`             | From config                   | Override engine name                                                                                                                                       |
 | `--model`              | From config                   | Override model (format: `provider/name`)                                                                                                                   |
 | `--parallelism`        | From config                   | Override `cases.parallelism`. Allowed range: 1–256                                                                                                          |
@@ -66,7 +66,7 @@ skill-up run ./evals/eval.yaml --baseline
 # Multiple report formats
 skill-up run ./evals/eval.yaml --format json --format html --format junit
 
-# Three iterations, one folder per run
+# Three samples in this command, one folder per run, plus a simple flaky summary
 skill-up run ./evals/eval.yaml --iteration 3
 
 # Auto-detect mode (consumes Anthropic evals.json directly)

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -27,7 +27,7 @@ skill-up run [path] [flags]
 | `--exclude-case-name` | —                            | 排除匹配的用例（支持 glob，可多次指定）                                                                                                                    |
 | `--format`            | —                            | 附加报告格式：`junit` / `html`（可多次指定）。`result.json` 始终写入；`--format junit` 生成 `report.xml`，`--format html` 生成 `report.html`；`--format json` 为空操作 |
 | `--output-dir`        | 与 skill 目录同级的 `<skill-name>-workspace/` | 报告和产物的输出目录                                                                                                                       |
-| `--iteration`         | `1`                          | 总运行次数。每轮运行的产物分别写入 `iteration-1/` 到 `iteration-N/`                                                                                         |
+| `--iteration`         | `0`（auto）                  | 重复运行已选用例，用于稳定性/flaky 采样。`0` 表示在最新 `iteration-N/` 后自动追加一轮，但不汇总历史结果；正整数 `N` 表示运行 N 次采样，产物写入 `iteration-1/` 到 `iteration-N/`；当 `N > 1` 时，终端摘要只覆盖本次命令执行的采样 |
 | `--engine`            | 配置文件中的值                | 覆盖 Engine 名称                                                                                                                                          |
 | `--model`             | 配置文件中的值                | 覆盖模型（格式：`provider/name`）                                                                                                                          |
 | `--parallelism`       | 配置文件中的值                | 覆盖 `cases.parallelism`，用于临时调整用例并行数，取值范围为 1 到 256                                                                                       |
@@ -59,7 +59,7 @@ skill-up run ./evals/eval.yaml --baseline
 # 生成多种格式报告
 skill-up run ./evals/eval.yaml --format json --format html --format junit
 
-# 连续运行 3 轮，产物分别写入 iteration-1/ 到 iteration-3/
+# 本次命令连续运行 3 次采样，产物分别写入 iteration-1/ 到 iteration-3/，终端打印简单 flaky 摘要
 skill-up run ./evals/eval.yaml --iteration 3
 
 # 自动检测模式（直接消费 Anthropic evals.json）

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -116,7 +116,7 @@ func init() {
 	runCmd.Flags().StringArray(engineKwargFlagName, nil, "Engine kwarg in key=value format (can be used multiple times; --ek is accepted as an alias). Recognised keys are per-agent (e.g. codex honours bypass_sandbox=true)")
 	runCmd.Flags().VarP(&verbose, "verbose", "v", "Increase log verbosity (-v or --verbose for debug, -vv or --verbose=2 for trace; --verbose=true/false is also supported)")
 	runCmd.Flags().Lookup("verbose").NoOptDefVal = "true"
-	runCmd.Flags().Int("iteration", 0, "Total number of evaluation runs. Each run writes artifacts to iteration-<N>. 0 = auto (appends after the last existing iteration). Default: auto")
+	runCmd.Flags().Int("iteration", 0, "Repeat selected eval cases N times for stability/flakiness sampling. Positive N writes iteration-<N> artifacts and prints a current-command summary when N > 1. 0 = auto-append one run after the last existing iteration without summarizing history")
 	runCmd.Flags().Bool("no-delete", false, "Skip cleanup of workspace after evaluation (useful for debugging)")
 	runCmd.Flags().Bool("dry-run", false, "Validate and show what would run without executing")
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -176,7 +178,91 @@ func (r *Runner) Evaluate(ctx context.Context, cases []*config.CaseConfig, ag ag
 			logging.WarnContextf(ctx, "Runner: failed to write results for run %d: %v", runNumber, err)
 		}
 	}
+	if runCount > 1 {
+		printIterationStabilitySummary(allResults)
+	}
 	return allResults, nil
+}
+
+type stabilityCaseSummary struct {
+	caseID string
+	trials int
+	counts map[string]int
+}
+
+func printIterationStabilitySummary(results []evaluator.EvalResult) {
+	summaries := buildIterationStabilitySummaries(results)
+	if len(summaries) == 0 {
+		return
+	}
+
+	ui.Blank()
+	ui.Status("INFO", "Iteration stability summary:")
+	for _, summary := range summaries {
+		ui.Status("", "  "+formatIterationStabilitySummary(summary))
+	}
+}
+
+func buildIterationStabilitySummaries(results []evaluator.EvalResult) []stabilityCaseSummary {
+	byCase := make(map[string]*stabilityCaseSummary)
+	order := make([]string, 0)
+	for _, result := range results {
+		if result.Configuration != "" && result.Configuration != "with_skill" {
+			continue
+		}
+		summary, ok := byCase[result.CaseID]
+		if !ok {
+			summary = &stabilityCaseSummary{
+				caseID: result.CaseID,
+				counts: make(map[string]int),
+			}
+			byCase[result.CaseID] = summary
+			order = append(order, result.CaseID)
+		}
+		summary.trials++
+		summary.counts[string(result.Status)]++
+	}
+
+	summaries := make([]stabilityCaseSummary, 0, len(order))
+	for _, caseID := range order {
+		summaries = append(summaries, *byCase[caseID])
+	}
+	return summaries
+}
+
+func formatIterationStabilitySummary(summary stabilityCaseSummary) string {
+	parts := []string{fmt.Sprintf("%s: %d trials", summary.caseID, summary.trials)}
+	seen := make(map[string]struct{})
+	for _, status := range []string{"PASS", "FAIL", "ERROR", "SKIP"} {
+		seen[status] = struct{}{}
+		if count := summary.counts[status]; count > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", count, status))
+		}
+	}
+	for _, status := range remainingStatuses(summary.counts, seen) {
+		parts = append(parts, fmt.Sprintf("%d %s", summary.counts[status], status))
+	}
+
+	line := strings.Join(parts, ", ")
+	if len(summary.counts) > 1 {
+		line += " -> flaky"
+	}
+	return line
+}
+
+func remainingStatuses(counts map[string]int, seen map[string]struct{}) []string {
+	statuses := make([]string, 0)
+	for status, count := range counts {
+		if count == 0 {
+			continue
+		}
+		if _, ok := seen[status]; ok {
+			continue
+		}
+		statuses = append(statuses, status)
+	}
+	sort.Strings(statuses)
+	return statuses
 }
 
 // caseResults groups with_skill and without_skill results for a single case.

--- a/internal/runner/workspace_options_test.go
+++ b/internal/runner/workspace_options_test.go
@@ -1,12 +1,16 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	_ "unsafe"
 
 	"github.com/alibaba/skill-up/internal/agent"
 	"github.com/alibaba/skill-up/internal/config"
@@ -16,6 +20,9 @@ import (
 	"github.com/alibaba/skill-up/internal/runtime"
 	"github.com/alibaba/skill-up/pkg/transcript"
 )
+
+//go:linkname uiOutput github.com/alibaba/skill-up/internal/ui.Output
+var uiOutput io.Writer
 
 func TestRunner_InitWorkspace_UsesExplicitRunNumber(t *testing.T) {
 	t.Parallel()
@@ -179,6 +186,182 @@ func TestRunner_Evaluate_RunsMultipleIterations(t *testing.T) {
 	if got := r.workspace.IterationNum; got != 2 {
 		t.Fatalf("IterationNum = %d, want 2 after final run", got)
 	}
+}
+
+func TestFormatIterationStabilitySummary(t *testing.T) {
+	t.Parallel()
+
+	summary := stabilityCaseSummary{
+		caseID: "case_a",
+		trials: 3,
+		counts: map[string]int{
+			"PASS": 2,
+			"FAIL": 1,
+		},
+	}
+
+	if got, want := formatIterationStabilitySummary(summary), "case_a: 3 trials, 2 PASS, 1 FAIL -> flaky"; got != want {
+		t.Fatalf("formatIterationStabilitySummary() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatIterationStabilitySummaryIncludesUnknownStatuses(t *testing.T) {
+	t.Parallel()
+
+	summary := stabilityCaseSummary{
+		caseID: "case_b",
+		trials: 3,
+		counts: map[string]int{
+			"PASS":    1,
+			"UNKNOWN": 1,
+			"Z_OTHER": 1,
+		},
+	}
+
+	want := "case_b: 3 trials, 1 PASS, 1 UNKNOWN, 1 Z_OTHER -> flaky"
+	if got := formatIterationStabilitySummary(summary); got != want {
+		t.Fatalf("formatIterationStabilitySummary() = %q, want %q", got, want)
+	}
+}
+
+func TestRunner_Evaluate_MultipleIterationsPrintStabilitySummaryAndDoNotWriteFiles(t *testing.T) {
+	evalDir := t.TempDir()
+	evalsDir := filepath.Join(evalDir, "evals")
+	if err := os.MkdirAll(evalsDir, 0o755); err != nil {
+		t.Fatalf("mkdir evals: %v", err)
+	}
+
+	loader := config.NewLoader(filepath.Join(evalsDir, "eval.yaml"))
+	r := NewRunner(&config.EvalConfig{
+		Environment: config.Environment{Type: "none"},
+		Cases:       config.CasesConfig{Parallelism: 1},
+	}, loader, nil, credential.AgentInitParams{})
+
+	origNewEvaluator := newEvaluator
+	t.Cleanup(func() { newEvaluator = origNewEvaluator })
+
+	statuses := []judge.Status{judge.StatusPass, judge.StatusFail, judge.StatusPass}
+	callCount := 0
+	newEvaluator = func(opts evaluator.EvalOptions) evaluator.Evaluator {
+		status := statuses[callCount]
+		callCount++
+		return evaluatorStub{
+			evaluateAll: func(context.Context, []*config.CaseConfig) ([]evaluator.EvalResult, error) {
+				return []evaluator.EvalResult{
+					{
+						CaseID:        "case_a",
+						CaseName:      "Case A",
+						Status:        status,
+						Configuration: "with_skill",
+						SessionResult: &agent.SessionResult{FinalMessage: "ok", ExitCode: 0},
+						Grading:       &judge.Result{Status: status},
+					},
+					{
+						CaseID:        "case_a",
+						CaseName:      "Case A baseline",
+						Status:        judge.StatusError,
+						Configuration: "without_skill",
+						SessionResult: &agent.SessionResult{FinalMessage: "baseline", ExitCode: 0},
+						Grading:       &judge.Result{Status: judge.StatusError},
+					},
+				}, nil
+			},
+		}
+	}
+
+	var output bytes.Buffer
+	captureUIOutput(t, &output)
+
+	workspaceRoot := filepath.Join(evalDir, "workspace")
+	if _, err := r.Evaluate(context.Background(), []*config.CaseConfig{{ID: "case_a", Title: "Case A"}}, &runnerTestAgent{}, EvaluateOptions{
+		OutputDir:       workspaceRoot,
+		Iteration:       3,
+		DeleteWorkspace: false,
+	}); err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+
+	rendered := output.String()
+	if !strings.Contains(rendered, "case_a: 3 trials, 2 PASS, 1 FAIL -> flaky") {
+		t.Fatalf("stability summary missing with_skill results, output:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "ERROR") {
+		t.Fatalf("stability summary should exclude baseline ERROR result, output:\n%s", rendered)
+	}
+
+	for _, filename := range []string{"stability.json", "stability.md"} {
+		if err := assertFileAbsentUnder(t, workspaceRoot, filename); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestRunner_Evaluate_AutoIterationAppendsWithoutStabilitySummary(t *testing.T) {
+	evalDir := t.TempDir()
+	evalsDir := filepath.Join(evalDir, "evals")
+	if err := os.MkdirAll(evalsDir, 0o755); err != nil {
+		t.Fatalf("mkdir evals: %v", err)
+	}
+	workspaceRoot := filepath.Join(evalDir, "workspace")
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "iteration-1"), 0o755); err != nil {
+		t.Fatalf("mkdir existing iteration: %v", err)
+	}
+
+	loader := config.NewLoader(filepath.Join(evalsDir, "eval.yaml"))
+	r := NewRunner(&config.EvalConfig{
+		Environment: config.Environment{Type: "none"},
+		Cases:       config.CasesConfig{Parallelism: 1},
+	}, loader, nil, credential.AgentInitParams{})
+
+	var output bytes.Buffer
+	captureUIOutput(t, &output)
+
+	if _, err := r.Evaluate(context.Background(), []*config.CaseConfig{{ID: "case_a", Title: "Case A"}}, &runnerTestAgent{}, EvaluateOptions{
+		OutputDir:       workspaceRoot,
+		Iteration:       0,
+		DeleteWorkspace: false,
+	}); err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+
+	if got := r.workspace.IterationNum; got != 2 {
+		t.Fatalf("IterationNum = %d, want 2", got)
+	}
+	if _, err := os.Stat(filepath.Join(workspaceRoot, "iteration-2", "result.json")); err != nil {
+		t.Fatalf("auto iteration should append result.json under iteration-2: %v", err)
+	}
+	if strings.Contains(output.String(), "Iteration stability summary") {
+		t.Fatalf("auto iteration should not print historical stability summary, output:\n%s", output.String())
+	}
+}
+
+func captureUIOutput(t *testing.T, output *bytes.Buffer) {
+	t.Helper()
+
+	origOutput := uiOutput
+	uiOutput = output
+	t.Cleanup(func() { uiOutput = origOutput })
+}
+
+func assertFileAbsentUnder(t *testing.T, root, filename string) error {
+	t.Helper()
+
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || entry.Name() != filename {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		if strings.Contains(rel, string(filepath.Separator)) {
+			return fmt.Errorf("%s should not be written under workspace, found at %s", filename, rel)
+		}
+		return fmt.Errorf("%s should not be written at workspace root", filename)
+	})
 }
 
 func TestRunner_Evaluate_ReturnsPartialResultsWhenLaterRunFails(t *testing.T) {

--- a/internal/runner/workspace_options_test.go
+++ b/internal/runner/workspace_options_test.go
@@ -5,12 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	_ "unsafe"
 
 	"github.com/alibaba/skill-up/internal/agent"
 	"github.com/alibaba/skill-up/internal/config"
@@ -18,11 +16,9 @@ import (
 	"github.com/alibaba/skill-up/internal/evaluator"
 	"github.com/alibaba/skill-up/internal/judge"
 	"github.com/alibaba/skill-up/internal/runtime"
+	"github.com/alibaba/skill-up/internal/ui"
 	"github.com/alibaba/skill-up/pkg/transcript"
 )
-
-//go:linkname uiOutput github.com/alibaba/skill-up/internal/ui.Output
-var uiOutput io.Writer
 
 func TestRunner_InitWorkspace_UsesExplicitRunNumber(t *testing.T) {
 	t.Parallel()
@@ -338,9 +334,9 @@ func TestRunner_Evaluate_AutoIterationAppendsWithoutStabilitySummary(t *testing.
 func captureUIOutput(t *testing.T, output *bytes.Buffer) {
 	t.Helper()
 
-	origOutput := uiOutput
-	uiOutput = output
-	t.Cleanup(func() { uiOutput = origOutput })
+	origOutput := ui.Output
+	ui.Output = output
+	t.Cleanup(func() { ui.Output = origOutput })
 }
 
 func assertFileAbsentUnder(t *testing.T, root, filename string) error {

--- a/skills/skill-upper/SKILL.md
+++ b/skills/skill-upper/SKILL.md
@@ -167,11 +167,14 @@ skill-up run <skill-root>/evals/eval.yaml
 | Engine override                  | `--engine codex --model openai/gpt-4` |
 | Parallelism                      | `--parallelism 4` (1–256)             |
 | Anthropic JSON                   | `--auto`                              |
-| N rounds                         | `--iteration 3`                       |
+| Stability/flakiness sampling     | `--iteration 3`                       |
 | Auto-append after last iteration | `--iteration 0` (default behavior)    |
 | Verbose                          | `-v`, `-vv`                           |
 
-Exit `0` = all passed; `1` = failure or error — suitable for CI.
+Exit `0` = all passed; `1` = failure or error — suitable for CI. When
+an explicit positive `--iteration N` runs more than one sample, inspect the
+terminal's simple current-command summary for lines like
+`case_a: 3 trials, 2 PASS, 1 FAIL -> flaky`.
 
 ### Step 7: Interpret the report
 
@@ -219,7 +222,10 @@ Full flags: `references/cli.md`.
 - Abusing `agent_judge`.
 - Anthropic `evals.json` expectations → default `agent_judge`; use `import` + hand edits for deterministic checks.
 - Paths relative to Skill root (`SKILL.md` directory).
-- `--iteration 0` appends after the latest existing iteration; positive `--iteration N` runs N rounds.
+- `--iteration 0` appends one run after the latest existing iteration without
+  summarizing history; positive `--iteration N` runs N samples of the selected
+  cases and, when N > 1, prints a simple stability/flakiness summary covering
+  only samples from the current command.
 
 ## References
 

--- a/skills/skill-upper/references/cli.md
+++ b/skills/skill-upper/references/cli.md
@@ -27,7 +27,7 @@ skill-up run [path] [flags]
 | `--exclude-case-name` | —                  | 排除匹配的用例（glob，可多次）                                                                                                                                                    |
 | `--format`            | —                  | 附加报告格式：`junit` / `html`（可多次）。`result.json` 始终写入；`--format junit` 生成 `report.xml`；`--format html` 生成 `report.html`；`--format json` 对 `result.json` 为冗余 |
 | `--output-dir`        | eval.yaml 同级目录 | 报告和产物的输出目录                                                                                                                                                              |
-| `--iteration`         | `0`（auto）        | 总运行次数。`0` = 自动：在最后一个已有 `iteration-N/` 之后追加一轮；正整数 = 显式运行 N 轮，产物写入 `iteration-1/` … `iteration-N/`                                              |
+| `--iteration`         | `0`（auto）        | 重复运行已选用例，用于稳定性/flaky 采样。`0` = 自动：在最后一个已有 `iteration-N/` 之后追加一轮，但不汇总历史结果；正整数 = 显式运行 N 次采样，产物写入 `iteration-1/` … `iteration-N/`；当 N > 1 时，终端摘要只覆盖本次命令执行的采样 |
 | `--engine`            | 配置中的值         | 覆盖 Engine 名称                                                                                                                                                                  |
 | `--runtime`           | 配置中的值         | 覆盖 `environment.type`（`none`、`opensandbox`、`docker`）                                                                                                                        |
 | `--model`             | 配置中的值         | 覆盖模型（格式：`provider/name`）                                                                                                                                                 |
@@ -54,6 +54,7 @@ skill-up run ./evals/eval.yaml --parallelism 4
 skill-up run ./evals/eval.yaml --baseline
 skill-up run ./evals/eval.yaml --format html --format junit
 skill-up run ./evals/eval.yaml --iteration 3
+# example terminal summary: case_a: 3 trials, 2 PASS, 1 FAIL -> flaky
 skill-up run ./evals/eval.yaml
 skill-up run --auto
 skill-up run ./my-skill/ --auto --engine codex


### PR DESCRIPTION
## Summary
- Print a simple terminal-only stability summary after multi-iteration runs, e.g. `case_a: 3 trials, 2 PASS, 1 FAIL -> flaky`.
- Clarify `--iteration` help/docs as stability/flakiness sampling.
- Keep per-iteration artifacts unchanged and avoid creating stability report files.

## Test Plan
- make fmt
- make verify
- GIT_CONFIG_GLOBAL=/dev/null make test

Note: plain `make test` can inherit local Git GPG signing config in temporary test repositories; the isolated global Git config avoids that unrelated local setting.