### PR TITLE
ci: use trusted Windows runner for manual E2E

### DIFF
--- a/.github/workflows/extended-ci.yml
+++ b/.github/workflows/extended-ci.yml
@@ -15,9 +15,10 @@ permissions: {}
 jobs:
   e2e-windows:
     name: E2E (none runtime, Windows)
-    # No trusted Windows self-hosted runner is provisioned. Use a clean,
-    # explicitly versioned GitHub-hosted Windows image.
-    runs-on: windows-2025
+    # Merge-group code stays on an ephemeral runner so it cannot persist hooks
+    # or tools for a later secret-bearing job. Maintainer dispatches exercise
+    # the trusted self-hosted Windows runner.
+    runs-on: ${{ fromJSON(github.event_name == 'merge_group' && '["windows-2025"]' || '["self-hosted","Windows","X64","trusted"]') }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -26,6 +27,20 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Verify self-hosted Windows prerequisites
+        shell: pwsh
+        run: |
+          git --version
+          bash --version
+          $probe = Join-Path $env:RUNNER_TEMP "skill-up-symlink-probe"
+          Remove-Item $probe -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $probe | Out-Null
+          New-Item -ItemType File -Path (Join-Path $probe "target") | Out-Null
+          New-Item -ItemType SymbolicLink `
+            -Path (Join-Path $probe "link") `
+            -Target (Join-Path $probe "target") | Out-Null
+          Remove-Item $probe -Recurse -Force
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/extended-ci.yml
+++ b/.github/workflows/extended-ci.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Verify self-hosted Windows prerequisites
-        shell: pwsh
+        shell: powershell
         run: |
           git --version
           bash --version

--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -280,7 +280,7 @@ jobs:
           persist-credentials: false
 
       - name: Verify self-hosted Windows prerequisites
-        shell: pwsh
+        shell: powershell
         run: |
           git --version
           bash --version
@@ -334,7 +334,7 @@ jobs:
 
       - name: List Claude project directories on failure
         if: failure() && steps.secrets.outputs.available == 'true'
-        shell: pwsh
+        shell: powershell
         run: |
           $projects = Join-Path $HOME ".claude\projects"
           if (-not (Test-Path $projects)) {

--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -269,7 +269,7 @@ jobs:
   e2e-windows:
     name: E2E (none runtime, Windows, live Claude)
     if: inputs.suite == 'all' || inputs.suite == 'windows-none-runtime'
-    runs-on: windows-2025
+    runs-on: [self-hosted, Windows, X64, trusted]
     timeout-minutes: 20
     permissions:
       contents: read
@@ -278,6 +278,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Verify self-hosted Windows prerequisites
+        shell: pwsh
+        run: |
+          git --version
+          bash --version
 
       - name: Check secret availability
         id: secrets

--- a/docs/guide/ci-maintenance.md
+++ b/docs/guide/ci-maintenance.md
@@ -21,9 +21,12 @@ The trusted Windows runner must have Git for Windows installed, with both
 their required Go and Node.js versions through pinned setup actions. The
 runner service account, work directory, tool cache, and agent home are
 persistent and must not be treated as a clean GitHub-hosted environment.
-Windows Developer Mode must be enabled so the service account can create the
-symbolic links used by the E2E fixtures; the workflow verifies this capability
-before installing the Go toolchain.
+Windows Developer Mode must be enabled. A non-administrative runner service
+account, such as `NETWORK SERVICE`, must also hold
+`SeCreateSymbolicLinkPrivilege`; restart the runner service after changing the
+local security policy so its new logon token includes the privilege. The
+workflow verifies actual symbolic-link creation before installing the Go
+toolchain.
 
 Merge-group code must not run on the same persistent Windows runner that later
 receives model credentials. Extended CI therefore uses `windows-2025` for

--- a/docs/guide/ci-maintenance.md
+++ b/docs/guide/ci-maintenance.md
@@ -10,9 +10,25 @@ Pull-request code runs on GitHub-hosted runners. Persistent self-hosted runners 
 | --- | --- | --- |
 | Trusted Linux | `self-hosted`, `linux`, `x64`, `trusted` | Trusted integration and model-backed tests |
 | Trusted Linux with Docker | `self-hosted`, `linux`, `x64`, `docker`, `trusted` | Trusted container E2E tests |
-| Untrusted PR validation | `ubuntu-24.04` or `windows-2025` | Builds, lint, smoke tests, docs, and CodeQL |
+| Trusted Windows | `self-hosted`, `Windows`, `X64`, `trusted` | Manually dispatched Windows E2E and model tests |
+| Untrusted PR and merge-group validation | `ubuntu-24.04` or `windows-2025` | Builds, lint, smoke tests, docs, CodeQL, and merge-group Windows E2E |
 
 Do not add `pull_request_target` to workflows that check out or execute pull-request code. Do not place a self-hosted label on PR jobs. Runner hosts are persistent: patch them regularly, remove unused software and credentials, restrict Docker access, and replace a runner after suspected compromise.
+
+The trusted Windows runner must have Git for Windows installed, with both
+`C:\Program Files\Git\cmd` and `C:\Program Files\Git\bin` on the machine
+`PATH`; restart the runner service after changing `PATH`. Workflows install
+their required Go and Node.js versions through pinned setup actions. The
+runner service account, work directory, tool cache, and agent home are
+persistent and must not be treated as a clean GitHub-hosted environment.
+Windows Developer Mode must be enabled so the service account can create the
+symbolic links used by the E2E fixtures; the workflow verifies this capability
+before installing the Go toolchain.
+
+Merge-group code must not run on the same persistent Windows runner that later
+receives model credentials. Extended CI therefore uses `windows-2025` for
+`merge_group` and selects the trusted self-hosted labels only for maintainer
+`workflow_dispatch` runs.
 
 ## Stable checks and merge queue
 
@@ -23,7 +39,7 @@ Configure rulesets using the displayed job names below. Job IDs such as `build` 
 | CI | `push`, `pull_request`, `merge_group` | `Build & Test`, `E2E Smoke`, `Lint` | — |
 | CodeQL | `push`, `pull_request`, `merge_group`, schedule | `Analyze (actions)`, `Analyze (go)`, `Analyze (python)` | — |
 | Extended CI | `merge_group`, manual | `Extended CI Summary` | Its component jobs are aggregated by the summary |
-| Model E2E | manual | Do not make required | `E2E (none runtime, live models)`, `E2E (OpenSandbox, live model)`, `E2E (Docker runtime, live model)` |
+| Model E2E | manual | Do not make required | `E2E (none runtime, live models)`, `E2E (OpenSandbox, live model)`, `E2E (none runtime, Windows, live Claude)`, `E2E (Docker runtime, live model)` |
 | Docs | docs-related `push` and `pull_request` | Do not make globally required because path filters can leave it absent | `Build` |
 | Workflow Security | workflow-related `push`, `pull_request`, `merge_group` | Keep optional while the initial baseline is triaged | `Zizmor` |
 

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -8,7 +8,9 @@ limitations, and the recommended workflow.
 ## Supported
 
 - **Build and unit tests** — `go build ./...` and `go test ./...` pass on
-  Windows. CI exercises a `windows-latest` runner alongside Linux.
+  Windows. Maintainer-dispatched Extended CI exercises a trusted self-hosted
+  runner; pull-request and merge-group code remains on clean GitHub-hosted
+  runners.
 - **The `none` runtime** — commands run on the host through `cmd.exe`.
 - **The `opensandbox` runtime** — unaffected by the host OS; it always
   executes inside a Linux sandbox.

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -72,14 +72,17 @@ under `scripts/windows/` instead:
 
 ```powershell
 # Install git hooks (equivalent to `make hooks`)
-pwsh scripts/windows/hooks.ps1
+powershell -NoProfile -File scripts/windows/hooks.ps1
 
 # Install pinned lint tools into .tools/bin (equivalent to `make lint-tools`)
-pwsh scripts/windows/lint-tools.ps1
+powershell -NoProfile -File scripts/windows/lint-tools.ps1
 
 # fmt-check + vet + revive + golangci-lint (equivalent to `make verify`)
-pwsh scripts/windows/verify.ps1
+powershell -NoProfile -File scripts/windows/verify.ps1
 ```
+
+These scripts support the Windows PowerShell 5.1 included with Windows Server.
+PowerShell 7 is optional; if installed, `pwsh -NoProfile -File ...` works too.
 
 Build and test use the standard Go toolchain, which is cross-platform:
 

--- a/docs/zh/guide/ci-maintenance.md
+++ b/docs/zh/guide/ci-maintenance.md
@@ -10,9 +10,22 @@ Pull Request 代码只在 GitHub 托管 Runner 上运行。持久化的自托管
 | --- | --- | --- |
 | 可信 Linux | `self-hosted`、`linux`、`x64`、`trusted` | 可信集成测试和模型测试 |
 | 支持 Docker 的可信 Linux | `self-hosted`、`linux`、`x64`、`docker`、`trusted` | 可信容器 E2E 测试 |
-| 不可信 PR 校验 | `ubuntu-24.04` 或 `windows-2025` | 构建、Lint、冒烟测试、文档和 CodeQL |
+| 可信 Windows | `self-hosted`、`Windows`、`X64`、`trusted` | 手动触发的 Windows E2E 与模型测试 |
+| 不可信 PR 与 Merge Group 校验 | `ubuntu-24.04` 或 `windows-2025` | 构建、Lint、冒烟测试、文档、CodeQL 与 Merge Group Windows E2E |
 
 不要给会检出或执行 PR 代码的工作流添加 `pull_request_target`，不要让 PR Job 使用自托管 Runner。Runner 主机是持久化环境，应定期打补丁、移除无用软件和凭据、限制 Docker 权限；怀疑被入侵后必须重建。
+
+可信 Windows Runner 必须安装 Git for Windows，并将
+`C:\Program Files\Git\cmd` 与 `C:\Program Files\Git\bin` 都加入机器级
+`PATH`；修改 `PATH` 后需重启 Runner 服务。工作流通过固定版本的 setup
+action 安装所需 Go 与 Node.js。Runner 服务账号、工作目录、工具缓存和 agent
+HOME 都会持久化，不能把它当作每次全新的 GitHub 托管环境。
+Windows 还必须开启开发者模式，使服务账号可以创建 E2E fixture
+所需的符号链接；workflow 会在安装 Go 工具链之前验证这项能力。
+
+Merge Group 代码不得与后续会接收模型凭据的持久 Windows Runner 共用环境。
+因此 Extended CI 的 `merge_group` 使用 `windows-2025`，只有维护者
+`workflow_dispatch` 才会选中可信自托管标签。
 
 ## 稳定检查与 Merge Queue
 
@@ -23,7 +36,7 @@ Ruleset 必须使用下表的 Job 展示名称。`build` 等 Job ID 只是实现
 | CI | `push`、`pull_request`、`merge_group` | `Build & Test`、`E2E Smoke`、`Lint` | — |
 | CodeQL | `push`、`pull_request`、`merge_group`、定时任务 | `Analyze (actions)`、`Analyze (go)`、`Analyze (python)` | — |
 | Extended CI | `merge_group`、手动触发 | `Extended CI Summary` | 其余组件 Job 由 Summary 汇总 |
-| Model E2E | 手动触发 | 不得设为必需检查 | `E2E (none runtime, live models)`、`E2E (OpenSandbox, live model)`、`E2E (Docker runtime, live model)` |
+| Model E2E | 手动触发 | 不得设为必需检查 | `E2E (none runtime, live models)`、`E2E (OpenSandbox, live model)`、`E2E (none runtime, Windows, live Claude)`、`E2E (Docker runtime, live model)` |
 | Docs | 文档相关的 `push` 和 `pull_request` | 不要设为全局必需；路径过滤会使非文档 PR 没有该检查 | `Build` |
 | Workflow Security | 工作流相关的 `push`、`pull_request`、`merge_group` | 初始基线完成处置前保持可选 | `Zizmor` |
 

--- a/docs/zh/guide/ci-maintenance.md
+++ b/docs/zh/guide/ci-maintenance.md
@@ -20,8 +20,10 @@ Pull Request 代码只在 GitHub 托管 Runner 上运行。持久化的自托管
 `PATH`；修改 `PATH` 后需重启 Runner 服务。工作流通过固定版本的 setup
 action 安装所需 Go 与 Node.js。Runner 服务账号、工作目录、工具缓存和 agent
 HOME 都会持久化，不能把它当作每次全新的 GitHub 托管环境。
-Windows 还必须开启开发者模式，使服务账号可以创建 E2E fixture
-所需的符号链接；workflow 会在安装 Go 工具链之前验证这项能力。
+Windows 还必须开启开发者模式。对于 `NETWORK SERVICE` 等非管理员 Runner
+服务账号，还需授予 `SeCreateSymbolicLinkPrivilege`，并在修改本地安全策略后
+重启 Runner 服务，使新登录令牌带上该权限。workflow 会在安装 Go 工具链之前
+实际创建符号链接来验证这项能力。
 
 Merge Group 代码不得与后续会接收模型凭据的持久 Windows Runner 共用环境。
 因此 Extended CI 的 `merge_group` 使用 `windows-2025`，只有维护者

--- a/docs/zh/guide/windows.md
+++ b/docs/zh/guide/windows.md
@@ -7,7 +7,8 @@ skill-up 原生支持 Windows。本页说明哪些功能可用、当前的限制
 ## 已支持
 
 - **构建与单元测试** —— `go build ./...` 和 `go test ./...` 在 Windows 上通过。
-  CI 在 Linux 之外额外运行 `windows-latest` runner。
+  维护者手动触发的 Extended CI 会使用可信自托管 Windows Runner；
+  Pull Request 和 Merge Group 代码仍仅在干净的 GitHub 托管 Runner 上运行。
 - **`none` runtime** —— 命令通过 `cmd.exe` 在宿主机上执行。
 - **`opensandbox` runtime** —— 不受宿主机 OS 影响，始终在 Linux 沙箱内执行。
 - **script judge** —— 按文件扩展名（或 shebang）分派解释器：

--- a/docs/zh/guide/windows.md
+++ b/docs/zh/guide/windows.md
@@ -62,14 +62,17 @@ Windows 默认没有 `make`。请改用 `scripts/windows/` 下的 PowerShell 脚
 
 ```powershell
 # 安装 git hooks（等价于 `make hooks`）
-pwsh scripts/windows/hooks.ps1
+powershell -NoProfile -File scripts/windows/hooks.ps1
 
 # 将固定版本的 lint 工具装入 .tools/bin（等价于 `make lint-tools`）
-pwsh scripts/windows/lint-tools.ps1
+powershell -NoProfile -File scripts/windows/lint-tools.ps1
 
 # fmt-check + vet + revive + golangci-lint（等价于 `make verify`）
-pwsh scripts/windows/verify.ps1
+powershell -NoProfile -File scripts/windows/verify.ps1
 ```
+
+这些脚本兼容 Windows Server 自带的 Windows PowerShell 5.1。PowerShell 7
+不是必需依赖；如果已安装，也可以使用 `pwsh -NoProfile -File ...`。
 
 构建和测试使用标准的 Go 工具链，本身就是跨平台的：
 


### PR DESCRIPTION
## Summary

- route maintainer-dispatched Windows E2E and live-model checks to the trusted self-hosted Windows runner
- keep merge-group Windows code on ephemeral GitHub-hosted runners so persistent state cannot cross into later secret-bearing jobs
- verify Git for Windows, Git Bash, and symlink capability before running tests
- document runner labels, PATH, Developer Mode, persistence, and trust boundaries in English and Chinese
- use stock Windows PowerShell so PowerShell 7 is not an undocumented host prerequisite

## Validation

- `make verify`
- `make test`
- `actionlint .github/workflows/extended-ci.yml .github/workflows/model-e2e.yml`
- Extended CI [run 31768265668](https://github.com/alibaba/skill-up/actions/runs/31768265668): Windows E2E passed on `IZTW1IE30KF87BZ` with 73 pass, 33 expected skip, 0 fail; the overall workflow failed only because an unrelated Linux Docker runner could not access `/var/run/docker.sock`
- Model E2E [run 31768419858](https://github.com/alibaba/skill-up/actions/runs/31768419858): Windows Claude token-usage test and artifact upload passed; readback reported 20,693 input and 25 output tokens

## Security boundary

`merge_group` continues to select `windows-2025`. Only maintainer-authorized `workflow_dispatch` runs select `[self-hosted, Windows, X64, trusted]`.