### PR TITLE
docs: prepare v0.9.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-08-20
+
 ### Fixed
 - `agent_judge` now uses stable criterion IDs and a strict JSON response
   contract, rejects malformed or semantically incomplete judge output, and
@@ -33,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   memory, and the `--output-last-message` artifact remains the authoritative
   final response, so a large tool result cannot leave an earlier progress update
   to be graded as the answer.
+- QoderCLI runs now enable token-usage exposure and parse usage from JSON
+  stdout, allowing `input_tokens` and `output_tokens` to be populated even when
+  the runtime cannot read Qoder's private session directory.
 
 ## [0.9.0] - 2026-08-12
 
@@ -94,11 +99,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aggregate report statistics now exclude `without_skill` baseline runs, so
   pass rates and status totals describe the evaluated Skill rather than mixing
   benchmark control results into the headline metrics.
-
-### Fixed
-- QoderCLI runs now enable token-usage exposure and parse usage from JSON
-  stdout, allowing `input_tokens` and `output_tokens` to be populated even when
-  the runtime cannot read Qoder's private session directory.
 
 ## [0.7.0] - 2026-07-16
 
@@ -509,6 +509,7 @@ The `v0.5.0` release tag is available at
   project and delivers the end-to-end capability to declare eval environments,
   run cases and emit structured reports as described in [README.md](README.md).
 
+[0.9.1]: https://github.com/alibaba/skill-up/releases/tag/v0.9.1
 [0.9.0]: https://github.com/alibaba/skill-up/releases/tag/v0.9.0
 [0.8.0]: https://github.com/alibaba/skill-up/releases/tag/v0.8.0
 [0.7.0]: https://github.com/alibaba/skill-up/releases/tag/v0.7.0


### PR DESCRIPTION
## Summary

- publish the accumulated post-v0.9.0 fixes under a v0.9.1 changelog section dated 2026-08-20
- include the bounded agent_judge correction retry merged in #209
- move the QoderCLI token-usage fix out of the historical v0.8.0 section
- add the v0.9.1 release reference link

## Verification

- `make fmt`
- `make verify`
- `make test`
- credentialed QoderCLI ultimate + agent_judge canary passed on `main@6da1264`: https://github.com/alibaba/skill-up/actions/runs/32321505124