### PR TITLE
chore(deps): group OpenTelemetry updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+    groups:
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/otel*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
## Summary

- group `go.opentelemetry.io/otel*` Dependabot version updates into one PR
- group only minor and patch releases so major upgrades remain independently reviewable
- keep separately versioned `go.opentelemetry.io/auto/*` and `go.opentelemetry.io/proto/*` outside the group

## Why

OpenTelemetry modules are released together and repeatedly produce overlapping `go.mod` and `go.sum` pull requests. The latest `1.44.0` to `1.45.0` update was split across multiple PRs, and merging one of them made the remaining branches conflict.

## Validation

- parsed `.github/dependabot.yml` successfully
- `make verify`
- `make test`
- push-before self-review found no actionable issues
