### PR TITLE
fix(qoder): match underscore workspace keys

### DIFF
--- a/internal/agent/qodercli.go
+++ b/internal/agent/qodercli.go
@@ -280,10 +280,17 @@ func (a *QoderCLIAgent) RunTurn(ctx context.Context, rt Runtime, opts ExecOption
 // are read only inside the runtime via Exec (not os.Getenv / host os.Stat).
 func findQoderSessionFile(ctx context.Context, rt Runtime) string {
 	return findAgentSessionJSONL(ctx, rt, agentSessionLookup{
-		envVar:    "SKILL_UP_QODER_WSKEY",
-		rootTmpl:  "$home/.qoder/projects/$SKILL_UP_QODER_WSKEY",
-		findExtra: `! -name "*-session.json"`,
+		envVar:                "SKILL_UP_QODER_WSKEY",
+		rootTmpl:              "$home/.qoder/projects/$SKILL_UP_QODER_WSKEY",
+		findExtra:             `! -name "*-session.json"`,
+		workspaceKeyTransform: qoderWorkspaceKey,
 	})
+}
+
+// qoderWorkspaceKey mirrors Qoder's projects-directory encoding. Unlike
+// Claude Code, Qoder replaces underscores as well as path separators.
+func qoderWorkspaceKey(key string) string {
+	return strings.ReplaceAll(key, "_", "-")
 }
 
 // Install installs qoder CLI via official install script.

--- a/internal/agent/qodercli_test.go
+++ b/internal/agent/qodercli_test.go
@@ -430,7 +430,7 @@ func TestFindQoderSessionFile_SelectsNewestByModTime(t *testing.T) {
 	if err == nil {
 		workspace = realPath
 	}
-	workspaceKey := strings.ReplaceAll(workspace, "/", "-")
+	workspaceKey := qoderWorkspaceKey(strings.ReplaceAll(workspace, "/", "-"))
 	projectDir := filepath.Join(tmpHome, ".qoder", "projects", workspaceKey)
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -456,6 +456,15 @@ func TestFindQoderSessionFile_SelectsNewestByModTime(t *testing.T) {
 	got := findQoderSessionFile(context.Background(), rt)
 	if got != newFile {
 		t.Fatalf("expected newest by mtime %q, got %q", newFile, got)
+	}
+}
+
+func TestQoderWorkspaceKey(t *testing.T) {
+	t.Parallel()
+
+	got := qoderWorkspaceKey("-private-var-folders-b_-skill-up")
+	if got != "-private-var-folders-b--skill-up" {
+		t.Fatalf("qoderWorkspaceKey() = %q", got)
 	}
 }
 

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -83,6 +83,9 @@ type agentSessionLookup struct {
 	// findExtra appends extra `find` predicates such as exclusion patterns.
 	// Empty string means no extra predicates.
 	findExtra string
+	// workspaceKeyTransform applies agent-specific path encoding after the
+	// shared runtime workspace key has been normalized.
+	workspaceKeyTransform func(string) string
 }
 
 // findAgentSessionJSONL resolves the newest *.jsonl session file under the
@@ -96,6 +99,9 @@ func findAgentSessionJSONL(ctx context.Context, rt Runtime, lookup agentSessionL
 	workspaceKey := workspaceKeyForRuntime(rt)
 	if workspaceKey == "" {
 		return ""
+	}
+	if lookup.workspaceKeyTransform != nil {
+		workspaceKey = lookup.workspaceKeyTransform(workspaceKey)
 	}
 	logging.DebugContextf(ctx, "agent session lookup: workspace=%q key=%q", rt.Workspace(), workspaceKey)
 


### PR DESCRIPTION
## Summary

- normalize underscores in Qoder project workspace keys
- keep the transform agent-specific so other session lookup behavior is unchanged
- add coverage for slash and underscore path encoding

## Validation

- `make fmt`
- `make verify`
- `env -u QODER_PERSONAL_ACCESS_TOKEN make test`
- real Qoder evaluation now resolves the native JSONL transcript; DataAgent base eval: 12/12 PASS, real integration eval: 16/16 PASS
