### PR TITLE
fix(runner): scope report timing to each iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without-Skill, and delta annotations beside the case heading. Agent-judge
   time and tokens are reported separately and included in an explicit overall
   token total.
+- Multi-iteration reports now record each iteration's own start time and wall
+  time instead of reusing the command start time and accumulating the duration
+  of all preceding iterations.
 - Codex JSONL parsing now accepts records up to a configurable 16 MiB default
   while rejecting oversized records explicitly. The stdout stream is written to
   a bounded-download artifact instead of being buffered without limit in host

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -55,8 +55,7 @@ type Runner struct {
 	runnerParams credential.AgentInitParams
 
 	workspace *report.IterationWorkspace
-	startTime time.Time
-	endTime   time.Time
+	now       func() time.Time
 }
 
 // NewRunner creates a new Runner with the given eval config and loader.
@@ -66,6 +65,7 @@ func NewRunner(evalCfg *config.EvalConfig, loader *config.Loader, resolver *cred
 		loader:       loader,
 		resolver:     resolver,
 		runnerParams: runnerParams,
+		now:          time.Now,
 	}
 }
 
@@ -138,8 +138,8 @@ func (r *Runner) Evaluate(ctx context.Context, cases []*config.CaseConfig, ag ag
 		attribute.Int("skill_up.iteration.count", runCount),
 	)
 	allResults := make([]evaluator.EvalResult, 0, len(cases)*runCount)
-	r.startTime = time.Now()
 	for i := range runCount {
+		iterationStartTime := r.now()
 		runNumber := startIteration + i
 		if err := r.setupWorkspace(ctx, workspaceDir, skillName, runNumber); err != nil {
 			return allResults, fmt.Errorf("failed to init workspace for run %d: %w", runNumber, err)
@@ -172,9 +172,9 @@ func (r *Runner) Evaluate(ctx context.Context, cases []*config.CaseConfig, ag ag
 			return allResults, err
 		}
 		allResults = append(allResults, results...)
-		r.endTime = time.Now()
+		iterationEndTime := r.now()
 
-		if err := r.WriteResults(ctx, results, reportName, skillDir, runNumber, opts.Formats); err != nil {
+		if err := r.WriteResults(ctx, results, reportName, skillDir, runNumber, opts.Formats, iterationStartTime, iterationEndTime); err != nil {
 			logging.WarnContextf(ctx, "Runner: failed to write results for run %d: %v", runNumber, err)
 		}
 	}
@@ -274,7 +274,7 @@ type caseResults struct {
 // WriteResults writes one run's evaluation results to the current iteration workspace.
 // formats specifies which report formats to generate in addition to result.json (always written).
 // Supported values: "json" (no-op, result.json suffices), "junit", "html".
-func (r *Runner) WriteResults(ctx context.Context, results []evaluator.EvalResult, skillName, skillPath string, runNumber int, formats []string) error {
+func (r *Runner) WriteResults(ctx context.Context, results []evaluator.EvalResult, skillName, skillPath string, runNumber int, formats []string, startTime, endTime time.Time) error {
 	if r.workspace == nil {
 		return errors.New("workspace not initialized; call InitWorkspace first")
 	}
@@ -301,7 +301,7 @@ func (r *Runner) WriteResults(ctx context.Context, results []evaluator.EvalResul
 		return fmt.Errorf("failed to write benchmark.md: %w", err)
 	}
 
-	input := buildReportInput(skillName, grouped, caseIDs, r.startTime, r.endTime, r.evalCfg)
+	input := buildReportInput(skillName, grouped, caseIDs, startTime, endTime, r.evalCfg)
 
 	// result.json is always written as the raw evaluation data source.
 	resultJSON, err := json.MarshalIndent(input, "", "  ")

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -78,7 +78,7 @@ func TestRunner_WriteResults_WithSkillOnly(t *testing.T) {
 		},
 	}
 
-	err = r.WriteResults(context.Background(), results, "test-skill", "/path/to/skill", 1, []string{"html"})
+	err = r.WriteResults(context.Background(), results, "test-skill", "/path/to/skill", 1, []string{"html"}, time.Time{}, time.Time{})
 	if err != nil {
 		t.Fatalf("WriteResults failed: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestRunner_WriteResults_WithBaseline(t *testing.T) {
 		},
 	}
 
-	err = r.WriteResults(context.Background(), results, "test-skill", "/path/to/skill", 1, nil)
+	err = r.WriteResults(context.Background(), results, "test-skill", "/path/to/skill", 1, nil, time.Time{}, time.Time{})
 	if err != nil {
 		t.Fatalf("WriteResults failed: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestRunner_WriteResults_UsesStderrWhenFinalMessageEmpty(t *testing.T) {
 		},
 	}
 
-	err = r.WriteResults(context.Background(), results, "test-skill", "/path/to/skill", 1, nil)
+	err = r.WriteResults(context.Background(), results, "test-skill", "/path/to/skill", 1, nil, time.Time{}, time.Time{})
 	if err != nil {
 		t.Fatalf("WriteResults failed: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestRunner_WriteResults_DoesNotUseStderrOnSuccessfulEmptyResponse(t *testin
 		},
 	}
 
-	err = r.WriteResults(context.Background(), results, "test-skill", "/path/to/skill", 1, nil)
+	err = r.WriteResults(context.Background(), results, "test-skill", "/path/to/skill", 1, nil, time.Time{}, time.Time{})
 	if err != nil {
 		t.Fatalf("WriteResults failed: %v", err)
 	}
@@ -515,7 +515,7 @@ func TestBuildReportInput_IncludesFailedJudgeSessionMetrics(t *testing.T) {
 
 func TestRunner_WriteResults_NoWorkspace(t *testing.T) {
 	r := NewRunner(&config.EvalConfig{}, nil, nil, credential.AgentInitParams{})
-	err := r.WriteResults(context.Background(), nil, "", "", 1, nil)
+	err := r.WriteResults(context.Background(), nil, "", "", 1, nil, time.Time{}, time.Time{})
 	if err == nil {
 		t.Error("expected error when workspace not initialized")
 	}

--- a/internal/runner/workspace_options_test.go
+++ b/internal/runner/workspace_options_test.go
@@ -3,18 +3,21 @@ package runner
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alibaba/skill-up/internal/agent"
 	"github.com/alibaba/skill-up/internal/config"
 	"github.com/alibaba/skill-up/internal/credential"
 	"github.com/alibaba/skill-up/internal/evaluator"
 	"github.com/alibaba/skill-up/internal/judge"
+	"github.com/alibaba/skill-up/internal/report"
 	"github.com/alibaba/skill-up/internal/runtime"
 	"github.com/alibaba/skill-up/internal/ui"
 	"github.com/alibaba/skill-up/pkg/transcript"
@@ -159,6 +162,23 @@ func TestRunner_Evaluate_RunsMultipleIterations(t *testing.T) {
 		Environment: config.Environment{Type: "none"},
 		Cases:       config.CasesConfig{Parallelism: 1},
 	}, loader, nil, credential.AgentInitParams{})
+	baseTime := time.Date(2026, time.August, 17, 10, 0, 0, 0, time.UTC)
+	clockTimes := []time.Time{
+		baseTime,
+		baseTime.Add(100 * time.Second),
+		baseTime.Add(200 * time.Second),
+		baseTime.Add(300 * time.Second),
+	}
+	clockIndex := 0
+	r.now = func() time.Time {
+		if clockIndex >= len(clockTimes) {
+			t.Fatalf("clock called more than %d times", len(clockTimes))
+			return time.Time{}
+		}
+		now := clockTimes[clockIndex]
+		clockIndex++
+		return now
+	}
 
 	ag := &runnerTestAgent{}
 	workspaceRoot := filepath.Join(evalDir, "workspace")
@@ -175,9 +195,29 @@ func TestRunner_Evaluate_RunsMultipleIterations(t *testing.T) {
 	}
 	for _, runNumber := range []int{1, 2} {
 		resultPath := filepath.Join(workspaceRoot, fmt.Sprintf("iteration-%d", runNumber), "result.json")
-		if _, err := os.Stat(resultPath); err != nil {
-			t.Fatalf("missing result.json for run %d: %v", runNumber, err)
+		data, readErr := os.ReadFile(resultPath)
+		if readErr != nil {
+			t.Fatalf("read result.json for run %d: %v", runNumber, readErr)
 		}
+		var input report.Input
+		if unmarshalErr := json.Unmarshal(data, &input); unmarshalErr != nil {
+			t.Fatalf("unmarshal result.json for run %d: %v", runNumber, unmarshalErr)
+		}
+
+		wantStart := baseTime.Add(time.Duration(runNumber-1) * 200 * time.Second)
+		wantEnd := wantStart.Add(100 * time.Second)
+		if !input.StartTime.Equal(wantStart) {
+			t.Errorf("run %d StartTime = %v, want %v", runNumber, input.StartTime, wantStart)
+		}
+		if !input.EndTime.Equal(wantEnd) {
+			t.Errorf("run %d EndTime = %v, want %v", runNumber, input.EndTime, wantEnd)
+		}
+		if got := input.TotalDuration(); got != 100*time.Second {
+			t.Errorf("run %d TotalDuration = %v, want 100s", runNumber, got)
+		}
+	}
+	if clockIndex != len(clockTimes) {
+		t.Fatalf("clock called %d times, want %d", clockIndex, len(clockTimes))
 	}
 	if got := r.workspace.IterationNum; got != 2 {
 		t.Fatalf("IterationNum = %d, want 2 after final run", got)


### PR DESCRIPTION
## Summary

- capture a fresh start and end time for every evaluation iteration
- pass iteration-local timing explicitly into `WriteResults` instead of storing it on the shared `Runner`
- add deterministic regression coverage that verifies independent 100-second timing windows across multiple iterations
- document the fix in the changelog

## Root cause

`Runner.startTime` was initialized once before the iteration loop, while `Runner.endTime` was updated after each iteration. Every per-iteration report therefore reused the command start time and reported a cumulative duration.

Because `result.json` is the source for the HTML, JUnit, JSON, and Markdown reporters, the incorrect timing propagated to all report formats. In particular, JUnit `testsuite.time` and `timestamp` could pollute CI duration statistics.

The timing values now have the same lifecycle as the iteration results they describe.

## Validation

- `make verify`
- `env -u QODER_PERSONAL_ACCESS_TOKEN make test`
- `env -u QODER_PERSONAL_ACCESS_TOKEN make e2e`
- `git diff --check`

Fixes #195
