### PR TITLE
fix(ci): run required checks for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '.github/workflows/docs.yml'
   pull_request:
     branches: [main]
     paths-ignore:
       - 'docs/**'
       - '*.md'
       - '.github/workflows/docs.yml'
+  # Maintainers can run required CI explicitly for documentation-only PRs.
+  workflow_dispatch:
   # Required checks must also run for commits synthesized by Merge Queue.
   merge_group:
 


### PR DESCRIPTION
## Summary

- keep documentation-only pull requests excluded from automatic CI
- always run full CI after changes reach `main`
- add `workflow_dispatch` so maintainers can run required CI explicitly for a documentation-only PR
- preserve the existing merge queue checks

## Root cause

PR #169 changes only Markdown, so the pull-request path filter correctly skips CI. The main ruleset still requires `Build & Test`, `E2E Smoke`, and `Lint`, leaving no check run to rerun.

## Intended flow

After this PR merges, update a documentation-only PR to the latest `main`, then run:

```bash
gh workflow run ci.yml --ref <pr-head-branch>
```

The manual workflow runs the existing required jobs on that branch head. A subsequent merge-queue commit is still validated through `merge_group`, and the merged commit is validated again by the unfiltered `push` trigger on `main`.

## Validation

- YAML syntax parsing
- `make fmt`
- `make verify`
- `make test`
- `git diff --check`