### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-12
+
 ### Fixed
 - Multi-turn evaluation now resumes the CLI session it started. Session
   transcripts are located without reconstructing a CLI's project-directory
@@ -475,6 +477,7 @@ The `v0.5.0` release tag is available at
   project and delivers the end-to-end capability to declare eval environments,
   run cases and emit structured reports as described in [README.md](README.md).
 
+[0.9.0]: https://github.com/alibaba/skill-up/releases/tag/v0.9.0
 [0.8.0]: https://github.com/alibaba/skill-up/releases/tag/v0.8.0
 [0.7.0]: https://github.com/alibaba/skill-up/releases/tag/v0.7.0
 [0.6.0]: https://github.com/alibaba/skill-up/releases/tag/v0.6.0


### PR DESCRIPTION
## Summary

Prepare v0.9.0 release.

## Changes

- Fix multi-turn evaluation session resume: transcripts are now located by matching the CLI's own cwd markers (JSON-encoded, HTML-unescape-safe, case-aware) rather than reconstructing the project-directory naming rule.
- Fix CodeQL `go/allocation-size-overflow` in `mergeEnvMaps`.

## CHANGELOG

See the committed CHANGELOG.md for full release notes.