### PR TITLE
fix(agent): normalize Windows session workspace keys

### DIFF
--- a/.github/model-e2e/package-lock.json
+++ b/.github/model-e2e/package-lock.json
@@ -1,0 +1,154 @@
+{
+  "name": "skill-up-model-e2e-tools",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "skill-up-model-e2e-tools",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/claude-code": "2.1.217"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.217",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.217.tgz",
+      "integrity": "sha512-EIcc3GmI7x+qPlKCjpcLIjCh7YOaCFbOqKfL4BmwZS6QmtduVNT5E98oyr8n2cxsgeWVbnQ0mSVljTw5C/kFtA==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "bin/claude.exe"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.217",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.217",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.217",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.217",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.217",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.217",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.217",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.217"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
+      "version": "2.1.217",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.217.tgz",
+      "integrity": "sha512-w1n/sitmcNyR0G8VzJ4j2RuNVd+K1oVO7YD69y2Je0kzTJ0XMhMXSe1DDd5i0Q93CabhftvRBo1Ja/ZEOvDALg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
+      "version": "2.1.217",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.217.tgz",
+      "integrity": "sha512-aXEI06uRiJw5aeM1PWRo8iiSLAwbTp60cI8+A6UFY3MII9HCWauGcya8n9peSB83Qxz0i63hjVLpVrgt92cHAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
+      "version": "2.1.217",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.217.tgz",
+      "integrity": "sha512-u0uRgmcZTL1vVQVvFbQ2GVjmmFQ+MhEGNrWaqm5xddqpVPE3RGVlm6wt1icMieV+wGdwCAzBNb89MeRM5giwzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
+      "version": "2.1.217",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.217.tgz",
+      "integrity": "sha512-gw/12P/vY0WIV9babBvk5M4c4J2BT3A09tX5KcGsqcnYf+wuYnOSmUFTVImb7OMlCDIBGPjCDmgfSUVs0pTGQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64": {
+      "version": "2.1.217",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.217.tgz",
+      "integrity": "sha512-tZbghQ8V49xA2uWuooi5+ZkN1l9JMC6cVCKUFL95qevNgi9HmAB312IgsbKdJd733QvVkBDeHqrvMuihcdtLvg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
+      "version": "2.1.217",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.217.tgz",
+      "integrity": "sha512-NRqy7DkptF+cPVwOu99JOo4E5KIFwY7XNfXefbPYUmJQEaZT6GakLaRY7KZnb7QCzV6G2ib40IU/IE4cpfzOdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
+      "version": "2.1.217",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.217.tgz",
+      "integrity": "sha512-MNXUzpmAvcTw3q8k4mrAxmJTTPr72Kwz+USHaXNn9Dnuf00fzPRtpxAbvRoP8rmiAvaxkx1FhIDMrx9MTr3OEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-x64": {
+      "version": "2.1.217",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.217.tgz",
+      "integrity": "sha512-NOopwp5bEXPR6TQiomDkRIKX1MQ24MzzTRUj6Oo7or2k4STB4qmCMHpYSJafllhv77HEQAWk4x+EVzp1hiHpVg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    }
+  }
+}

--- a/.github/model-e2e/package.json
+++ b/.github/model-e2e/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "skill-up-model-e2e-tools",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@anthropic-ai/claude-code": "2.1.217"
+  }
+}

--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -326,6 +326,19 @@ jobs:
           ANTHROPIC_BASE_URL: https://dashscope.aliyuncs.com/apps/anthropic
           ANTHROPIC_MODEL: qwen3.6-plus
 
+      - name: List Claude project directories on failure
+        if: failure() && steps.secrets.outputs.available == 'true'
+        shell: pwsh
+        run: |
+          $projects = Join-Path $HOME ".claude\projects"
+          if (-not (Test-Path $projects)) {
+            Write-Host "Claude projects directory does not exist"
+            exit 0
+          }
+          Get-ChildItem $projects -Directory | ForEach-Object {
+            Write-Host "Claude project directory: $($_.Name)"
+          }
+
       - name: Upload Windows Claude workspace artifacts
         if: always() && steps.secrets.outputs.available == 'true' && hashFiles('e2e-windows-live-artifacts/**') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -310,8 +310,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install -g --include=optional '@anthropic-ai/claude-code@2.1.217'
-          claude --version
+          cd .github/model-e2e
+          npm ci --include=optional
+          ./node_modules/.bin/claude --version
+          cygpath -w "$(pwd)/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Verify Windows Claude token usage
         if: steps.secrets.outputs.available == 'true'

--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -324,27 +324,6 @@ jobs:
           ANTHROPIC_BASE_URL: https://dashscope.aliyuncs.com/apps/anthropic
           ANTHROPIC_MODEL: qwen3.6-plus
 
-      - name: Collect Windows Claude session diagnostics
-        if: always() && steps.secrets.outputs.available == 'true'
-        shell: pwsh
-        run: |
-          $source = Join-Path $HOME ".claude\projects"
-          $destination = Join-Path $env:GITHUB_WORKSPACE "e2e-windows-live-artifacts\claude-projects"
-          if (-not (Test-Path $source)) {
-            Write-Host "Claude projects directory does not exist: $source"
-            exit 0
-          }
-          Get-ChildItem $source -Directory | ForEach-Object {
-            Write-Host "Claude project directory: $($_.Name)"
-          }
-          Get-ChildItem $source -Recurse -File -Filter "*.jsonl" | ForEach-Object {
-            $relative = [System.IO.Path]::GetRelativePath($source, $_.FullName)
-            $target = Join-Path $destination $relative
-            New-Item -ItemType Directory -Force -Path (Split-Path $target) | Out-Null
-            Copy-Item $_.FullName $target
-            Write-Host "Collected Claude session: $relative"
-          }
-
       - name: Upload Windows Claude workspace artifacts
         if: always() && steps.secrets.outputs.available == 'true' && hashFiles('e2e-windows-live-artifacts/**') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -14,6 +14,7 @@ on:
         options:
           - all
           - none-runtime
+          - windows-none-runtime
           - opensandbox
           - docker
 
@@ -265,6 +266,73 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  e2e-windows:
+    name: E2E (none runtime, Windows, live Claude)
+    if: inputs.suite == 'all' || inputs.suite == 'windows-none-runtime'
+    runs-on: windows-2025
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check secret availability
+        id: secrets
+        shell: bash
+        env:
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DASHSCOPE_API_KEY" ]; then
+            echo "::error::DASHSCOPE_API_KEY is required for Windows Claude e2e."
+            exit 1
+          fi
+          echo "available=true" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        if: steps.secrets.outputs.available == 'true'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Set up Node.js
+        if: steps.secrets.outputs.available == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Install claude-code CLI
+        if: steps.secrets.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install -g --include=optional '@anthropic-ai/claude-code@2.1.217'
+          claude --version
+
+      - name: Verify Windows Claude token usage
+        if: steps.secrets.outputs.available == 'true'
+        shell: bash
+        run: go test -tags e2e -timeout 600s -count=1 -v -run '^TestAgent_ClaudeCode_WindowsTokenUsage$' ./e2e
+        env:
+          SKILL_UP_FULL_E2E: "1"
+          SKILL_UP_E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-windows-live-artifacts
+          ANTHROPIC_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          ANTHROPIC_BASE_URL: https://dashscope.aliyuncs.com/apps/anthropic
+          ANTHROPIC_MODEL: qwen3.6-plus
+
+      - name: Upload Windows Claude workspace artifacts
+        if: always() && steps.secrets.outputs.available == 'true' && hashFiles('e2e-windows-live-artifacts/**') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: model-e2e-windows-claude-workspaces
+          path: e2e-windows-live-artifacts/
+          if-no-files-found: ignore
+          retention-days: 14
+
   e2e-docker:
     name: E2E (Docker runtime, live model)
     if: inputs.suite == 'all' || inputs.suite == 'docker'
@@ -323,7 +391,7 @@ jobs:
   summary:
     name: Model E2E Summary
     if: always()
-    needs: [e2e, e2e-opensandbox, e2e-docker]
+    needs: [e2e, e2e-opensandbox, e2e-docker, e2e-windows]
     runs-on: [self-hosted, linux, x64, trusted]
     timeout-minutes: 5
     permissions: {}
@@ -331,6 +399,7 @@ jobs:
       - name: Write job summary
         env:
           NONE_RESULT: ${{ needs.e2e.result }}
+          WINDOWS_RESULT: ${{ needs.e2e-windows.result }}
           OPENSANDBOX_RESULT: ${{ needs.e2e-opensandbox.result }}
           DOCKER_RESULT: ${{ needs.e2e-docker.result }}
           SELECTED_SUITE: ${{ inputs.suite }}
@@ -344,10 +413,11 @@ jobs:
             echo "| Runtime | Result |"
             echo "|---|---|"
             echo "| none | ${NONE_RESULT} |"
+            echo "| none (Windows, Claude) | ${WINDOWS_RESULT} |"
             echo "| OpenSandbox | ${OPENSANDBOX_RESULT} |"
             echo "| Docker | ${DOCKER_RESULT} |"
           } >> "$GITHUB_STEP_SUMMARY"
-          for result in "$NONE_RESULT" "$OPENSANDBOX_RESULT" "$DOCKER_RESULT"; do
+          for result in "$NONE_RESULT" "$WINDOWS_RESULT" "$OPENSANDBOX_RESULT" "$DOCKER_RESULT"; do
             if [ "$result" != success ] && [ "$result" != skipped ]; then
               echo "::error::One or more selected live-model suites failed"
               exit 1

--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -324,6 +324,27 @@ jobs:
           ANTHROPIC_BASE_URL: https://dashscope.aliyuncs.com/apps/anthropic
           ANTHROPIC_MODEL: qwen3.6-plus
 
+      - name: Collect Windows Claude session diagnostics
+        if: always() && steps.secrets.outputs.available == 'true'
+        shell: pwsh
+        run: |
+          $source = Join-Path $HOME ".claude\projects"
+          $destination = Join-Path $env:GITHUB_WORKSPACE "e2e-windows-live-artifacts\claude-projects"
+          if (-not (Test-Path $source)) {
+            Write-Host "Claude projects directory does not exist: $source"
+            exit 0
+          }
+          Get-ChildItem $source -Directory | ForEach-Object {
+            Write-Host "Claude project directory: $($_.Name)"
+          }
+          Get-ChildItem $source -Recurse -File -Filter "*.jsonl" | ForEach-Object {
+            $relative = [System.IO.Path]::GetRelativePath($source, $_.FullName)
+            $target = Join-Path $destination $relative
+            New-Item -ItemType Directory -Force -Path (Split-Path $target) | Out-Null
+            Copy-Item $_.FullName $target
+            Write-Host "Collected Claude session: $relative"
+          }
+
       - name: Upload Windows Claude workspace artifacts
         if: always() && steps.secrets.outputs.available == 'true' && hashFiles('e2e-windows-live-artifacts/**') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   append-and-deduplicate semantics for list checks and case-level overrides for
   `exit_code` and `golden_file`.
 
+### Fixed
+- Claude Code session lookup now normalizes Windows workspace paths to the
+  project-directory key used by the CLI, restoring token usage in reports.
+
 ## [0.7.0] - 2026-07-16
 
 ### Added

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1172,6 +1173,93 @@ report:
 	} else {
 		t.Logf("claude run succeeded")
 	}
+}
+
+// TestAgent_ClaudeCode_WindowsTokenUsage verifies that a real Claude Code run
+// on Windows resolves the CLI's workspace-key directory and reports non-zero
+// token usage from the persisted session JSONL.
+func TestAgent_ClaudeCode_WindowsTokenUsage(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific Claude Code session lookup acceptance test")
+	}
+	skipIfNotFullE2E(t)
+	skipIfClaudeUnavailable(t)
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		t.Skip("ANTHROPIC_API_KEY not set, skipping real token usage test")
+	}
+
+	evalDir := createTestEvalDir(t, "test-skill-claude-windows-tokens")
+	evalContent := `schema_version: v1alpha1
+
+environment:
+  type: none
+  workspace_mount: /workspace
+
+mcp:
+  servers: []
+
+engine:
+  name: claude_code
+  model:
+    provider: dashscope
+    name: qwen3.6-plus
+
+skills: []
+
+cases:
+  files:
+    - evals/cases/test-case.yaml
+  defaults:
+    timeout_seconds: 120
+    max_turns: 1
+  parallelism: 1
+
+judge:
+  type: rule_based
+  rule_based:
+    must_contain:
+      - "hello"
+
+report:
+  formats: [json]
+  artifacts: [transcript]
+`
+	evalPath := filepath.Join(evalDir, "eval.yaml")
+	if err := os.WriteFile(evalPath, []byte(evalContent), 0o644); err != nil {
+		t.Fatalf("write eval.yaml: %v", err)
+	}
+
+	outputDir := t.TempDir()
+	preserveWorkspaceArtifacts(t, outputDir)
+	result := Run(t, RunConfig{Timeout: 180 * time.Second},
+		"run", evalPath, "--output-dir", outputDir)
+	if result.ExitCode != 0 {
+		t.Fatalf("Claude Code run failed: exit=%d\nstdout=%s\nstderr=%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	resultPath := filepath.Join(outputDir, "iteration-1", "result.json")
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("read result.json: %v", err)
+	}
+	var report struct {
+		CaseResults []struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"case_results"`
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("parse result.json: %v", err)
+	}
+	if len(report.CaseResults) != 1 {
+		t.Fatalf("case_results length = %d, want 1\n%s", len(report.CaseResults), data)
+	}
+	usage := report.CaseResults[0]
+	if usage.InputTokens <= 0 || usage.OutputTokens <= 0 {
+		t.Fatalf("expected non-zero Claude token usage, got input=%d output=%d\n%s",
+			usage.InputTokens, usage.OutputTokens, data)
+	}
+	t.Logf("verified Claude token usage: input=%d output=%d", usage.InputTokens, usage.OutputTokens)
 }
 
 func TestAgent_ClaudeCode_Installation(t *testing.T) {

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -1232,7 +1232,7 @@ report:
 	outputDir := t.TempDir()
 	preserveWorkspaceArtifacts(t, outputDir)
 	result := Run(t, RunConfig{Timeout: 180 * time.Second},
-		"run", evalPath, "--output-dir", outputDir)
+		"run", evalPath, "--output-dir", outputDir, "--verbose")
 	if result.ExitCode != 0 {
 		t.Fatalf("Claude Code run failed: exit=%d\nstdout=%s\nstderr=%s", result.ExitCode, result.Stdout, result.Stderr)
 	}
@@ -1256,8 +1256,8 @@ report:
 	}
 	usage := report.CaseResults[0]
 	if usage.InputTokens <= 0 || usage.OutputTokens <= 0 {
-		t.Fatalf("expected non-zero Claude token usage, got input=%d output=%d\n%s",
-			usage.InputTokens, usage.OutputTokens, data)
+		t.Fatalf("expected non-zero Claude token usage, got input=%d output=%d\n%s\nstdout=%s\nstderr=%s",
+			usage.InputTokens, usage.OutputTokens, data, result.Stdout, result.Stderr)
 	}
 	t.Logf("verified Claude token usage: input=%d output=%d", usage.InputTokens, usage.OutputTokens)
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -641,3 +641,29 @@ func TestWorkspaceKeyForRuntime(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildSessionLookupScriptPathFormat(t *testing.T) {
+	t.Parallel()
+
+	lookup := agentSessionLookup{
+		envVar:   "SKILL_UP_CLAUDE_WSKEY",
+		rootTmpl: "$home/.claude/projects/$SKILL_UP_CLAUDE_WSKEY",
+	}
+	tests := []struct {
+		name        string
+		build       func(agentSessionLookup) string
+		wantCygpath bool
+	}{
+		{name: "posix path", build: buildSessionLookupScript, wantCygpath: false},
+		{name: "windows native path", build: buildWindowsSessionLookupScript, wantCygpath: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			script := tt.build(lookup)
+			if got := strings.Contains(script, `cygpath -w "$best"`); got != tt.wantCygpath {
+				t.Fatalf("cygpath conversion present = %v, want %v\n%s", got, tt.wantCygpath, script)
+			}
+		})
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -317,6 +317,7 @@ type probeMergeTestRuntime struct {
 	probeErr    error
 	merged      map[string]string
 	shell       platform.Shell
+	workspace   string
 }
 
 func (r *probeMergeTestRuntime) Create(context.Context) error                     { return nil }
@@ -329,7 +330,7 @@ func (r *probeMergeTestRuntime) DownloadFile(context.Context, string, string) er
 	return nil
 }
 func (r *probeMergeTestRuntime) DownloadDir(context.Context, string, string) error { return nil }
-func (r *probeMergeTestRuntime) Workspace() string                                 { return "" }
+func (r *probeMergeTestRuntime) Workspace() string                                 { return r.workspace }
 func (r *probeMergeTestRuntime) RequiresProcessSandbox() bool                      { return false }
 func (r *probeMergeTestRuntime) Exec(_ context.Context, cmd string, _ ExecOptions) (ExecResult, error) {
 	r.probeCmd = cmd
@@ -591,6 +592,45 @@ func TestExtractSessionIDFromPath(t *testing.T) {
 			got := extractSessionIDFromPath(tt.path)
 			if got != tt.want {
 				t.Fatalf("extractSessionIDFromPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceKeyForRuntime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		workspace string
+		shell     platform.Shell
+		want      string
+	}{
+		{
+			name:      "windows backslashes",
+			workspace: `C:\Users\tester\AppData\Local\Temp\skill-up-123`,
+			shell:     platform.Shell{GOOS: platform.GOOSWindows, Family: platform.ShellPOSIX, BashPath: `C:\Git\bin\bash.exe`},
+			want:      "C--Users-tester-AppData-Local-Temp-skill-up-123",
+		},
+		{
+			name:      "windows forward slashes",
+			workspace: "C:/Users/tester/AppData/Local/Temp/skill-up-123",
+			shell:     platform.Shell{GOOS: platform.GOOSWindows, Family: platform.ShellPOSIX, BashPath: `C:\Git\bin\bash.exe`},
+			want:      "C--Users-tester-AppData-Local-Temp-skill-up-123",
+		},
+		{
+			name:      "posix colon remains valid",
+			workspace: "/tmp/skill-up:123",
+			shell:     platform.Shell{GOOS: platform.GOOSLinux, Family: platform.ShellPOSIX},
+			want:      "-tmp-skill-up:123",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rt := &probeMergeTestRuntime{workspace: tt.workspace, shell: tt.shell}
+			if got := workspaceKeyForRuntime(rt); got != tt.want {
+				t.Fatalf("workspaceKeyForRuntime() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -619,6 +619,12 @@ func TestWorkspaceKeyForRuntime(t *testing.T) {
 			want:      "C--Users-tester-AppData-Local-Temp-skill-up-123",
 		},
 		{
+			name:      "windows short path",
+			workspace: `C:\Users\RUNNER~1\AppData\Local\Temp\skill-up-123`,
+			shell:     platform.Shell{GOOS: platform.GOOSWindows, Family: platform.ShellPOSIX, BashPath: `C:\Git\bin\bash.exe`},
+			want:      "C--Users-RUNNER-1-AppData-Local-Temp-skill-up-123",
+		},
+		{
 			name:      "posix colon remains valid",
 			workspace: "/tmp/skill-up:123",
 			shell:     platform.Shell{GOOS: platform.GOOSLinux, Family: platform.ShellPOSIX},

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 // against a dead ctx and logs misleading "command exited with code -1"
 // noise that hides the real timeout.
 const sessionCleanupTimeout = 30 * time.Second
+
+var windowsWorkspaceKeyInvalidChars = regexp.MustCompile(`[^A-Za-z0-9_-]`)
 
 // sessionCleanupContext derives a context for post-run session-file
 // persistence, lookup and download. It detaches from cancellation of the
@@ -117,7 +120,7 @@ func workspaceKeyForRuntime(rt Runtime) string {
 		workspace = realPath
 	}
 	if rt.Shell().GOOS == platform.GOOSWindows {
-		return strings.NewReplacer("\\", "-", "/", "-", ":", "-").Replace(workspace)
+		return windowsWorkspaceKeyInvalidChars.ReplaceAllString(workspace, "-")
 	}
 	return strings.ReplaceAll(workspace, "/", "-")
 }

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -100,6 +100,9 @@ func findAgentSessionJSONL(ctx context.Context, rt Runtime, lookup agentSessionL
 	logging.DebugContextf(ctx, "agent session lookup: workspace=%q key=%q", rt.Workspace(), workspaceKey)
 
 	script := buildSessionLookupScript(lookup)
+	if rt.Shell().GOOS == platform.GOOSWindows {
+		script = buildWindowsSessionLookupScript(lookup)
+	}
 	result, err := rt.Exec(ctx, script, ExecOptions{
 		Env: map[string]string{lookup.envVar: workspaceKey},
 	})
@@ -145,6 +148,20 @@ func extractSessionIDFromPath(sessionPath string) string {
 // buildSessionLookupScript renders the shared shell snippet that picks the
 // newest *.jsonl under the configured root.
 func buildSessionLookupScript(lookup agentSessionLookup) string {
+	return buildSessionLookupScriptWithPrinter(lookup, `printf %s "$best"`)
+}
+
+func buildWindowsSessionLookupScript(lookup agentSessionLookup) string {
+	// Git Bash reports /c/... paths, which Windows filepath handling does
+	// not consider absolute. Convert the selected session path before it is
+	// passed to Runtime.DownloadFile.
+	return buildSessionLookupScriptWithPrinter(
+		lookup,
+		`if [ -n "$best" ]; then cygpath -w "$best" 2>/dev/null || printf %s "$best"; fi`,
+	)
+}
+
+func buildSessionLookupScriptWithPrinter(lookup agentSessionLookup, printBest string) string {
 	extra := ""
 	if lookup.findExtra != "" {
 		extra = " " + lookup.findExtra
@@ -160,5 +177,5 @@ while IFS= read -r p || [ -n "$p" ]; do
   case $m in ''|*[!0-9]*) continue;; esac
   if [ "$ts" -eq -1 ] || [ "$m" -gt "$ts" ]; then ts=$m; best=$p; fi
 done <"$tmp"
-printf %%s "$best"`, lookup.rootTmpl, extra)
+%s`, lookup.rootTmpl, extra, printBest)
 }

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/alibaba/skill-up/internal/platform"
 )
 
 // sessionCleanupTimeout caps how long the post-run session-file lookup,
@@ -107,11 +109,15 @@ func findAgentSessionJSONL(ctx context.Context, rt Runtime, lookup agentSessionL
 }
 
 // workspaceKeyForRuntime computes the projects-tree subdirectory name for the
-// runtime's workspace path (slashes replaced with hyphens, symlinks resolved).
+// runtime's workspace path (path separators replaced with hyphens, symlinks
+// resolved).
 func workspaceKeyForRuntime(rt Runtime) string {
 	workspace := rt.Workspace()
 	if realPath, err := filepath.EvalSymlinks(workspace); err == nil {
 		workspace = realPath
+	}
+	if rt.Shell().GOOS == platform.GOOSWindows {
+		return strings.NewReplacer("\\", "-", "/", "-", ":", "-").Replace(workspace)
 	}
 	return strings.ReplaceAll(workspace, "/", "-")
 }

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -121,8 +121,8 @@ func findAgentSessionJSONL(ctx context.Context, rt Runtime, lookup agentSessionL
 
 // workspaceKeyForRuntime computes the projects-tree subdirectory name for the
 // runtime's workspace path. Claude derives Windows keys from the cwd spelling
-// it receives, so preserve short-path components such as RUNNER~1 instead of
-// resolving them to their long form.
+// it receives, so avoid expanding 8.3 short names to their long form before
+// sanitizing them.
 func workspaceKeyForRuntime(rt Runtime) string {
 	workspace := rt.Workspace()
 	if rt.Shell().GOOS == platform.GOOSWindows {

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -112,15 +112,16 @@ func findAgentSessionJSONL(ctx context.Context, rt Runtime, lookup agentSessionL
 }
 
 // workspaceKeyForRuntime computes the projects-tree subdirectory name for the
-// runtime's workspace path (path separators replaced with hyphens, symlinks
-// resolved).
+// runtime's workspace path. Claude derives Windows keys from the cwd spelling
+// it receives, so preserve short-path components such as RUNNER~1 instead of
+// resolving them to their long form.
 func workspaceKeyForRuntime(rt Runtime) string {
 	workspace := rt.Workspace()
-	if realPath, err := filepath.EvalSymlinks(workspace); err == nil {
-		workspace = realPath
-	}
 	if rt.Shell().GOOS == platform.GOOSWindows {
 		return windowsWorkspaceKeyInvalidChars.ReplaceAllString(workspace, "-")
+	}
+	if realPath, err := filepath.EvalSymlinks(workspace); err == nil {
+		workspace = realPath
 	}
 	return strings.ReplaceAll(workspace, "/", "-")
 }

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alibaba/skill-up/internal/logging"
 	"github.com/alibaba/skill-up/internal/platform"
 )
 
@@ -96,18 +97,22 @@ func findAgentSessionJSONL(ctx context.Context, rt Runtime, lookup agentSessionL
 	if workspaceKey == "" {
 		return ""
 	}
+	logging.DebugContextf(ctx, "agent session lookup: workspace=%q key=%q", rt.Workspace(), workspaceKey)
 
 	script := buildSessionLookupScript(lookup)
 	result, err := rt.Exec(ctx, script, ExecOptions{
 		Env: map[string]string{lookup.envVar: workspaceKey},
 	})
 	if err != nil || result.ExitCode != 0 {
+		logging.DebugContextf(ctx, "agent session lookup failed: err=%v exit_code=%d", err, result.ExitCode)
 		return ""
 	}
 	sessionPath := strings.TrimSpace(result.Stdout)
 	if sessionPath == "" || !strings.HasSuffix(sessionPath, ".jsonl") {
+		logging.DebugContextf(ctx, "agent session lookup returned no JSONL path")
 		return ""
 	}
+	logging.DebugContextf(ctx, "agent session lookup found %q", sessionPath)
 	return sessionPath
 }
 


### PR DESCRIPTION
## Summary

- normalize Windows workspace keys exactly as Claude Code does while preserving short-path components such as `RUNNER~1`
- convert Git Bash `/c/...` session paths to native Windows paths before artifact download
- add unit coverage plus a manual GitHub-hosted Windows live-Claude acceptance suite
- pin the Windows Claude CLI dependency with an npm lockfile

## Validation

- `make verify`
- `make test`
- `GOOS=windows GOARCH=amd64 go test -c -tags e2e -o /tmp/skill-up-e2e-windows.test ./e2e`
- Windows live E2E: https://github.com/alibaba/skill-up/actions/runs/30630293556
  - `result.json`: input tokens `20681`, output tokens `25`, total tokens `20706`
  - uploaded artifact contains the matching Claude session JSONL and its usage fields agree with the report

Closes #160