### PR TITLE
fix(release): install GitHub CLI before publish

### DIFF
--- a/.github/scripts/install-gh.sh
+++ b/.github/scripts/install-gh.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+gh_version="2.97.0"
+gh_linux_amd64_sha256="a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112"
+
+: "${RUNNER_TEMP:?RUNNER_TEMP must be set}"
+: "${GITHUB_PATH:?GITHUB_PATH must be set}"
+
+archive="gh_${gh_version}_linux_amd64.tar.gz"
+archive_path="${RUNNER_TEMP}/${archive}"
+
+curl --fail --location --retry 3 --show-error --silent \
+  "https://github.com/cli/cli/releases/download/v${gh_version}/${archive}" \
+  --output "$archive_path"
+printf '%s  %s\n' "$gh_linux_amd64_sha256" "$archive_path" | sha256sum --check
+tar -xzf "$archive_path" -C "$RUNNER_TEMP"
+
+gh_bin_dir="${RUNNER_TEMP}/gh_${gh_version}_linux_amd64/bin"
+"$gh_bin_dir/gh" --version
+echo "$gh_bin_dir" >> "$GITHUB_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,48 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/scripts/install-gh.sh"
+      - ".github/workflows/release.yml"
 
 permissions: {}
 
 concurrency:
   # Release tags share one publication lane. Different tags must not mutate
   # GitHub Releases concurrently.
-  group: release
-  cancel-in-progress: false
+  group: release-${{ github.event_name == 'push' && 'publish' || github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  verify-tooling:
+    name: Verify release tooling
+    if: github.event_name == 'pull_request'
+    runs-on: [self-hosted, linux, x64, trusted]
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install GitHub CLI
+        run: .github/scripts/install-gh.sh
+
+      - name: Verify GitHub API access
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh --version
+          gh api "repos/${GITHUB_REPOSITORY}" --jq .full_name
+
   build:
     name: Build release artifacts
+    if: github.event_name == 'push'
     runs-on: [self-hosted, linux, x64, trusted]
     timeout-minutes: 30
     permissions:
@@ -99,6 +129,14 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install GitHub CLI
+        run: .github/scripts/install-gh.sh
+
       - name: Download approved release candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:


### PR DESCRIPTION
## Summary

- install a pinned GitHub CLI in the protected publish job
- verify the official Linux amd64 archive with its pinned SHA-256 checksum
- run the exact same installer on the trusted Linux x64 runner during pull requests
- verify PATH propagation and authenticated GitHub API access without publishing

## Root cause

The v0.8.0 release built, downloaded, and attested its artifacts successfully, but `Publish GitHub Release` failed with `gh: command not found`. PR #156 moved the publish job from `ubuntu-24.04` to the trusted self-hosted fleet, where GitHub CLI is not preinstalled.

The v0.8.0 release was recovered from the exact approved artifact after checksum verification. This PR prevents the same failure on future tags.

## Verification

- `make verify`
- `make test`
- `uvx zizmor@1.28.0 .github/workflows/release.yml`
- `bash -n .github/scripts/install-gh.sh`
- `Verify release tooling` runs `.github/scripts/install-gh.sh` on `[self-hosted, linux, x64, trusted]`, then checks `gh --version` and authenticated `gh api` access
