### PR TITLE
fix: resume the same CLI session across evaluation turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Multi-turn evaluation now resumes the CLI session it started. Session
+  transcripts are located without reconstructing a CLI's project-directory
+  naming rule: directory names and the workspace path are compared in a shared
+  canonical form, falling back to the working directory a transcript records.
+  Workspace paths containing underscores, dots, spaces or non-ASCII characters
+  no longer break resume — previously such paths (macOS default `TMPDIR` among
+  them) made every turn start a brand-new session and lose all earlier context.
+- Session lookup no longer mistakes a sub-agent transcript for the main session.
+  A Skill or Task call writes `<sessionID>/subagents/agent-*.jsonl` into the same
+  project tree, and those file names are not resumable session ids.
+- Per-turn responses in multi-turn evaluation are now the answer that closed each
+  turn. Turn boundaries are derived from the transcript each turn appends instead
+  of from session-file turn numbers, which count tool results and injected Skill
+  bodies as user events and therefore advance several times within one turn.
+- Multi-turn evaluation warns when an engine reports no session id and later
+  turns cannot resume, instead of silently degrading to independent sessions.
+
+### Changed
+- Assistant messages in a parsed transcript carry only the text the assistant
+  produced. A tool call is represented by its own `tool_call` entry and no longer
+  also appears as a `[tool: Name]` placeholder in assistant content, so such a
+  placeholder can no longer be graded as a turn's answer.
+
 ## [0.8.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`C:\\Users\\...`) is recognised and a path that merely appears in the
   conversation is not mistaken for identity. When a neighbouring transcript proves
   the directory is shared and none can be attributed to this workspace, the lookup
-  reports no session instead of guessing.
+  reports no session instead of guessing. Markers are encoded the way the CLIs
+  write them (no HTML escaping, so a path containing `&`, `<` or `>` matches), and
+  Windows comparisons fold case because the same directory may reach skill-up
+  spelled differently from how the CLI recorded it.
 - Per-turn responses in multi-turn evaluation are now the answer that closed each
   turn. Turn boundaries are derived from the transcript each turn appends instead
   of from session-file turn numbers, which count tool results and injected Skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project tree, and those file names are not resumable session ids.
 - Session lookup no longer resumes or grades a transcript belonging to another
   workspace. The CLIs collapse punctuation when naming a project directory, so
-  workspaces whose paths differ only in punctuation share one directory;
-  candidates are now ranked by the working directory they record and a transcript
-  recording a different one is never used.
+  workspaces whose paths differ only in punctuation share one directory.
+  Candidates are resolved against the working directory a transcript records,
+  matched as the JSON fragment it is written as, so a Windows path
+  (`C:\\Users\\...`) is recognised and a path that merely appears in the
+  conversation is not mistaken for identity. When a neighbouring transcript proves
+  the directory is shared and none can be attributed to this workspace, the lookup
+  reports no session instead of guessing.
 - Per-turn responses in multi-turn evaluation are now the answer that closed each
   turn. Turn boundaries are derived from the transcript each turn appends instead
   of from session-file turn numbers, which count tool results and injected Skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session lookup no longer mistakes a sub-agent transcript for the main session.
   A Skill or Task call writes `<sessionID>/subagents/agent-*.jsonl` into the same
   project tree, and those file names are not resumable session ids.
+- Session lookup no longer resumes or grades a transcript belonging to another
+  workspace. The CLIs collapse punctuation when naming a project directory, so
+  workspaces whose paths differ only in punctuation share one directory;
+  candidates are now ranked by the working directory they record and a transcript
+  recording a different one is never used.
 - Per-turn responses in multi-turn evaluation are now the answer that closed each
   turn. Turn boundaries are derived from the transcript each turn appends instead
   of from session-file turn numbers, which count tool results and injected Skill

--- a/e2e/multiturn_session_test.go
+++ b/e2e/multiturn_session_test.go
@@ -1,0 +1,115 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alibaba/skill-up/internal/judge"
+	"github.com/alibaba/skill-up/internal/report"
+)
+
+// getMultiTurnSessionTestdataDir returns e2e/testdata/multiturn-session.
+func getMultiTurnSessionTestdataDir() string {
+	return filepath.Join(getProjectRoot(), "e2e", "testdata", "multiturn-session")
+}
+
+// TestPipeline_MultiTurnSessionResume drives a real two-turn evaluation against
+// a mock that behaves like qodercli where session state is concerned: it writes
+// its transcript into $HOME/.qoder/projects/<project-key>/, answers the first
+// turn through a Skill (tool call first, prose last), drops a sub-agent
+// transcript inside the same project tree, and can only recall earlier context
+// when it is resumed with -r.
+//
+// TMPDIR is pointed at a directory whose name contains an underscore, which is
+// what macOS default temp directories look like — the framework has to derive
+// the same project-key as the CLI for any of this to work.
+//
+// The case fails unless all three behaviours hold:
+//   - turn 1's response is the final answer, not a "[tool: …]" placeholder,
+//   - the framework picks the main session file, not the sub-agent transcript,
+//   - turn 2 runs inside turn 1's session and can quote it back.
+func TestPipeline_MultiTurnSessionResume(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	t.Parallel()
+
+	fixtureDir := getMultiTurnSessionTestdataDir()
+	evalPath := filepath.Join(fixtureDir, "evals", "eval.yaml")
+
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create fake HOME bin dir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(fixtureDir, "session-engine.sh"), filepath.Join(binDir, "qodercli")); err != nil {
+		t.Fatalf("symlink mock qodercli: %v", err)
+	}
+
+	// The workspace is created under TMPDIR, so this is how the test controls
+	// the workspace path shape the project-key is derived from.
+	tmpDir := filepath.Join(t.TempDir(), "skill_up_tmp")
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		t.Fatalf("create tmpdir: %v", err)
+	}
+
+	outputDir := t.TempDir()
+	result := Run(t, RunConfig{
+		Env: []string{
+			"PATH=" + binDir + ":" + os.Getenv("PATH"),
+			"HOME=" + home,
+			"TMPDIR=" + tmpDir,
+		},
+		WorkDir: fixtureDir,
+		Timeout: 120 * time.Second,
+	}, "run", evalPath, "--no-delete", "--output-dir", outputDir)
+
+	t.Logf("stdout:\n%s", result.Stdout)
+	if result.Stderr != "" {
+		t.Logf("stderr:\n%s", result.Stderr)
+	}
+
+	reportPath := filepath.Join(outputDir, "iteration-1", "report.json")
+	reportData, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("failed to read report.json at %s: %v", reportPath, err)
+	}
+	var rpt report.Input
+	if err := json.Unmarshal(reportData, &rpt); err != nil {
+		t.Fatalf("failed to parse report.json: %v", err)
+	}
+	if len(rpt.CaseResults) != 1 {
+		t.Fatalf("expected exactly 1 case result, got %d", len(rpt.CaseResults))
+	}
+	cr := rpt.CaseResults[0]
+
+	if len(cr.TurnResults) != 2 {
+		t.Fatalf("expected 2 turn results, got %d: %#v", len(cr.TurnResults), cr.TurnResults)
+	}
+	turn1, turn2 := cr.TurnResults[0], cr.TurnResults[1]
+
+	if strings.Contains(turn1.Response, "[tool:") {
+		t.Errorf("turn 1 response is a tool placeholder instead of the answer: %q", turn1.Response)
+	}
+	if !strings.Contains(turn1.Response, "alidocs.dingtalk.com") {
+		t.Errorf("turn 1 response should carry the Skill's answer, got %q", turn1.Response)
+	}
+	const recallMarker = "context-recall: Explain GRADING-POLICY tiering."
+	if !strings.Contains(turn2.Response, recallMarker) {
+		t.Errorf("turn 2 did not resume turn 1's session (want %q), got %q", recallMarker, turn2.Response)
+	}
+
+	if cr.Grading == nil {
+		t.Fatalf("expected grading to be non-nil")
+	}
+	if cr.Grading.Status != judge.StatusPass {
+		t.Errorf("expected case status PASS, got %q (assertions: %#v)", cr.Grading.Status, cr.Grading.AssertionResults)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", result.ExitCode)
+	}
+}

--- a/e2e/testdata/multiturn-session/SKILL.md
+++ b/e2e/testdata/multiturn-session/SKILL.md
@@ -1,0 +1,3 @@
+# Multi-turn session fixture Skill
+
+A placeholder Skill used by the multi-turn session e2e fixture.

--- a/e2e/testdata/multiturn-session/evals/cases/multi-turn-resume.yaml
+++ b/e2e/testdata/multiturn-session/evals/cases/multi-turn-resume.yaml
@@ -1,0 +1,35 @@
+id: multi-turn-resume
+title: Multi-turn evaluation resumes the same CLI session
+description: >
+  Turn 1 is answered through a Skill (tool call first, prose afterwards), so its
+  response must be the final text rather than a tool placeholder. Turn 2 depends
+  on turn 1's context, which is only available when the framework resumes the
+  session the first turn created.
+tag: functional_test
+input:
+  turns:
+    - role: user
+      content: Explain GRADING-POLICY tiering.
+      post_condition:
+        must_contain_any: ["alidocs.dingtalk.com"]
+        must_not_contain: ["[tool:"]
+        on_fail: fail
+    - role: user
+      content: You did not answer my question.
+
+constraints:
+  timeout_seconds: 60
+  max_turns: 5
+
+judge:
+  type: rule_based
+  success:
+    - turn_response_contains:
+        turn: 1
+        contains_all: ["alidocs.dingtalk.com"]
+    - turn_response_not_contains:
+        turn: 1
+        not_contains: ["[tool:"]
+    - turn_response_contains:
+        turn: 2
+        contains_all: ["context-recall: Explain GRADING-POLICY tiering."]

--- a/e2e/testdata/multiturn-session/evals/eval.yaml
+++ b/e2e/testdata/multiturn-session/evals/eval.yaml
@@ -1,0 +1,24 @@
+schema_version: v1alpha1
+
+environment:
+  type: none
+
+skills:
+  - source: local_path
+    path: .
+
+engine:
+  name: qoder-cli
+  model:
+    provider: qoder
+    name: auto
+
+cases:
+  files:
+    - evals/cases/multi-turn-resume.yaml
+  defaults:
+    timeout_seconds: 60
+  parallelism: 1
+
+report:
+  formats: [json]

--- a/e2e/testdata/multiturn-session/session-engine.sh
+++ b/e2e/testdata/multiturn-session/session-engine.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# session-engine.sh — a mock that impersonates qodercli closely enough to
+# exercise skill-up's *session handling* (which the plain mock-engine cannot,
+# because it never writes a session transcript).
+#
+# Faithful behaviours that matter for multi-turn evaluation:
+#   1. Session transcripts live at
+#      $HOME/.qoder/projects/<project-key>/<session-id>.jsonl, where
+#      <project-key> is the working directory with every non-alphanumeric
+#      character replaced by "-" (the CLI's own naming rule).
+#   2. The first assistant event of a turn carries only a tool_use block; the
+#      tool result and the real answer arrive afterwards, and the tool result is
+#      recorded as a "user" event.
+#   3. A Skill invocation also writes a sub-agent transcript under
+#      <session-id>/subagents/, inside the same project tree.
+#   4. Context is recalled only when -r resumes a session file that exists;
+#      otherwise the turn behaves like a brand-new conversation.
+set -euo pipefail
+
+PROMPT=""
+RESUME=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p)
+      shift
+      PROMPT="${1:-}"
+      ;;
+    -r)
+      shift
+      RESUME="${1:-}"
+      ;;
+  esac
+  shift || true
+done
+
+# Large prompts are piped in on stdin as `-p -`.
+if [[ -z "$PROMPT" || "$PROMPT" == "-" ]]; then
+  if [[ ! -t 0 ]]; then
+    PROMPT="$(cat)"
+  fi
+fi
+
+# Flatten the prompt so it can be embedded in a JSON string literal.
+FLAT_PROMPT="$(printf '%s' "$PROMPT" | tr '\n\r' '  ' | tr '"' "'" | sed 's/[[:space:]]\{1,\}/ /g; s/^ //; s/ $//')"
+
+PROJECT_KEY="$(printf '%s' "$PWD" | sed 's/[^a-zA-Z0-9]/-/g')"
+ROOT="$HOME/.qoder/projects/$PROJECT_KEY"
+mkdir -p "$ROOT"
+
+rand_hex() {
+  od -An -tx1 -N"$1" /dev/urandom | tr -d ' \n'
+}
+
+RECALLED=""
+if [[ -n "$RESUME" && -f "$ROOT/$RESUME.jsonl" ]]; then
+  SESSION_ID="$RESUME"
+  # Only reachable when the resumed session file is the one this mock wrote
+  # earlier: recall the very first user prompt of that session.
+  RECALLED="$(sed -n 's/^{"type":"user","cwd":"[^"]*","message":{"content":"\([^"]*\)".*/\1/p' "$ROOT/$SESSION_ID.jsonl" | head -1)"
+else
+  SESSION_ID="$(rand_hex 4)-$(rand_hex 2)-$(rand_hex 2)-$(rand_hex 2)-$(rand_hex 6)"
+fi
+
+SESSION_FILE="$ROOT/$SESSION_ID.jsonl"
+TOOL_ID="toolu_$(rand_hex 6)"
+
+if [[ -n "$RECALLED" ]]; then
+  ANSWER="context-recall: ${RECALLED} | apologies, escalating to the support desk"
+else
+  ANSWER="TIER11 answer, source: alidocs.dingtalk.com/i/p/tiering"
+fi
+
+{
+  printf '{"type":"workspace-directories","sessionId":"%s","directories":["%s"]}\n' "$SESSION_ID" "$PWD"
+  printf '{"type":"user","cwd":"%s","message":{"content":"%s","role":"user"}}\n' "$PWD" "$FLAT_PROMPT"
+  printf '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"%s","name":"Skill","input":{"skill":"kb"}}],"role":"assistant"}}\n' "$TOOL_ID"
+  printf '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"%s","content":"Launching skill: kb"}],"role":"user"}}\n' "$TOOL_ID"
+  printf '{"type":"assistant","message":{"content":[{"type":"text","text":"%s"}],"role":"assistant"}}\n' "$ANSWER"
+} >>"$SESSION_FILE"
+
+# The Skill call spawns a sub-agent, whose transcript lands inside the project
+# tree and is the most recently modified file there.
+SUBAGENT_FILE="$ROOT/$SESSION_ID/subagents/agent-aExplore-$(rand_hex 4).jsonl"
+mkdir -p "$(dirname "$SUBAGENT_FILE")"
+printf '{"type":"user","message":{"content":"sub-agent scratch work","role":"user"}}\n' >"$SUBAGENT_FILE"
+touch -t 203001010000 "$SUBAGENT_FILE"
+
+echo "$ANSWER"

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -720,7 +720,11 @@ func TestExtractSessionIDFromPath(t *testing.T) {
 	}
 }
 
-func TestWorkspaceKeyForRuntime(t *testing.T) {
+// TestCanonicalWorkspaceKey covers the comparison form both sides of the session
+// lookup are reduced to. Windows spellings must survive unexpanded (an 8.3 short
+// name stays short), because the CLI derives its directory name from the cwd it
+// was handed.
+func TestCanonicalWorkspaceKey(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -748,18 +752,24 @@ func TestWorkspaceKeyForRuntime(t *testing.T) {
 			want:      "C--Users-RUNNER-1-AppData-Local-Temp-skill-up-123",
 		},
 		{
-			name:      "posix colon remains valid",
-			workspace: "/tmp/skill-up:123",
+			name:      "posix underscores dots and colons",
+			workspace: "/tmp/skill_up.eval:123",
 			shell:     platform.Shell{GOOS: platform.GOOSLinux, Family: platform.ShellPOSIX},
-			want:      "-tmp-skill-up:123",
+			want:      "-tmp-skill-up-eval-123",
+		},
+		{
+			name:      "posix spaces and non-ascii",
+			workspace: "/tmp/eval space/中文",
+			shell:     platform.Shell{GOOS: platform.GOOSLinux, Family: platform.ShellPOSIX},
+			want:      "-tmp-eval-space---",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			rt := &probeMergeTestRuntime{workspace: tt.workspace, shell: tt.shell}
-			if got := workspaceKeyForRuntime(rt); got != tt.want {
-				t.Fatalf("workspaceKeyForRuntime() = %q, want %q", got, tt.want)
+			if got := canonicalWorkspaceKey(workspaceForRuntime(rt)); got != tt.want {
+				t.Fatalf("canonicalWorkspaceKey() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -769,8 +779,8 @@ func TestBuildSessionLookupScriptPathFormat(t *testing.T) {
 	t.Parallel()
 
 	lookup := agentSessionLookup{
-		envVar:   "SKILL_UP_CLAUDE_WSKEY",
-		rootTmpl: "$home/.claude/projects/$SKILL_UP_CLAUDE_WSKEY",
+		projectsRootTmpl: "$home/.claude/projects",
+		sessionDepth:     1,
 	}
 	tests := []struct {
 		name        string

--- a/internal/agent/claude_code.go
+++ b/internal/agent/claude_code.go
@@ -569,9 +569,9 @@ func buildClaudeTextSessionResult(engine, instruction string, start time.Time, r
 // projects tree (~/.claude/projects/<workspace-key>/) for this workspace.
 func findClaudeSessionFile(ctx context.Context, rt Runtime) string {
 	return findAgentSessionJSONL(ctx, rt, agentSessionLookup{
-		envVar:    "SKILL_UP_CLAUDE_WSKEY",
-		rootTmpl:  "$home/.claude/projects/$SKILL_UP_CLAUDE_WSKEY",
-		findExtra: "",
+		projectsRootTmpl: "$home/.claude/projects",
+		sessionDepth:     1,
+		findExtra:        "",
 	})
 }
 
@@ -975,13 +975,20 @@ func processClaudeAssistantEvent(event claudeEvent, turn int) ([]transcript.Mess
 		role = transcript.RoleError
 	}
 	messages := extractToolMessagesFromContent(event.Message.Content, turn)
-	if text := extractTextFromContent(event.Message.Content); text != "" {
+	// Only real prose becomes an assistant message: tool_use blocks are already
+	// recorded as their own tool_call messages above, and letting their
+	// "[tool: Name]" rendering stand in as assistant text makes a placeholder
+	// eligible as the answer under evaluation.
+	if text := extractAssistantTextFromContent(event.Message.Content); text != "" {
 		messages = append(messages, transcript.Message{Role: role, Content: text, Turn: turn})
 	}
 	return messages, "", turn
 }
 
 // extractTextFromContent extracts text content from Claude message content block.
+// Tool calls are rendered as "[tool: Name]" so that a caller inspecting raw
+// content still sees that a tool ran; use extractAssistantTextFromContent when
+// the result stands in for what the assistant actually said.
 func extractTextFromContent(content any) string {
 	if content == nil {
 		return ""
@@ -1007,6 +1014,36 @@ func extractTextFromContent(content any) string {
 				if name, ok := blockMap["name"].(string); ok {
 					textParts = append(textParts, "[tool: "+name+"]")
 				}
+			}
+		}
+		if len(textParts) > 0 {
+			return strings.Join(textParts, "\n\n")
+		}
+	}
+
+	return ""
+}
+
+// extractAssistantTextFromContent returns only the prose an assistant emitted,
+// ignoring tool_use blocks. An assistant event that carries nothing but tool
+// calls therefore yields "", which keeps it out of the running when the final
+// answer of a turn is selected.
+func extractAssistantTextFromContent(content any) string {
+	switch c := content.(type) {
+	case string:
+		return c
+	case []any:
+		var textParts []string
+		for _, block := range c {
+			blockMap, ok := block.(map[string]any)
+			if !ok {
+				continue
+			}
+			if blockType, _ := blockMap["type"].(string); blockType != "text" {
+				continue
+			}
+			if text, ok := blockMap["text"].(string); ok {
+				textParts = append(textParts, text)
 			}
 		}
 		if len(textParts) > 0 {

--- a/internal/agent/claude_code_test.go
+++ b/internal/agent/claude_code_test.go
@@ -649,6 +649,55 @@ func TestParseSessionFile_ToolCalls(t *testing.T) {
 	}
 }
 
+// TestParseSessionFile_ToolUseOnlyAssistantEventKeepsFinalTextAnswer uses the
+// shape a real qodercli session takes when the model answers by delegating to a
+// Skill: the first assistant event carries nothing but a tool_use block, the
+// tool result and the injected Skill body arrive as "user" events, and the
+// actual answer is the last assistant text. qodercli writes no "result" event,
+// so the final message has to come from the transcript.
+//
+// A tool_use block is already represented by its own tool_call message, so it
+// must not additionally masquerade as assistant prose — otherwise a placeholder
+// like "[tool: Skill]" can be selected as the answer under evaluation.
+func TestParseSessionFile_ToolUseOnlyAssistantEventKeepsFinalTextAnswer(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	sessionFile := filepath.Join(tmpDir, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl")
+
+	content := `{"type":"user","message":{"content":"How is data tiering defined?","role":"user"}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Skill","input":{"skill":"kb"}}],"role":"assistant"}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"Launching skill: kb"}],"role":"user"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Tier 1.1 applies. See alidocs.dingtalk.com/i/p/tiering"}],"role":"assistant"}}
+`
+	if err := os.WriteFile(sessionFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write session file: %v", err)
+	}
+
+	trans, finalMsg, _, _ := parseSessionFile(sessionFile)
+
+	const wantAnswer = "Tier 1.1 applies. See alidocs.dingtalk.com/i/p/tiering"
+	if finalMsg != wantAnswer {
+		t.Errorf("final message = %q, want %q", finalMsg, wantAnswer)
+	}
+	if got := trans.FinalAssistantMessage(); got != wantAnswer {
+		t.Errorf("FinalAssistantMessage() = %q, want %q", got, wantAnswer)
+	}
+	for i, msg := range trans {
+		if msg.Role == transcript.RoleAssistant && strings.Contains(msg.Content, "[tool:") {
+			t.Errorf("message %d: assistant text must not be a tool placeholder, got %q", i, msg.Content)
+		}
+	}
+
+	calls := trans.ToolCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected the Skill tool call to stay visible, got %d tool calls", len(calls))
+	}
+	if calls[0].ToolCall.Name != "Skill" {
+		t.Errorf("tool call name = %q, want Skill", calls[0].ToolCall.Name)
+	}
+}
+
 func TestParseSessionFile_EmptyFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/qodercli.go
+++ b/internal/agent/qodercli.go
@@ -275,14 +275,19 @@ func (a *QoderCLIAgent) RunTurn(ctx context.Context, rt Runtime, opts ExecOption
 	return sessionResult, nil
 }
 
-// findQoderSessionFile resolves the newest matching session JSONL under the Qoder
-// projects tree for this workspace. Per runtime isolation, HOME and the tree
-// are read only inside the runtime via Exec (not os.Getenv / host os.Stat).
+// findQoderSessionFile resolves the newest session JSONL that belongs to this
+// workspace under the Qoder projects tree. Per runtime isolation, HOME and the
+// tree are read only inside the runtime via Exec (not os.Getenv / host os.Stat).
+//
+// sessionDepth of 1 matters beyond performance: a Skill or Task call spawns a
+// sub-agent whose transcript is written to <sessionID>/subagents/agent-*.jsonl
+// inside this same tree. Those are often the newest files, and their names are
+// not resumable session ids.
 func findQoderSessionFile(ctx context.Context, rt Runtime) string {
 	return findAgentSessionJSONL(ctx, rt, agentSessionLookup{
-		envVar:    "SKILL_UP_QODER_WSKEY",
-		rootTmpl:  "$home/.qoder/projects/$SKILL_UP_QODER_WSKEY",
-		findExtra: `! -name "*-session.json"`,
+		projectsRootTmpl: "$home/.qoder/projects",
+		sessionDepth:     1,
+		findExtra:        `! -name "*-session.json"`,
 	})
 }
 

--- a/internal/agent/qodercli_test.go
+++ b/internal/agent/qodercli_test.go
@@ -383,8 +383,11 @@ func TestQoderSessionJSONL_ParseMCPToolCalls(t *testing.T) {
 	if finalMsg != "done" {
 		t.Fatalf("finalMsg = %q, want done", finalMsg)
 	}
-	if len(trans) != 5 {
-		t.Fatalf("expected 5 transcript messages, got %d: %#v", len(trans), trans)
+	// user prompt, tool call, tool result, assistant text. The tool_use block is
+	// represented by the tool_call message only; it does not also appear as
+	// assistant prose.
+	if len(trans) != 4 {
+		t.Fatalf("expected 4 transcript messages, got %d: %#v", len(trans), trans)
 	}
 	if trans[1].Role != transcript.RoleToolCall || trans[1].ToolCall == nil {
 		t.Fatalf("expected tool call message, got %#v", trans[1])
@@ -392,11 +395,11 @@ func TestQoderSessionJSONL_ParseMCPToolCalls(t *testing.T) {
 	if trans[1].ToolCall.Name != "mcp__agent-sandbox__create_sandbox" {
 		t.Fatalf("tool call name = %q", trans[1].ToolCall.Name)
 	}
-	if trans[3].Role != transcript.RoleToolResult || trans[3].ToolResult == nil {
-		t.Fatalf("expected tool result message, got %#v", trans[3])
+	if trans[2].Role != transcript.RoleToolResult || trans[2].ToolResult == nil {
+		t.Fatalf("expected tool result message, got %#v", trans[2])
 	}
-	if trans[3].ToolResult.CallID != "call_1" || trans[3].ToolResult.Status != "success" {
-		t.Fatalf("unexpected tool result: %#v", trans[3].ToolResult)
+	if trans[2].ToolResult.CallID != "call_1" || trans[2].ToolResult.Status != "success" {
+		t.Fatalf("unexpected tool result: %#v", trans[2].ToolResult)
 	}
 }
 

--- a/internal/agent/qwen_code.go
+++ b/internal/agent/qwen_code.go
@@ -294,6 +294,8 @@ func findQwenCodeSessionFile(ctx context.Context, rt Runtime) string {
 		projectsRootTmpl: "$home/.qwen/projects",
 		// qwen keeps chats one level below the workspace directory:
 		// <workspace-key>/chats/<session>.jsonl.
+		// qwen chat events carry no working directory, so the directory match is
+		// the only signal available for this format.
 		sessionDepth: 2,
 	})
 }

--- a/internal/agent/qwen_code.go
+++ b/internal/agent/qwen_code.go
@@ -291,8 +291,10 @@ func (a *QwenCodeAgent) buildSessionResult(ctx context.Context, rt Runtime, opts
 // shared project-tree lookup (HOME + tree are read only inside the runtime).
 func findQwenCodeSessionFile(ctx context.Context, rt Runtime) string {
 	return findAgentSessionJSONL(ctx, rt, agentSessionLookup{
-		envVar:   "SKILL_UP_QWEN_WSKEY",
-		rootTmpl: "$home/.qwen/projects/$SKILL_UP_QWEN_WSKEY/chats",
+		projectsRootTmpl: "$home/.qwen/projects",
+		// qwen keeps chats one level below the workspace directory:
+		// <workspace-key>/chats/<session>.jsonl.
+		sessionDepth: 2,
 	})
 }
 

--- a/internal/agent/session_key_test.go
+++ b/internal/agent/session_key_test.go
@@ -276,6 +276,79 @@ func TestFindClaudeSessionFileMatchesJSONEscapedWindowsCwd(t *testing.T) {
 	}
 }
 
+// TestFindQoderSessionFileWithHTMLSensitiveWorkspace covers workspace paths
+// containing characters a JSON encoder may escape at its own discretion. Go
+// escapes "&", "<" and ">" by default while the Node-based CLIs write them
+// literally, so a marker built from the default encoding matches nothing and the
+// transcript is discarded. Nothing about this is Windows-specific.
+func TestFindQoderSessionFileWithHTMLSensitiveWorkspace(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	home := t.TempDir()
+	workspace := filepath.Join(t.TempDir(), "ws&a<b>c")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	resolved := resolvePath(t, workspace)
+
+	session := filepath.Join(home, ".qoder", "projects", cliProjectDirKey(t, workspace),
+		"55555555-5555-5555-5555-555555555555.jsonl")
+	writeSessionFixture(t, session, qoderSessionFixture(resolved))
+
+	rt := newShellSessionRuntime(workspace, home)
+	if got := findQoderSessionFile(context.Background(), rt); got != session {
+		t.Fatalf("findQoderSessionFile() = %q, want %q", got, session)
+	}
+}
+
+// TestFindClaudeSessionFileFoldsWindowsPathCase covers Windows path equivalence:
+// the spelling skill-up receives and the spelling the CLI recorded may differ in
+// case for the same directory, so both the project-directory comparison and the
+// recorded working directory have to be compared case-insensitively there.
+func TestFindClaudeSessionFileFoldsWindowsPathCase(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	home := t.TempDir()
+	const (
+		workspace = `C:\Users\RunnerAdmin\AppData\Local\Temp\skill_up-1`
+		recorded  = `C:\Users\RUNNERADMIN\AppData\Local\Temp\skill_up-1`
+	)
+	root := filepath.Join(home, ".claude", "projects", canonicalWorkspaceKey(recorded))
+	session := filepath.Join(root, "66666666-6666-6666-6666-666666666666.jsonl")
+	writeSessionFixture(t, session,
+		`{"type":"user","cwd":"C:\\Users\\RUNNERADMIN\\AppData\\Local\\Temp\\skill_up-1","message":{"content":"hi","role":"user"}}`)
+
+	rt := newShellSessionRuntime(workspace, home)
+	rt.shell = platform.Shell{GOOS: platform.GOOSWindows, Family: platform.ShellPOSIX, BashPath: "bash"}
+	if got := findClaudeSessionFile(context.Background(), rt); got != session {
+		t.Fatalf("findClaudeSessionFile() = %q, want %q", got, session)
+	}
+}
+
+// TestFindQoderSessionFileKeepsPOSIXPathCase is the counterpart guard: POSIX paths
+// are case-sensitive, so /w/ws_a and /w/WS_A are different workspaces and the
+// Windows folding must not leak into that comparison.
+func TestFindQoderSessionFileKeepsPOSIXPathCase(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	home := t.TempDir()
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "ws_a")
+	otherWorkspace := filepath.Join(parent, "WS_A")
+
+	session := filepath.Join(home, ".qoder", "projects", canonicalWorkspaceKey(otherWorkspace),
+		"77777777-7777-7777-7777-777777777777.jsonl")
+	writeSessionFixture(t, session, qoderSessionFixture(otherWorkspace))
+
+	rt := newShellSessionRuntime(workspace, home)
+	if got := findQoderSessionFile(context.Background(), rt); got != "" {
+		t.Fatalf("findQoderSessionFile() = %q, want no result for a case-different workspace", got)
+	}
+}
+
 // qoderSessionFixture returns a minimal transcript in the shape qodercli writes,
 // including the recorded working directory the lookup can fall back to.
 func qoderSessionFixture(workspace string) string {
@@ -394,6 +467,7 @@ func skipIfNoLocalBash(t *testing.T) {
 type shellSessionRuntime struct {
 	workspace string
 	home      string
+	shell     platform.Shell
 	merged    map[string]string
 }
 
@@ -453,6 +527,9 @@ func (r *shellSessionRuntime) MergeEnv(env map[string]string) {
 }
 
 func (r *shellSessionRuntime) Shell() platform.Shell {
+	if r.shell.GOOS != "" {
+		return r.shell
+	}
 	return platform.Shell{GOOS: platform.GOOSLinux, Family: platform.ShellPOSIX, BashPath: "bash"}
 }
 

--- a/internal/agent/session_key_test.go
+++ b/internal/agent/session_key_test.go
@@ -140,56 +140,139 @@ func TestFindQoderSessionFileDisambiguatesCollidingWorkspaces(t *testing.T) {
 	skipIfNoLocalBash(t)
 	t.Parallel()
 
-	tests := []struct {
-		name string
-		// ourFixture builds the transcript of the workspace under test; the other
-		// workspace's transcript always records its own working directory.
-		ourFixture func(workspace string) string
-	}{
-		{
-			name:       "transcripts record their working directory",
-			ourFixture: qoderSessionFixture,
-		},
-		{
-			name: "our transcript records none, the other one does",
-			ourFixture: func(string) string {
-				return `{"type":"user","message":{"content":"hi","role":"user"}}`
-			},
-		},
+	home := t.TempDir()
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "ws_x")
+	otherWorkspace := filepath.Join(parent, "ws-x")
+	for _, dir := range []string{workspace, otherWorkspace} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	projectDir := cliProjectDirKey(t, workspace)
+	if other := cliProjectDirKey(t, otherWorkspace); other != projectDir {
+		t.Fatalf("fixture no longer collides: %q vs %q", projectDir, other)
+	}
 
-			home := t.TempDir()
-			parent := t.TempDir()
-			workspace := filepath.Join(parent, "ws_x")
-			otherWorkspace := filepath.Join(parent, "ws-x")
-			for _, dir := range []string{workspace, otherWorkspace} {
-				if err := os.MkdirAll(dir, 0o755); err != nil {
-					t.Fatalf("create %s: %v", dir, err)
-				}
-			}
-			projectDir := cliProjectDirKey(t, workspace)
-			if other := cliProjectDirKey(t, otherWorkspace); other != projectDir {
-				t.Fatalf("fixture no longer collides: %q vs %q", projectDir, other)
-			}
+	root := filepath.Join(home, ".qoder", "projects", projectDir)
+	oursSession := filepath.Join(root, "11111111-1111-1111-1111-111111111111.jsonl")
+	otherSession := filepath.Join(root, "22222222-2222-2222-2222-222222222222.jsonl")
+	writeSessionFixture(t, oursSession, qoderSessionFixture(resolvePath(t, workspace)))
+	writeSessionFixture(t, otherSession, qoderSessionFixture(resolvePath(t, otherWorkspace)))
 
-			root := filepath.Join(home, ".qoder", "projects", projectDir)
-			oursSession := filepath.Join(root, "11111111-1111-1111-1111-111111111111.jsonl")
-			otherSession := filepath.Join(root, "22222222-2222-2222-2222-222222222222.jsonl")
-			writeSessionFixture(t, oursSession, tt.ourFixture(resolvePath(t, workspace)))
-			writeSessionFixture(t, otherSession, qoderSessionFixture(resolvePath(t, otherWorkspace)))
+	// The other workspace ran last, so modification time alone would pick it.
+	touch(t, oursSession, time.Now().Add(-2*time.Minute))
+	touch(t, otherSession, time.Now())
 
-			// The other workspace ran last, so modification time alone would pick it.
-			touch(t, oursSession, time.Now().Add(-2*time.Minute))
-			touch(t, otherSession, time.Now())
+	rt := newShellSessionRuntime(workspace, home)
+	if got := findQoderSessionFile(context.Background(), rt); got != oursSession {
+		t.Fatalf("findQoderSessionFile() = %q, want this workspace's session %q", got, oursSession)
+	}
+}
 
-			rt := newShellSessionRuntime(workspace, home)
-			if got := findQoderSessionFile(context.Background(), rt); got != oursSession {
-				t.Fatalf("findQoderSessionFile() = %q, want this workspace's session %q", got, oursSession)
-			}
-		})
+// TestFindQoderSessionFileIgnoresPathMentionedInContent guards the workspace
+// predicate against false positives: a transcript belonging to a colliding
+// workspace may quote our workspace path in a prompt or tool output (agents print
+// paths routinely), which must not be read as "this transcript is ours". Only
+// recorded working-directory metadata identifies a workspace.
+func TestFindQoderSessionFileIgnoresPathMentionedInContent(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	home := t.TempDir()
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "ws_x")
+	otherWorkspace := filepath.Join(parent, "ws-x")
+	for _, dir := range []string{workspace, otherWorkspace} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+	resolved := resolvePath(t, workspace)
+	root := filepath.Join(home, ".qoder", "projects", cliProjectDirKey(t, workspace))
+
+	oursSession := filepath.Join(root, "11111111-1111-1111-1111-111111111111.jsonl")
+	writeSessionFixture(t, oursSession, qoderSessionFixture(resolved))
+
+	// The other workspace's transcript passes our directory to a tool, so the path
+	// appears there as a plain JSON string just like a recorded cwd would.
+	otherSession := filepath.Join(root, "22222222-2222-2222-2222-222222222222.jsonl")
+	writeSessionFixture(t, otherSession, qoderSessionFixture(resolvePath(t, otherWorkspace))+"\n"+
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Read","input":{"path":"`+resolved+`"}}],"role":"assistant"}}`)
+
+	touch(t, oursSession, time.Now().Add(-2*time.Minute))
+	touch(t, otherSession, time.Now())
+
+	rt := newShellSessionRuntime(workspace, home)
+	if got := findQoderSessionFile(context.Background(), rt); got != oursSession {
+		t.Fatalf("findQoderSessionFile() = %q, want this workspace's session %q", got, oursSession)
+	}
+}
+
+// TestFindQoderSessionFileFailsSafeWhenIdentityUnknown covers a collision where
+// our own transcript carries no working directory but a neighbour's does. The
+// recorded directory proves the project directory is shared, so nothing here can
+// be attributed to this workspace: returning no result (which the evaluator
+// reports as a lost session) beats grading another workspace's conversation.
+//
+// Transcripts that record no directory at all are still usable when nothing
+// contradicts them — qwen's format never records one, and neither did older CLI
+// releases; TestFindQoderSessionFile_SelectsNewestByModTime covers that path.
+func TestFindQoderSessionFileFailsSafeWhenIdentityUnknown(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	home := t.TempDir()
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "ws_x")
+	otherWorkspace := filepath.Join(parent, "ws-x")
+	for _, dir := range []string{workspace, otherWorkspace} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+	root := filepath.Join(home, ".qoder", "projects", cliProjectDirKey(t, workspace))
+
+	oursSession := filepath.Join(root, "11111111-1111-1111-1111-111111111111.jsonl")
+	otherSession := filepath.Join(root, "22222222-2222-2222-2222-222222222222.jsonl")
+	writeSessionFixture(t, oursSession, `{"type":"user","message":{"content":"hi","role":"user"}}`)
+	writeSessionFixture(t, otherSession, qoderSessionFixture(resolvePath(t, otherWorkspace)))
+	touch(t, oursSession, time.Now().Add(-2*time.Minute))
+	touch(t, otherSession, time.Now())
+
+	rt := newShellSessionRuntime(workspace, home)
+	if got := findQoderSessionFile(context.Background(), rt); got != "" {
+		t.Fatalf("findQoderSessionFile() = %q, want no result rather than an unattributable transcript", got)
+	}
+}
+
+// TestFindClaudeSessionFileMatchesJSONEscapedWindowsCwd pins the predicate to the
+// JSON encoding a transcript actually uses: a Windows working directory appears
+// as "C:\\Users\\...", so a raw comparison against the path never matches and the
+// correct transcript would be discarded. The script itself runs under a POSIX
+// shell here; only the workspace spelling and the recorded cwd are Windows-like,
+// which is what the predicate is being tested on.
+func TestFindClaudeSessionFileMatchesJSONEscapedWindowsCwd(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	home := t.TempDir()
+	const workspace = `C:\Users\tester\AppData\Local\Temp\skill_up-1`
+	root := filepath.Join(home, ".claude", "projects", canonicalWorkspaceKey(workspace))
+	session := filepath.Join(root, "33333333-3333-3333-3333-333333333333.jsonl")
+	writeSessionFixture(t, session,
+		`{"type":"user","cwd":"C:\\Users\\tester\\AppData\\Local\\Temp\\skill_up-1","message":{"content":"hi","role":"user"}}`)
+
+	// A colliding workspace (skill-up-1 vs skill_up-1) shares the directory and ran later.
+	other := filepath.Join(root, "44444444-4444-4444-4444-444444444444.jsonl")
+	writeSessionFixture(t, other,
+		`{"type":"user","cwd":"C:\\Users\\tester\\AppData\\Local\\Temp\\skill-up-1","message":{"content":"hi","role":"user"}}`)
+	touch(t, session, time.Now().Add(-2*time.Minute))
+	touch(t, other, time.Now())
+
+	rt := newShellSessionRuntime(workspace, home)
+	if got := findClaudeSessionFile(context.Background(), rt); got != session {
+		t.Fatalf("findClaudeSessionFile() = %q, want %q", got, session)
 	}
 }
 

--- a/internal/agent/session_key_test.go
+++ b/internal/agent/session_key_test.go
@@ -1,0 +1,319 @@
+package agent
+
+import (
+	"context"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	goruntime "runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alibaba/skill-up/internal/platform"
+)
+
+// TestFindQoderSessionFileAcrossProjectDirNamingRules is the core guarantee of
+// the session lookup: it must find the workspace's transcript without depending
+// on how the CLI happened to name the directory it lives in.
+//
+// The rules below are all real or realistic: "non-alphanumeric to hyphen" is what
+// qodercli 1.1.8 does, "spaces preserved" is what an older release did (such
+// directories still exist on developer machines), "underscores" stands for a
+// future release picking a different separator, and the truncated-plus-hashed
+// name is what the CLIs fall back to for very long paths.
+//
+// Fixtures for the derivable names deliberately omit the recorded working
+// directory, so only directory matching can resolve them; the truncated name
+// cannot be derived from the path at all and is resolved from the recorded
+// working directory instead. Each mechanism is therefore covered on its own and
+// neither can mask the other.
+func TestFindQoderSessionFileAcrossProjectDirNamingRules(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		dirName    func(workspace string) string
+		recordsCwd bool
+	}{
+		{
+			name: "non-alphanumeric replaced with hyphen",
+			dirName: func(workspace string) string {
+				return regexp.MustCompile(`[^A-Za-z0-9]`).ReplaceAllString(workspace, "-")
+			},
+		},
+		{
+			name: "only separators replaced, spaces preserved",
+			dirName: func(workspace string) string {
+				return strings.ReplaceAll(workspace, "/", "-")
+			},
+		},
+		{
+			name: "underscores instead of hyphens",
+			dirName: func(workspace string) string {
+				return regexp.MustCompile(`[^A-Za-z0-9]`).ReplaceAllString(workspace, "_")
+			},
+		},
+		{
+			name: "truncated with hash suffix",
+			dirName: func(workspace string) string {
+				key := regexp.MustCompile(`[^A-Za-z0-9]`).ReplaceAllString(workspace, "-")
+				return key[:len(key)/2] + "-1a2b3c"
+			},
+			recordsCwd: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			home := t.TempDir()
+			// An underscore and a dot in the workspace path reproduce the shape of
+			// a macOS temp directory.
+			workspace := filepath.Join(t.TempDir(), "skill_up.ws")
+			if err := os.MkdirAll(workspace, 0o755); err != nil {
+				t.Fatalf("create workspace: %v", err)
+			}
+			rt := newShellSessionRuntime(workspace, home)
+			resolved := resolvePath(t, workspace)
+
+			fixture := `{"type":"user","message":{"content":"hi","role":"user"}}`
+			if tt.recordsCwd {
+				fixture = qoderSessionFixture(resolved)
+			}
+
+			const sessionID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+			mainSession := filepath.Join(home, ".qoder", "projects", tt.dirName(resolved), sessionID+".jsonl")
+			writeSessionFixture(t, mainSession, fixture)
+
+			if got := findQoderSessionFile(context.Background(), rt); got != mainSession {
+				t.Fatalf("findQoderSessionFile() = %q, want %q", got, mainSession)
+			}
+		})
+	}
+}
+
+// TestFindQoderSessionFileIgnoresOtherWorkspaces guards the discriminator the
+// lookup relies on: cases running in parallel share one projects tree, so a
+// newer transcript from a different workspace must never be picked up.
+func TestFindQoderSessionFileIgnoresOtherWorkspaces(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	home := t.TempDir()
+	workspace := filepath.Join(t.TempDir(), "skill_up.ws")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	rt := newShellSessionRuntime(workspace, home)
+	resolved := resolvePath(t, workspace)
+
+	projects := filepath.Join(home, ".qoder", "projects")
+	mainSession := filepath.Join(projects, cliProjectDirKey(t, workspace), "11111111-1111-1111-1111-111111111111.jsonl")
+	writeSessionFixture(t, mainSession, qoderSessionFixture(resolved))
+
+	otherWorkspace := filepath.Join(t.TempDir(), "other_case.ws")
+	if err := os.MkdirAll(otherWorkspace, 0o755); err != nil {
+		t.Fatalf("create other workspace: %v", err)
+	}
+	otherSession := filepath.Join(projects, cliProjectDirKey(t, otherWorkspace), "22222222-2222-2222-2222-222222222222.jsonl")
+	writeSessionFixture(t, otherSession, qoderSessionFixture(resolvePath(t, otherWorkspace)))
+
+	touch(t, mainSession, time.Now().Add(-2*time.Minute))
+	touch(t, otherSession, time.Now())
+
+	if got := findQoderSessionFile(context.Background(), rt); got != mainSession {
+		t.Fatalf("findQoderSessionFile() = %q, want this workspace's session %q", got, mainSession)
+	}
+}
+
+// qoderSessionFixture returns a minimal transcript in the shape qodercli writes,
+// including the recorded working directory the lookup can fall back to.
+func qoderSessionFixture(workspace string) string {
+	return `{"type":"workspace-directories","directories":["` + workspace + `"]}
+{"type":"user","cwd":"` + workspace + `","message":{"content":"hi","role":"user"}}`
+}
+
+func resolvePath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve %q: %v", path, err)
+	}
+	return resolved
+}
+
+// TestFindQoderSessionFileSkipsSubagentTranscripts covers the case where a
+// Skill (or any Task-style tool) spawns a sub-agent: qodercli stores that
+// sub-agent's transcript at <projects>/<key>/<sessionID>/subagents/agent-*.jsonl,
+// inside the same project tree. The lookup must still return the main session
+// file, because the selected file name is handed to `-r` as the session ID and
+// "agent-aExplore-…" is not a resumable session.
+func TestFindQoderSessionFileSkipsSubagentTranscripts(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	home := t.TempDir()
+	workspace := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	rt := newShellSessionRuntime(workspace, home)
+
+	const sessionID = "11111111-2222-3333-4444-555555555555"
+	root := filepath.Join(home, ".qoder", "projects", cliProjectDirKey(t, workspace))
+	mainSession := filepath.Join(root, sessionID+".jsonl")
+	subagentSession := filepath.Join(root, sessionID, "subagents", "agent-aExplore-deadbeef.jsonl")
+	writeSessionFixture(t, mainSession, `{"type":"user","message":{"content":"hi","role":"user"}}`)
+	writeSessionFixture(t, subagentSession, `{"type":"user","message":{"content":"sub","role":"user"}}`)
+
+	// The sub-agent transcript is the newest file in the tree, so an unbounded
+	// search would prefer it over the session skill-up actually drove.
+	touch(t, mainSession, time.Now().Add(-2*time.Minute))
+	touch(t, subagentSession, time.Now())
+
+	got := findQoderSessionFile(context.Background(), rt)
+	if got != mainSession {
+		t.Fatalf("findQoderSessionFile() = %q, want main session %q", got, mainSession)
+	}
+	if id := extractSessionIDFromPath(got); id != sessionID {
+		t.Fatalf("extractSessionIDFromPath(%q) = %q, want %q", got, id, sessionID)
+	}
+}
+
+// TestFindQoderSessionFileWithNonAlphanumericWorkspace drives the lookup through
+// a workspace path shaped like a macOS temp directory (underscore plus dot).
+func TestFindQoderSessionFileWithNonAlphanumericWorkspace(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	home := t.TempDir()
+	workspace := filepath.Join(t.TempDir(), "skill_up.ws")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	rt := newShellSessionRuntime(workspace, home)
+
+	const sessionID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	root := filepath.Join(home, ".qoder", "projects", cliProjectDirKey(t, workspace))
+	mainSession := filepath.Join(root, sessionID+".jsonl")
+	writeSessionFixture(t, mainSession, `{"type":"user","message":{"content":"hi","role":"user"}}`)
+
+	if got := findQoderSessionFile(context.Background(), rt); got != mainSession {
+		t.Fatalf("findQoderSessionFile() = %q, want %q", got, mainSession)
+	}
+}
+
+// cliProjectDirKey mirrors qodercli 1.1.8's naming rule independently of the
+// production code, for fixtures that only need one plausible directory name.
+// TestFindQoderSessionFileAcrossProjectDirNamingRules covers the other rules.
+func cliProjectDirKey(t *testing.T, path string) string {
+	t.Helper()
+	return regexp.MustCompile(`[^A-Za-z0-9]`).ReplaceAllString(resolvePath(t, path), "-")
+}
+
+func writeSessionFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create dir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content+"\n"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func touch(t *testing.T, path string, mtime time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}
+
+func skipIfNoLocalBash(t *testing.T) {
+	t.Helper()
+	if goruntime.GOOS == platform.GOOSWindows {
+		t.Skip("session lookup script needs a POSIX shell")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found in PATH")
+	}
+}
+
+// shellSessionRuntime runs the generated lookup script through a real bash so
+// the test exercises the script itself (depth, ordering, filters) instead of a
+// canned Exec result.
+type shellSessionRuntime struct {
+	workspace string
+	home      string
+	merged    map[string]string
+}
+
+func newShellSessionRuntime(workspace, home string) *shellSessionRuntime {
+	return &shellSessionRuntime{workspace: workspace, home: home}
+}
+
+func (r *shellSessionRuntime) Create(context.Context) error                      { return nil }
+func (r *shellSessionRuntime) Close() error                                      { return nil }
+func (r *shellSessionRuntime) Start(context.Context) error                       { return nil }
+func (r *shellSessionRuntime) Stop(context.Context) error                        { return nil }
+func (r *shellSessionRuntime) UploadFile(context.Context, string, string) error  { return nil }
+func (r *shellSessionRuntime) UploadDir(context.Context, string, string) error   { return nil }
+func (r *shellSessionRuntime) DownloadDir(context.Context, string, string) error { return nil }
+func (r *shellSessionRuntime) Workspace() string                                 { return r.workspace }
+func (r *shellSessionRuntime) RequiresProcessSandbox() bool                      { return false }
+
+func (r *shellSessionRuntime) DownloadFile(_ context.Context, remote, local string) error {
+	data, err := os.ReadFile(remote) //nolint:gosec // both paths are fixtures the test itself created
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(local, data, 0o600) //nolint:gosec // both paths are fixtures the test itself created
+}
+
+func (r *shellSessionRuntime) Exec(ctx context.Context, cmd string, opts ExecOptions) (ExecResult, error) {
+	c := exec.CommandContext(ctx, "bash", "-c", cmd)
+	c.Env = append(os.Environ(), "HOME="+r.home)
+	for k, v := range opts.Env {
+		c.Env = append(c.Env, k+"="+v)
+	}
+	if opts.Cwd != "" {
+		c.Dir = opts.Cwd
+	}
+	var stdout, stderr strings.Builder
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	err := c.Run()
+	result := ExecResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	var exitErr *exec.ExitError
+	if err != nil {
+		if ok := asExitError(err, &exitErr); ok {
+			result.ExitCode = exitErr.ExitCode()
+			return result, nil
+		}
+		return result, err
+	}
+	return result, nil
+}
+
+func (r *shellSessionRuntime) MergeEnv(env map[string]string) {
+	if r.merged == nil {
+		r.merged = make(map[string]string, len(env))
+	}
+	maps.Copy(r.merged, env)
+}
+
+func (r *shellSessionRuntime) Shell() platform.Shell {
+	return platform.Shell{GOOS: platform.GOOSLinux, Family: platform.ShellPOSIX, BashPath: "bash"}
+}
+
+func asExitError(err error, target **exec.ExitError) bool {
+	exitErr, ok := err.(*exec.ExitError) //nolint:errorlint // direct type assert keeps the helper trivial
+	if ok {
+		*target = exitErr
+	}
+	return ok
+}

--- a/internal/agent/session_key_test.go
+++ b/internal/agent/session_key_test.go
@@ -130,6 +130,69 @@ func TestFindQoderSessionFileIgnoresOtherWorkspaces(t *testing.T) {
 	}
 }
 
+// TestFindQoderSessionFileDisambiguatesCollidingWorkspaces covers workspaces whose
+// paths differ only in punctuation, such as /w/ws_x and /w/ws-x. The CLIs replace
+// every non-alphanumeric character, so both workspaces are stored under the *same*
+// project directory and the directory name alone cannot tell them apart. Picking
+// the newest transcript there would resume another workspace's session, which is
+// how concurrent cases would silently grade each other's conversations.
+func TestFindQoderSessionFileDisambiguatesCollidingWorkspaces(t *testing.T) {
+	skipIfNoLocalBash(t)
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// ourFixture builds the transcript of the workspace under test; the other
+		// workspace's transcript always records its own working directory.
+		ourFixture func(workspace string) string
+	}{
+		{
+			name:       "transcripts record their working directory",
+			ourFixture: qoderSessionFixture,
+		},
+		{
+			name: "our transcript records none, the other one does",
+			ourFixture: func(string) string {
+				return `{"type":"user","message":{"content":"hi","role":"user"}}`
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			home := t.TempDir()
+			parent := t.TempDir()
+			workspace := filepath.Join(parent, "ws_x")
+			otherWorkspace := filepath.Join(parent, "ws-x")
+			for _, dir := range []string{workspace, otherWorkspace} {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatalf("create %s: %v", dir, err)
+				}
+			}
+			projectDir := cliProjectDirKey(t, workspace)
+			if other := cliProjectDirKey(t, otherWorkspace); other != projectDir {
+				t.Fatalf("fixture no longer collides: %q vs %q", projectDir, other)
+			}
+
+			root := filepath.Join(home, ".qoder", "projects", projectDir)
+			oursSession := filepath.Join(root, "11111111-1111-1111-1111-111111111111.jsonl")
+			otherSession := filepath.Join(root, "22222222-2222-2222-2222-222222222222.jsonl")
+			writeSessionFixture(t, oursSession, tt.ourFixture(resolvePath(t, workspace)))
+			writeSessionFixture(t, otherSession, qoderSessionFixture(resolvePath(t, otherWorkspace)))
+
+			// The other workspace ran last, so modification time alone would pick it.
+			touch(t, oursSession, time.Now().Add(-2*time.Minute))
+			touch(t, otherSession, time.Now())
+
+			rt := newShellSessionRuntime(workspace, home)
+			if got := findQoderSessionFile(context.Background(), rt); got != oursSession {
+				t.Fatalf("findQoderSessionFile() = %q, want this workspace's session %q", got, oursSession)
+			}
+		})
+	}
+}
+
 // qoderSessionFixture returns a minimal transcript in the shape qodercli writes,
 // including the recorded working directory the lookup can fall back to.
 func qoderSessionFixture(workspace string) string {

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -204,9 +204,16 @@ func buildWindowsSessionLookupScript(lookup agentSessionLookup) string {
 //     that cannot be derived from the path at all, such as the truncated and
 //     hashed names the CLIs fall back to for very long paths.
 //
-// Both steps identify the workspace explicitly, so concurrent cases writing into
-// the same projects tree cannot be confused for one another. The depth bound
-// keeps nested transcripts (e.g. qodercli's <sessionID>/subagents/) out.
+// Canonicalisation is lossy in both directions: because the CLIs collapse
+// punctuation too, workspaces whose paths differ only in punctuation (say
+// /w/a_b and /w/a-b) share one project directory. Candidates are therefore
+// ranked by how well they identify the workspace: transcripts recording it as
+// their working directory first, then transcripts recording none at all (formats
+// that omit it). A transcript recording a *different* directory is never used,
+// so a colliding workspace's session cannot be resumed or graded by mistake.
+//
+// The depth bound keeps nested transcripts (e.g. qodercli's
+// <sessionID>/subagents/) out.
 //
 // Shell constraints (some runtimes provide a minimal POSIX shell): no process
 // substitution, and no pipeline whose body is shell code — such a body runs in a
@@ -227,17 +234,30 @@ func buildSessionLookupScriptWithPrinter(lookup agentSessionLookup, printBest st
 root="%s"; [ -d "$root" ] || exit 0
 ws=$(printenv %s); wskey=$(printenv %s); [ -n "$wskey" ] || exit 0
 tmp=$(mktemp) || exit 0; list=$(mktemp) || exit 0; trap 'rm -f "$tmp" "$list"' 0
+keep_recording_ws() {
+  : >"$tmp"
+  while IFS= read -r c || [ -n "$c" ]; do
+    if head -c 65536 "$c" 2>/dev/null | grep -qF "\"$ws\""; then printf '%%s\n' "$c" >>"$tmp"; fi
+  done <"$1"
+}
+add_recording_no_cwd() {
+  while IFS= read -r c || [ -n "$c" ]; do
+    if ! head -c 65536 "$c" 2>/dev/null | grep -qE '"cwd"[[:space:]]*:|"workspace-directories"'; then printf '%%s\n' "$c" >>"$tmp"; fi
+  done <"$1"
+}
 find "$root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null >"$tmp" || true
 awk -v key="$wskey" '{n=$0; sub(/.*\//,"",n); gsub(/[^a-zA-Z0-9]/,"-",n); if (n==key) print}' "$tmp" >"$list" || true
 : >"$tmp"
 while IFS= read -r d || [ -n "$d" ]; do
   find "$d" -maxdepth %d -type f -name "*.jsonl"%s 2>/dev/null >>"$tmp" || true
 done <"$list"
-if [ ! -s "$tmp" ] && [ -n "$ws" ]; then
+if [ -s "$tmp" ]; then
+  cp "$tmp" "$list"
+  keep_recording_ws "$list"
+  [ -s "$tmp" ] || add_recording_no_cwd "$list"
+elif [ -n "$ws" ]; then
   find "$root" -maxdepth %d -type f -name "*.jsonl"%s 2>/dev/null >"$list" || true
-  while IFS= read -r c || [ -n "$c" ]; do
-    if head -c 65536 "$c" 2>/dev/null | grep -qF "\"$ws\""; then printf '%%s\n' "$c" >>"$tmp"; fi
-  done <"$list"
+  keep_recording_ws "$list"
 fi
 best=; ts=-1
 while IFS= read -r p || [ -n "$p" ]; do

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -172,12 +173,20 @@ func canonicalWorkspaceKey(workspace string) string {
 // matched in the escaped form it is actually written in ("C:\\Users\\..."), and
 // the key is part of the fragment, so a path that merely appears somewhere in the
 // conversation — a tool argument, say — is not mistaken for recorded identity.
+//
+// HTML escaping is disabled to match the producer: the CLIs are JavaScript
+// programs, and JSON.stringify writes "&", "<" and ">" literally where Go's
+// default encoder emits \u0026, \u003c and \u003e. A path containing any of them
+// would otherwise never match. (Go still escapes U+2028/U+2029 where JavaScript
+// does not; those are line separators and not a realistic path character.)
 func workspaceCwdMarkers(workspace string) []string {
-	encoded, err := json.Marshal(workspace)
-	if err != nil {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(workspace); err != nil {
 		return nil
 	}
-	quoted := string(encoded)
+	quoted := strings.TrimRight(buf.String(), "\n")
 
 	markers := make([]string, 0, 4)
 	for _, key := range []string{`"cwd":`, `"directories":[`} {
@@ -197,10 +206,26 @@ func extractSessionIDFromPath(sessionPath string) string {
 	return base
 }
 
+// pathComparison captures how paths are compared on the target platform: POSIX
+// paths are case-sensitive, Windows paths are not, and the same directory may
+// reach us spelled differently from how the CLI recorded it.
+type pathComparison struct {
+	// awkNameMatch is the awk condition comparing a canonicalised directory name
+	// (n) against the workspace key (key).
+	awkNameMatch string
+	// grepFlags selects fixed-string matching of the recorded-cwd markers.
+	grepFlags string
+}
+
+var (
+	caseSensitivePaths   = pathComparison{awkNameMatch: "n==key", grepFlags: "-qFf"}
+	caseInsensitivePaths = pathComparison{awkNameMatch: "tolower(n)==tolower(key)", grepFlags: "-qiFf"}
+)
+
 // buildSessionLookupScript renders the shared shell snippet that picks the
 // newest *.jsonl under the configured root.
 func buildSessionLookupScript(lookup agentSessionLookup) string {
-	return buildSessionLookupScriptWithPrinter(lookup, `printf %s "$best"`)
+	return buildSessionLookupScriptWithPrinter(lookup, `printf %s "$best"`, caseSensitivePaths)
 }
 
 func buildWindowsSessionLookupScript(lookup agentSessionLookup) string {
@@ -210,6 +235,7 @@ func buildWindowsSessionLookupScript(lookup agentSessionLookup) string {
 	return buildSessionLookupScriptWithPrinter(
 		lookup,
 		`if [ -n "$best" ]; then cygpath -w "$best" 2>/dev/null || printf %s "$best"; fi`,
+		caseInsensitivePaths,
 	)
 }
 
@@ -246,6 +272,11 @@ func buildWindowsSessionLookupScript(lookup agentSessionLookup) string {
 // `--session-id`, and a session_id field under `--output-format json`), which is a
 // change to how every engine is invoked and is tracked separately.
 //
+// Path comparison follows the platform: POSIX paths are case-sensitive, while on
+// Windows the same directory may be spelled with different case by the runtime
+// and by the CLI, so both the directory match and the recorded working directory
+// are folded there.
+//
 // The depth bound keeps nested transcripts (e.g. qodercli's
 // <sessionID>/subagents/) out.
 //
@@ -254,7 +285,7 @@ func buildWindowsSessionLookupScript(lookup agentSessionLookup) string {
 // subshell, and a subshell exiting can fire the EXIT trap and delete the temp
 // files the outer script still needs. Candidate lists therefore go through temp
 // files that plain `while ... done <file` loops read back.
-func buildSessionLookupScriptWithPrinter(lookup agentSessionLookup, printBest string) string {
+func buildSessionLookupScriptWithPrinter(lookup agentSessionLookup, printBest string, paths pathComparison) string {
 	extra := ""
 	if lookup.findExtra != "" {
 		extra = " " + lookup.findExtra
@@ -277,7 +308,7 @@ keep_recording_ws() {
   : >"$tmp"
   [ -s "$marks" ] || return 0
   while IFS= read -r c || [ -n "$c" ]; do
-    if head -c 65536 "$c" 2>/dev/null | grep -qFf "$marks"; then printf '%%s\n' "$c" >>"$tmp"; fi
+    if head -c 65536 "$c" 2>/dev/null | grep %s "$marks"; then printf '%%s\n' "$c" >>"$tmp"; fi
   done <"$1"
 }
 any_records_cwd() {
@@ -287,7 +318,7 @@ any_records_cwd() {
   return 1
 }
 find "$root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null >"$tmp" || true
-awk -v key="$wskey" '{n=$0; sub(/.*\//,"",n); gsub(/[^a-zA-Z0-9]/,"-",n); if (n==key) print}' "$tmp" >"$list" || true
+awk -v key="$wskey" '{n=$0; sub(/.*\//,"",n); gsub(/[^a-zA-Z0-9]/,"-",n); if (%s) print}' "$tmp" >"$list" || true
 : >"$tmp"
 while IFS= read -r d || [ -n "$d" ]; do
   find "$d" -maxdepth %d -type f -name "*.jsonl"%s 2>/dev/null >>"$tmp" || true
@@ -311,6 +342,8 @@ done <"$tmp"
 		lookup.projectsRootTmpl,
 		envSessionWorkspace, envSessionWorkspaceKey,
 		envSessionCwdMarkers,
+		paths.grepFlags,
+		paths.awkNameMatch,
 		sessionDepth, extra,
 		sessionDepth+1, extra,
 		printBest)

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -21,7 +21,14 @@ import (
 // noise that hides the real timeout.
 const sessionCleanupTimeout = 30 * time.Second
 
-var windowsWorkspaceKeyInvalidChars = regexp.MustCompile(`[^A-Za-z0-9_-]`)
+var nonAlphanumeric = regexp.MustCompile(`[^A-Za-z0-9]`)
+
+const (
+	// envSessionWorkspace carries the workspace path as the CLI sees it.
+	envSessionWorkspace = "SKILL_UP_SESSION_WS"
+	// envSessionWorkspaceKey carries the canonical comparison form of that path.
+	envSessionWorkspaceKey = "SKILL_UP_SESSION_WSKEY"
+)
 
 // sessionCleanupContext derives a context for post-run session-file
 // persistence, lookup and download. It detaches from cancellation of the
@@ -72,39 +79,46 @@ func withDownloadedSession(
 }
 
 // agentSessionLookup parametrises the per-agent project-tree lookup so that
-// claude-code / qoder / future CLIs can share the same shell script.
+// claude-code / qoder / qwen / future CLIs can share the same shell script.
 type agentSessionLookup struct {
-	// envVar is the environment variable name used inside the runtime to pass
-	// the workspace key (e.g. SKILL_UP_CLAUDE_WSKEY).
-	envVar string
-	// rootTmpl is the shell-expanded root directory expression, referencing
-	// $home and the envVar (e.g. "$home/.claude/projects/$SKILL_UP_CLAUDE_WSKEY").
-	rootTmpl string
+	// projectsRootTmpl is the shell-expanded directory that holds one
+	// subdirectory per workspace (e.g. "$home/.claude/projects").
+	projectsRootTmpl string
+	// sessionDepth bounds how deep below a workspace directory a session file
+	// may live: 1 when session files sit directly inside it (claude, qoder), 2
+	// for layouts with one intermediate directory (qwen's "chats"). It keeps
+	// unrelated transcripts out of the result — qodercli stores sub-agent
+	// transcripts in <sessionID>/subagents/, which are neither resumable
+	// sessions nor this run's conversation.
+	sessionDepth int
 	// findExtra appends extra `find` predicates such as exclusion patterns.
 	// Empty string means no extra predicates.
 	findExtra string
 }
 
-// findAgentSessionJSONL resolves the newest *.jsonl session file under the
-// agent-specific projects tree for the runtime's workspace. HOME and the tree
-// are read only inside the runtime via Exec to preserve runtime isolation.
+// findAgentSessionJSONL resolves the newest *.jsonl session file that belongs to
+// the runtime's workspace. HOME and the tree are read only inside the runtime via
+// Exec to preserve runtime isolation.
 //
-// Shell logic (cannot use process substitution / set -e in some runtimes):
-//
-//	tmp=$(mktemp); find ... >"$tmp"; while read -r p; do pick newest mtime; done <"$tmp"
+// The workspace directory is identified without reproducing any CLI's naming
+// rule: see buildSessionLookupScriptWithPrinter.
 func findAgentSessionJSONL(ctx context.Context, rt Runtime, lookup agentSessionLookup) string {
-	workspaceKey := workspaceKeyForRuntime(rt)
+	workspace := workspaceForRuntime(rt)
+	workspaceKey := canonicalWorkspaceKey(workspace)
 	if workspaceKey == "" {
 		return ""
 	}
-	logging.DebugContextf(ctx, "agent session lookup: workspace=%q key=%q", rt.Workspace(), workspaceKey)
+	logging.DebugContextf(ctx, "agent session lookup: workspace=%q key=%q", workspace, workspaceKey)
 
 	script := buildSessionLookupScript(lookup)
 	if rt.Shell().GOOS == platform.GOOSWindows {
 		script = buildWindowsSessionLookupScript(lookup)
 	}
 	result, err := rt.Exec(ctx, script, ExecOptions{
-		Env: map[string]string{lookup.envVar: workspaceKey},
+		Env: map[string]string{
+			envSessionWorkspace:    workspace,
+			envSessionWorkspaceKey: workspaceKey,
+		},
 	})
 	if err != nil || result.ExitCode != 0 {
 		logging.DebugContextf(ctx, "agent session lookup failed: err=%v exit_code=%d", err, result.ExitCode)
@@ -119,19 +133,33 @@ func findAgentSessionJSONL(ctx context.Context, rt Runtime, lookup agentSessionL
 	return sessionPath
 }
 
-// workspaceKeyForRuntime computes the projects-tree subdirectory name for the
-// runtime's workspace path. Claude derives Windows keys from the cwd spelling
-// it receives, so avoid expanding 8.3 short names to their long form before
-// sanitizing them.
-func workspaceKeyForRuntime(rt Runtime) string {
+// workspaceForRuntime returns the workspace path as the agent CLI sees it.
+// POSIX CLIs learn their cwd from getcwd, which reports the physical path, so
+// symlinks are resolved first. On Windows the spelling the CLI receives is kept
+// as-is (8.3 short names are not expanded).
+func workspaceForRuntime(rt Runtime) string {
 	workspace := rt.Workspace()
 	if rt.Shell().GOOS == platform.GOOSWindows {
-		return windowsWorkspaceKeyInvalidChars.ReplaceAllString(workspace, "-")
+		return workspace
 	}
 	if realPath, err := filepath.EvalSymlinks(workspace); err == nil {
 		workspace = realPath
 	}
-	return strings.ReplaceAll(workspace, "/", "-")
+	return workspace
+}
+
+// canonicalWorkspaceKey maps a workspace path to a comparison form: every
+// non-alphanumeric character becomes "-".
+//
+// This is deliberately *not* an attempt to reproduce how a CLI names the
+// directory it stores sessions in. Those rules are unversioned implementation
+// details that differ per CLI and have changed between releases (qodercli once
+// preserved spaces, today it replaces them). Instead, the same canonical form is
+// applied to both sides of the comparison in the lookup script, so any rule that
+// derives the directory name by substituting separators and special characters —
+// with "-", "_", or anything else non-alphanumeric — still matches.
+func canonicalWorkspaceKey(workspace string) string {
+	return nonAlphanumeric.ReplaceAllString(workspace, "-")
 }
 
 // extractSessionIDFromPath extracts a session identifier from a session JSONL
@@ -161,15 +189,56 @@ func buildWindowsSessionLookupScript(lookup agentSessionLookup) string {
 	)
 }
 
+// buildSessionLookupScriptWithPrinter renders the shared lookup script.
+//
+// The workspace directory is located without reproducing any CLI's naming rule:
+//
+//  1. Canonical name match: each directory name under the projects root and the
+//     workspace path are both reduced to the same form (every non-alphanumeric
+//     character becomes "-") before comparing, in a single awk pass. Any rule
+//     that substitutes separators and special characters matches, whatever it
+//     substitutes them with, so a CLI release changing its rule cannot silently
+//     break resume.
+//  2. Recorded-cwd match, used only when step 1 finds nothing: pick transcripts
+//     that record this workspace as their working directory. This covers names
+//     that cannot be derived from the path at all, such as the truncated and
+//     hashed names the CLIs fall back to for very long paths.
+//
+// Both steps identify the workspace explicitly, so concurrent cases writing into
+// the same projects tree cannot be confused for one another. The depth bound
+// keeps nested transcripts (e.g. qodercli's <sessionID>/subagents/) out.
+//
+// Shell constraints (some runtimes provide a minimal POSIX shell): no process
+// substitution, and no pipeline whose body is shell code — such a body runs in a
+// subshell, and a subshell exiting can fire the EXIT trap and delete the temp
+// files the outer script still needs. Candidate lists therefore go through temp
+// files that plain `while ... done <file` loops read back.
 func buildSessionLookupScriptWithPrinter(lookup agentSessionLookup, printBest string) string {
 	extra := ""
 	if lookup.findExtra != "" {
 		extra = " " + lookup.findExtra
 	}
+	sessionDepth := lookup.sessionDepth
+	if sessionDepth <= 0 {
+		sessionDepth = 1
+	}
+
 	return fmt.Sprintf(`home=$(printenv HOME); [ -n "$home" ] || exit 0
 root="%s"; [ -d "$root" ] || exit 0
-tmp=$(mktemp) || exit 0; trap 'rm -f "$tmp"' 0
-find "$root" -type f -name "*.jsonl"%s 2>/dev/null >"$tmp" || true
+ws=$(printenv %s); wskey=$(printenv %s); [ -n "$wskey" ] || exit 0
+tmp=$(mktemp) || exit 0; list=$(mktemp) || exit 0; trap 'rm -f "$tmp" "$list"' 0
+find "$root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null >"$tmp" || true
+awk -v key="$wskey" '{n=$0; sub(/.*\//,"",n); gsub(/[^a-zA-Z0-9]/,"-",n); if (n==key) print}' "$tmp" >"$list" || true
+: >"$tmp"
+while IFS= read -r d || [ -n "$d" ]; do
+  find "$d" -maxdepth %d -type f -name "*.jsonl"%s 2>/dev/null >>"$tmp" || true
+done <"$list"
+if [ ! -s "$tmp" ] && [ -n "$ws" ]; then
+  find "$root" -maxdepth %d -type f -name "*.jsonl"%s 2>/dev/null >"$list" || true
+  while IFS= read -r c || [ -n "$c" ]; do
+    if head -c 65536 "$c" 2>/dev/null | grep -qF "\"$ws\""; then printf '%%s\n' "$c" >>"$tmp"; fi
+  done <"$list"
+fi
 best=; ts=-1
 while IFS= read -r p || [ -n "$p" ]; do
   [ -f "$p" ] || continue
@@ -177,5 +246,10 @@ while IFS= read -r p || [ -n "$p" ]; do
   case $m in ''|*[!0-9]*) continue;; esac
   if [ "$ts" -eq -1 ] || [ "$m" -gt "$ts" ]; then ts=$m; best=$p; fi
 done <"$tmp"
-%s`, lookup.rootTmpl, extra, printBest)
+%s`,
+		lookup.projectsRootTmpl,
+		envSessionWorkspace, envSessionWorkspaceKey,
+		sessionDepth, extra,
+		sessionDepth+1, extra,
+		printBest)
 }

--- a/internal/agent/session_lookup.go
+++ b/internal/agent/session_lookup.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -28,6 +29,9 @@ const (
 	envSessionWorkspace = "SKILL_UP_SESSION_WS"
 	// envSessionWorkspaceKey carries the canonical comparison form of that path.
 	envSessionWorkspaceKey = "SKILL_UP_SESSION_WSKEY"
+	// envSessionCwdMarkers carries the newline-separated JSON fragments that
+	// identify a transcript as belonging to the workspace.
+	envSessionCwdMarkers = "SKILL_UP_SESSION_CWD_MARKERS"
 )
 
 // sessionCleanupContext derives a context for post-run session-file
@@ -118,6 +122,7 @@ func findAgentSessionJSONL(ctx context.Context, rt Runtime, lookup agentSessionL
 		Env: map[string]string{
 			envSessionWorkspace:    workspace,
 			envSessionWorkspaceKey: workspaceKey,
+			envSessionCwdMarkers:   strings.Join(workspaceCwdMarkers(workspace), "\n"),
 		},
 	})
 	if err != nil || result.ExitCode != 0 {
@@ -162,6 +167,25 @@ func canonicalWorkspaceKey(workspace string) string {
 	return nonAlphanumeric.ReplaceAllString(workspace, "-")
 }
 
+// workspaceCwdMarkers renders the JSON fragments that mark a transcript as this
+// workspace's. The path is JSON-encoded, so a Windows working directory is
+// matched in the escaped form it is actually written in ("C:\\Users\\..."), and
+// the key is part of the fragment, so a path that merely appears somewhere in the
+// conversation — a tool argument, say — is not mistaken for recorded identity.
+func workspaceCwdMarkers(workspace string) []string {
+	encoded, err := json.Marshal(workspace)
+	if err != nil {
+		return nil
+	}
+	quoted := string(encoded)
+
+	markers := make([]string, 0, 4)
+	for _, key := range []string{`"cwd":`, `"directories":[`} {
+		markers = append(markers, key+quoted, key+" "+quoted)
+	}
+	return markers
+}
+
 // extractSessionIDFromPath extracts a session identifier from a session JSONL
 // file path. It strips the directory and .jsonl extension, returning the bare
 // filename which agents use as the session identifier for resume.
@@ -192,25 +216,35 @@ func buildWindowsSessionLookupScript(lookup agentSessionLookup) string {
 // buildSessionLookupScriptWithPrinter renders the shared lookup script.
 //
 // The workspace directory is located without reproducing any CLI's naming rule:
+// each directory name under the projects root and the workspace path are both
+// reduced to the same form (every non-alphanumeric character becomes "-") before
+// comparing, in a single awk pass. Any rule that substitutes separators and
+// special characters matches, whatever it substitutes them with, so a CLI release
+// changing its rule cannot silently break resume.
 //
-//  1. Canonical name match: each directory name under the projects root and the
-//     workspace path are both reduced to the same form (every non-alphanumeric
-//     character becomes "-") before comparing, in a single awk pass. Any rule
-//     that substitutes separators and special characters matches, whatever it
-//     substitutes them with, so a CLI release changing its rule cannot silently
-//     break resume.
-//  2. Recorded-cwd match, used only when step 1 finds nothing: pick transcripts
-//     that record this workspace as their working directory. This covers names
-//     that cannot be derived from the path at all, such as the truncated and
-//     hashed names the CLIs fall back to for very long paths.
+// That comparison alone cannot establish identity, because it is lossy in both
+// directions: the CLIs collapse punctuation too, so workspaces whose paths differ
+// only in punctuation (say /w/a_b and /w/a-b) are stored in one directory.
+// Candidates are therefore resolved against the working directory a transcript
+// records, matched as the JSON fragment it is actually written as (`"cwd":"..."`,
+// `"directories":["..."]`). Matching the encoded form keeps Windows paths
+// (`C:\\Users\\...`) working and prevents a path that merely appears in the
+// conversation, such as a tool argument, from being read as identity:
 //
-// Canonicalisation is lossy in both directions: because the CLIs collapse
-// punctuation too, workspaces whose paths differ only in punctuation (say
-// /w/a_b and /w/a-b) share one project directory. Candidates are therefore
-// ranked by how well they identify the workspace: transcripts recording it as
-// their working directory first, then transcripts recording none at all (formats
-// that omit it). A transcript recording a *different* directory is never used,
-// so a colliding workspace's session cannot be resumed or graded by mistake.
+//  1. transcripts recording this workspace are the answer;
+//  2. otherwise, if any candidate records a working directory at all, it belongs
+//     to a different workspace and the directory is provably shared — the lookup
+//     returns nothing, because reporting a lost session (which the evaluator
+//     warns about) beats resuming or grading another workspace's conversation;
+//  3. otherwise no candidate carries identity at all — qwen's chat JSONL never
+//     does, and neither did older CLI releases — so the directory match is the
+//     only signal available and the newest transcript is used.
+//
+// Step 3 leaves one residual case: two colliding workspaces whose transcripts all
+// omit identity are indistinguishable on disk. Resolving that requires taking the
+// session id from the CLI instead of the filesystem (qodercli offers
+// `--session-id`, and a session_id field under `--output-format json`), which is a
+// change to how every engine is invoked and is tracked separately.
 //
 // The depth bound keeps nested transcripts (e.g. qodercli's
 // <sessionID>/subagents/) out.
@@ -233,17 +267,24 @@ func buildSessionLookupScriptWithPrinter(lookup agentSessionLookup, printBest st
 	return fmt.Sprintf(`home=$(printenv HOME); [ -n "$home" ] || exit 0
 root="%s"; [ -d "$root" ] || exit 0
 ws=$(printenv %s); wskey=$(printenv %s); [ -n "$wskey" ] || exit 0
-tmp=$(mktemp) || exit 0; list=$(mktemp) || exit 0; trap 'rm -f "$tmp" "$list"' 0
+tmp=$(mktemp) || exit 0; list=$(mktemp) || exit 0; marks=$(mktemp) || exit 0
+trap 'rm -f "$tmp" "$list" "$marks"' 0
+printenv %s >"$marks" || true
+records_cwd() {
+  head -c 65536 "$1" 2>/dev/null | grep -qE '"cwd"[[:space:]]*:|"workspace-directories"'
+}
 keep_recording_ws() {
   : >"$tmp"
+  [ -s "$marks" ] || return 0
   while IFS= read -r c || [ -n "$c" ]; do
-    if head -c 65536 "$c" 2>/dev/null | grep -qF "\"$ws\""; then printf '%%s\n' "$c" >>"$tmp"; fi
+    if head -c 65536 "$c" 2>/dev/null | grep -qFf "$marks"; then printf '%%s\n' "$c" >>"$tmp"; fi
   done <"$1"
 }
-add_recording_no_cwd() {
+any_records_cwd() {
   while IFS= read -r c || [ -n "$c" ]; do
-    if ! head -c 65536 "$c" 2>/dev/null | grep -qE '"cwd"[[:space:]]*:|"workspace-directories"'; then printf '%%s\n' "$c" >>"$tmp"; fi
+    if records_cwd "$c"; then return 0; fi
   done <"$1"
+  return 1
 }
 find "$root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null >"$tmp" || true
 awk -v key="$wskey" '{n=$0; sub(/.*\//,"",n); gsub(/[^a-zA-Z0-9]/,"-",n); if (n==key) print}' "$tmp" >"$list" || true
@@ -254,8 +295,8 @@ done <"$list"
 if [ -s "$tmp" ]; then
   cp "$tmp" "$list"
   keep_recording_ws "$list"
-  [ -s "$tmp" ] || add_recording_no_cwd "$list"
-elif [ -n "$ws" ]; then
+  if [ ! -s "$tmp" ] && ! any_records_cwd "$list"; then cp "$list" "$tmp"; fi
+else
   find "$root" -maxdepth %d -type f -name "*.jsonl"%s 2>/dev/null >"$list" || true
   keep_recording_ws "$list"
 fi
@@ -269,6 +310,7 @@ done <"$tmp"
 %s`,
 		lookup.projectsRootTmpl,
 		envSessionWorkspace, envSessionWorkspaceKey,
+		envSessionCwdMarkers,
 		sessionDepth, extra,
 		sessionDepth+1, extra,
 		printBest)

--- a/internal/evaluator/multiturn.go
+++ b/internal/evaluator/multiturn.go
@@ -59,11 +59,15 @@ type multiTurnState struct {
 	sessionID    string
 	turnResults  []TurnResult
 	transcript   transcript.Transcript
-	inputTokens  int
-	outputTokens int
-	tokenBaseIn  int
-	tokenBaseOut int
-	durationMs   int64
+	// sessionTranscript is the transcript the previous turn returned. Engines
+	// that re-read the whole session file every turn return it again with the
+	// new turn appended, so this is what marks the boundary of the next turn.
+	sessionTranscript transcript.Transcript
+	inputTokens       int
+	outputTokens      int
+	tokenBaseIn       int
+	tokenBaseOut      int
+	durationMs        int64
 }
 
 // executeMultiTurn orchestrates multi-turn evaluation for cases with
@@ -109,16 +113,13 @@ func (e *defaultEvaluator) executeMultiTurn(
 		}
 
 		// Update state from the successful turn.
-		if sessionResult != nil && sessionResult.SessionID != "" {
-			state.sessionID = sessionResult.SessionID
-		}
 		lastSessionResult = sessionResult
-		sessionResult, cumulativeUsage := normalizeTurnSessionResult(sessionResult, turnNum)
-		if cumulativeUsage {
-			accumulateCumulativeMetrics(state, sessionResult)
-		} else {
-			accumulatePerTurnMetrics(state, sessionResult)
-		}
+		sessionResult = absorbTurnSession(ctx, state, sessionResult, turnSessionMeta{
+			caseID:     caseCfg.ID,
+			agentName:  runAgent.Name(),
+			turnNum:    turnNum,
+			totalTurns: len(turns),
+		})
 
 		// Build turn result.
 		tr := buildTurnResult(turnNum, content, sessionResult)
@@ -192,12 +193,60 @@ func buildTurnResult(turnNum int, content string, sessionResult *agent.SessionRe
 	return tr
 }
 
-func normalizeTurnSessionResult(sessionResult *agent.SessionResult, turnNum int) (*agent.SessionResult, bool) {
+// turnSessionMeta carries the identifiers needed to report on a turn's session.
+type turnSessionMeta struct {
+	caseID     string
+	agentName  string
+	turnNum    int
+	totalTurns int
+}
+
+// absorbTurnSession folds a completed turn's session result into the running
+// state: it tracks the resumable session id, isolates the transcript this turn
+// contributed, and accumulates duration and token usage. It returns the
+// turn-scoped session result.
+func absorbTurnSession(
+	ctx context.Context,
+	state *multiTurnState,
+	sessionResult *agent.SessionResult,
+	meta turnSessionMeta,
+) *agent.SessionResult {
+	switch {
+	case sessionResult != nil && sessionResult.SessionID != "":
+		state.sessionID = sessionResult.SessionID
+	case meta.turnNum < meta.totalTurns:
+		// Without a session id the next turn cannot resume this conversation and
+		// silently starts a fresh one, losing every earlier turn. The only visible
+		// symptom would be "the agent forgot the previous turn", which reads like a
+		// Skill or model problem rather than a broken session lookup.
+		logging.WarnContextf(
+			ctx,
+			"Evaluator: case %s turn %d: agent %s reported no session id; turn %d cannot resume and will start a new session, losing earlier context",
+			meta.caseID, meta.turnNum, meta.agentName, meta.turnNum+1,
+		)
+	}
+
+	var sessionTranscript transcript.Transcript
+	if sessionResult != nil {
+		sessionTranscript = sessionResult.Transcript
+	}
+	normalized, cumulativeUsage := normalizeTurnSessionResult(sessionResult, meta.turnNum, state.sessionTranscript)
+	state.sessionTranscript = sessionTranscript
+	if cumulativeUsage {
+		accumulateCumulativeMetrics(state, normalized)
+	} else {
+		accumulatePerTurnMetrics(state, normalized)
+	}
+
+	return normalized
+}
+
+func normalizeTurnSessionResult(sessionResult *agent.SessionResult, turnNum int, previous transcript.Transcript) (*agent.SessionResult, bool) {
 	if sessionResult == nil {
 		return nil, false
 	}
 	normalized := *sessionResult
-	turnTranscript, cumulative := transcriptForLogicalTurn(sessionResult.Transcript, turnNum)
+	turnTranscript, cumulative := transcriptForLogicalTurn(sessionResult.Transcript, previous, turnNum)
 	normalized.Transcript = turnTranscript
 	if len(turnTranscript) > 0 {
 		normalized.Turns = 1
@@ -205,25 +254,52 @@ func normalizeTurnSessionResult(sessionResult *agent.SessionResult, turnNum int)
 			normalized.FinalMessage = final
 		}
 	}
-	return &normalized, cumulative || sessionResult.Turns > 1
+	return &normalized, cumulative
 }
 
-func transcriptForLogicalTurn(trans transcript.Transcript, turnNum int) (transcript.Transcript, bool) {
-	if len(trans) == 0 {
+// transcriptForLogicalTurn isolates the messages one logical turn contributed.
+//
+// The built-in CLI engines re-read the whole session file after every turn, so a
+// turn is the tail appended after the transcript the previous turn returned;
+// engines that already scope their transcript to a single turn (custom engines,
+// stubs) return it unchanged. Parsed turn numbers cannot be used for this: a
+// session file records tool results and injected Skill bodies as "user" events,
+// so those numbers advance several times inside one logical turn.
+//
+// The returned messages are re-stamped with the logical turn number, which is
+// what per-turn judge rules and reports address.
+func transcriptForLogicalTurn(current, previous transcript.Transcript, turnNum int) (transcript.Transcript, bool) {
+	if len(current) == 0 {
 		return nil, false
 	}
 
-	matching := trans.MessagesForTurn(turnNum)
-	if len(matching) > 0 {
-		return matching, len(matching) < len(trans)
+	tail := current
+	cumulative := false
+	if len(previous) > 0 && len(current) >= len(previous) && transcriptHasPrefix(current, previous) {
+		tail = current[len(previous):]
+		cumulative = true
 	}
 
-	normalized := make(transcript.Transcript, len(trans))
-	copy(normalized, trans)
-	for i := range normalized {
-		normalized[i].Turn = turnNum
+	stamped := make(transcript.Transcript, len(tail))
+	copy(stamped, tail)
+	for i := range stamped {
+		stamped[i].Turn = turnNum
 	}
-	return normalized, false
+	return stamped, cumulative
+}
+
+// transcriptHasPrefix reports whether t starts with prefix, comparing the fields
+// that survive a session-file round trip.
+func transcriptHasPrefix(t, prefix transcript.Transcript) bool {
+	if len(prefix) > len(t) {
+		return false
+	}
+	for i := range prefix {
+		if t[i].Role != prefix[i].Role || t[i].Content != prefix[i].Content {
+			return false
+		}
+	}
+	return true
 }
 
 // substituteTemplate replaces {{variable}} placeholders in content with captured values.

--- a/internal/evaluator/multiturn_test.go
+++ b/internal/evaluator/multiturn_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/alibaba/skill-up/internal/agent"
@@ -579,6 +580,180 @@ func TestExecuteMultiTurn_NormalizesCumulativeSessionResults(t *testing.T) {
 	calls := turnResults[1].Transcript.ToolCalls()
 	if len(calls) != 1 || calls[0].ToolCall.Name != "second_tool" {
 		t.Fatalf("turn 2 tool calls = %#v, want only second_tool", calls)
+	}
+}
+
+const (
+	realisticFirstAnswer  = "tier 1.1 applies, see alidocs.dingtalk.com/i/p/tiering"
+	realisticSecondAnswer = "sorry for the confusion, escalating to the support desk"
+)
+
+// realisticSessionTranscripts returns the transcripts a built-in CLI engine hands
+// back after turn 1 and after turn 2: the whole session file each time, with turn
+// numbers that count transcript events rather than logical turns.
+func realisticSessionTranscripts() (afterTurn1, afterTurn2 transcript.Transcript) {
+	afterTurn1 = transcript.Transcript{
+		{Role: transcript.RoleUser, Content: "explain data tiering", Turn: 1},
+		{Role: transcript.RoleAssistant, Content: "let me look it up", Turn: 1},
+		{Role: transcript.RoleToolCall, ToolCall: &transcript.ToolCallInfo{Name: "Skill"}, Turn: 1},
+		// The tool result is a "user" event in the session file, so the parsed turn
+		// counter increments here even though the turn is not over.
+		{Role: transcript.RoleToolResult, ToolResult: &transcript.ToolResultInfo{CallID: "t1"}, Turn: 2},
+		{Role: transcript.RoleAssistant, Content: realisticFirstAnswer, Turn: 2},
+	}
+	afterTurn2 = make(transcript.Transcript, 0, len(afterTurn1)+2)
+	afterTurn2 = append(afterTurn2, afterTurn1...)
+	afterTurn2 = append(afterTurn2,
+		transcript.Message{Role: transcript.RoleUser, Content: "you did not answer my question", Turn: 3},
+		transcript.Message{Role: transcript.RoleAssistant, Content: realisticSecondAnswer, Turn: 3},
+	)
+
+	return afterTurn1, afterTurn2
+}
+
+func assertTurnStamps(t *testing.T, msgs transcript.Transcript, wantTurn int) {
+	t.Helper()
+	for i, msg := range msgs {
+		if msg.Turn != wantTurn {
+			t.Errorf("message %d carries turn %d, want logical turn %d", i, msg.Turn, wantTurn)
+		}
+	}
+}
+
+// TestExecuteMultiTurn_SplitsRealisticCumulativeTranscript models what the
+// built-in CLI engines actually hand back: every turn re-reads the whole
+// session file, and the parsed turn numbers count transcript *events* rather
+// than logical turns — tool results and injected Skill bodies arrive as "user"
+// events and bump the counter mid-answer. A logical turn therefore cannot be
+// recovered by filtering on those numbers; it is the tail appended since the
+// previous turn.
+//
+// With event-numbered turns, filtering yields turn 1's preamble ("let me look
+// it up") as turn 1's answer, and turn 1's real answer as turn 2's answer.
+func TestExecuteMultiTurn_SplitsRealisticCumulativeTranscript(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{workspace: t.TempDir()}
+	afterTurn1, afterTurn2 := realisticSessionTranscripts()
+	firstAnswer, secondAnswer := realisticFirstAnswer, realisticSecondAnswer
+
+	results := []*agent.SessionResult{
+		{
+			FinalMessage: firstAnswer,
+			SessionID:    "sess-1",
+			Turns:        2,
+			InputTokens:  100,
+			OutputTokens: 10,
+			Transcript:   afterTurn1,
+		},
+		{
+			FinalMessage: secondAnswer,
+			SessionID:    "sess-1",
+			Turns:        3,
+			InputTokens:  260,
+			OutputTokens: 24,
+			Transcript:   afterTurn2,
+		},
+	}
+	call := 0
+	ag := &mockResumerAgent{
+		mockAgent: mockAgent{name: "test-resumer"},
+		runTurnFunc: func(_ context.Context, _ runtime.Runtime, _ agent.ExecOptions, _ transcript.Message, _ string) (*agent.SessionResult, error) {
+			result := results[call]
+			call++
+			return result, nil
+		},
+	}
+
+	caseCfg := &config.CaseConfig{
+		ID: "realistic-cumulative",
+		Input: config.Input{
+			Turns: []config.Turn{
+				{Role: "user", Content: "explain data tiering"},
+				{Role: "user", Content: "you did not answer my question"},
+			},
+		},
+	}
+
+	e := newTestEvaluator(EvalOptions{Agent: ag, EvalCfg: &config.EvalConfig{}})
+	turnResults, aggResult, err := e.executeMultiTurn(context.Background(), rt, caseCfg, ag, agent.ExecOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(turnResults) != 2 {
+		t.Fatalf("turn results = %d, want 2", len(turnResults))
+	}
+	if got := turnResults[0].Response; got != firstAnswer {
+		t.Errorf("turn 1 response = %q, want the answer that closed turn 1 (%q)", got, firstAnswer)
+	}
+	if got := turnResults[1].Response; got != secondAnswer {
+		t.Errorf("turn 2 response = %q, want the answer that closed turn 2 (%q)", got, secondAnswer)
+	}
+	if got := len(turnResults[0].Transcript); got != len(afterTurn1) {
+		t.Errorf("turn 1 transcript length = %d, want %d", got, len(afterTurn1))
+	}
+	if got := len(turnResults[1].Transcript); got != 2 {
+		t.Errorf("turn 2 transcript length = %d, want only the 2 messages appended by turn 2", got)
+	}
+	assertTurnStamps(t, turnResults[0].Transcript, 1)
+	assertTurnStamps(t, turnResults[1].Transcript, 2)
+	if got := aggResult.InputTokens; got != 260 {
+		t.Errorf("aggregate input tokens = %d, want cumulative high-water 260", got)
+	}
+	if got := aggResult.OutputTokens; got != 24 {
+		t.Errorf("aggregate output tokens = %d, want cumulative high-water 24", got)
+	}
+	if got := aggResult.FinalMessage; got != secondAnswer {
+		t.Errorf("aggregate final message = %q, want %q", got, secondAnswer)
+	}
+}
+
+// TestExecuteMultiTurn_WarnsWhenSessionResumeUnavailable pins the observability
+// contract for the degradation itself: when an engine cannot report a session
+// ID, later turns silently start brand-new sessions and lose all context. That
+// must be surfaced, otherwise the only visible symptom is "the model forgot the
+// previous turn", which reads like a Skill or model problem.
+func TestExecuteMultiTurn_WarnsWhenSessionResumeUnavailable(t *testing.T) {
+	var seenSessionIDs []string
+	ag := &mockResumerAgent{
+		mockAgent: mockAgent{name: "test-resumer"},
+		runTurnFunc: func(_ context.Context, _ runtime.Runtime, _ agent.ExecOptions, msg transcript.Message, sessionID string) (*agent.SessionResult, error) {
+			seenSessionIDs = append(seenSessionIDs, sessionID)
+			return &agent.SessionResult{
+				FinalMessage: fmt.Sprintf("answer %d", msg.Turn),
+				SessionID:    "", // engine could not resolve its own session
+				Turns:        1,
+			}, nil
+		},
+	}
+
+	caseCfg := &config.CaseConfig{
+		ID: "resume-unavailable",
+		Input: config.Input{
+			Turns: []config.Turn{
+				{Role: "user", Content: "first"},
+				{Role: "user", Content: "second"},
+			},
+		},
+	}
+
+	e := newTestEvaluator(EvalOptions{Agent: ag, EvalCfg: &config.EvalConfig{}})
+	rt := &mockRuntime{workspace: t.TempDir()}
+
+	logs := captureStdout(t, func() {
+		if _, _, err := e.executeMultiTurn(context.Background(), rt, caseCfg, ag, agent.ExecOptions{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if len(seenSessionIDs) != 2 || seenSessionIDs[1] != "" {
+		t.Fatalf("session IDs handed to RunTurn = %#v, want turn 2 to receive an empty ID", seenSessionIDs)
+	}
+	if !strings.Contains(logs, "WARNING") {
+		t.Errorf("expected a warning about the lost session, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "resume-unavailable") || !strings.Contains(strings.ToLower(logs), "session") {
+		t.Errorf("expected the warning to name the case and the session problem, got logs:\n%s", logs)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -52,7 +52,11 @@ func mergeEnvMaps(persistentEnv, callEnv map[string]string) map[string]string {
 	if len(persistentEnv) == 0 && len(callEnv) == 0 {
 		return nil
 	}
-	env := make(map[string]string, len(persistentEnv)+len(callEnv))
+	// The capacity hint deliberately avoids summing both lengths: the sum is an
+	// unbounded arithmetic expression feeding an allocation, which static analysis
+	// flags as a possible overflow. Keys overlap anyway, so the larger input is a
+	// sound lower bound and the map grows from there if needed.
+	env := make(map[string]string, max(len(persistentEnv), len(callEnv)))
 	maps.Copy(env, persistentEnv)
 	maps.Copy(env, callEnv)
 	return env


### PR DESCRIPTION
## Summary

Multi-turn evaluation never actually resumed the CLI session it started, so every
turn after the first ran in a brand-new conversation and lost all earlier
context. Turn responses were also mis-attributed: a turn could be graded against
a fragment of the previous turn, or against a `[tool: Name]` placeholder.

Reported from a real eval where turn 2 asserts on the agent remembering turn 1;
the case had to be commented out of its eval because no released version could
run it on macOS.

Root causes, all independent:

1. The session lookup rebuilt the project-directory name a CLI derives from the
   workspace path, replacing only `/`. The CLIs replace **every**
   non-alphanumeric character, so any workspace path containing `_`, `.`, a space
   or a non-ASCII character resolved to a directory that does not exist. macOS
   default `TMPDIR` paths commonly contain an underscore, which is why this
   reproduced on macOS and not on Linux `/tmp`. Without a resolved session file
   there is no session id, and `RunTurn` silently falls back to starting a new
   session — so `-r` was never sent.
2. The lookup searched the project tree unbounded and picked the newest
   `*.jsonl`. A Skill or Task call writes `<sessionID>/subagents/agent-*.jsonl`
   into that same tree; selecting one yields a file name that is not a resumable
   session id.
3. Turn boundaries were recovered by filtering on the turn numbers the session
   parser assigns, but those count transcript *events* — tool results and
   injected Skill bodies are recorded as `user` events, so one logical turn
   advances them several times.
4. Losing the session id was silent, so the only visible symptom was "the agent
   forgot the previous turn", which reads like a Skill or model problem.

## Related issues

<!-- none filed; reported directly -->

## Changes

- `internal/agent/session_lookup.go`: stop reconstructing any CLI's naming rule.
  Directory names and the workspace path are compared in a shared canonical form,
  which is invariant to *which* separator a CLI substitutes, and a recorded
  working directory serves as fallback for names that cannot be derived from the
  path at all (e.g. the truncated-plus-hashed names used for long paths). Both
  steps identify the workspace explicitly, so `cases.parallelism > 1` cannot
  cross-match.
- `internal/agent/{qodercli,claude_code,qwen_code}.go`: declare the projects root
  and the depth session files live at, keeping nested transcripts out of scope.
- `internal/evaluator/multiturn.go`: a turn is the transcript appended since the
  previous turn, re-stamped with the logical turn number; warn when an engine
  reports no session id and further turns remain.
- `internal/agent/claude_code.go`: assistant messages carry only assistant text.
  Tool calls remain as their own `tool_call` entries.
- `e2e/testdata/multiturn-session/` + `e2e/multiturn_session_test.go`: a mock that
  writes real session transcripts, so the lookup and parsing path is covered end
  to end.
- `CHANGELOG.md`: entries under `Unreleased`.

## Test plan

- [x] `make test` passes (19/19 packages, `-race`)
- [x] `make verify` passes (fmt + vet + revive + golangci-lint, 0 issues)
- [x] `make e2e` passes, including the new `TestPipeline_MultiTurnSessionResume`
- [x] Manual testing steps:
  - Reproduced against the reporter's real eval with `v0.8.0` and with this
    branch, same conditions (`TMPDIR` containing an underscore, real `qodercli`,
    a PATH shim logging the argv):

    | Signal | v0.8.0 | this branch |
    | --- | --- | --- |
    | turn 2 command line | `-p …` (no `-r`) | `-r 7a08b76a-… -p …` |
    | session files for the run | 2 files, one turn each | 1 file, both turns |
    | turn 2 answer | no reference to turn 1 | carries turn 1's topic |
    | turn 1 response source | stdout fallback (lookup failed) | parsed transcript |
    | broken resume visible? | nothing in the log | n/a (resume works) |
  - The reporter confirmed the fix on their own machine, with the knowledge-base
    sub-Skill installed and the default `TMPDIR`.

## Notes for reviewers

- **Behaviour change worth calling out**: a tool call no longer appears as
  `[tool: Name]` inside assistant content. Evals asserting on that text need to
  assert on tool rules instead. One in-tree test (`ParseMCPToolCalls`) asserted
  the message count that included such a placeholder and was updated; its MCP
  assertions are unchanged.
- One pre-existing test expectation encoded the bug (`posix colon remains valid`
  asserted that `:` is *not* replaced) and was corrected.
- The Windows branch of the old key derivation is gone; the canonical comparison
  covers the cases it was added for (`C:\…` and 8.3 short names) and its
  expectations are unchanged. Not exercised on real Windows.
- Deliberately **not** included: switching the run command to `--session-id` /
  `--output-format json`, which would remove the disk lookup entirely. That is a
  larger change to how every engine is invoked and belongs in its own PR.
