### PR TITLE
feat(judge): add structured failure diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Failed `agent_judge` criteria can now include an optional, structured
+  AI-generated diagnosis with a likely failure attribution, confidence,
+  attribution evidence, and an actionable improvement suggestion. Standard
+  judge context includes a bounded, hashed, pre-execution snapshot of the
+  evaluated Skill source, while benchmark baselines and engines without
+  trustworthy Skill-use evidence are prevented from producing unsupported
+  Skill-specific blame.
+
 ### Fixed
 - `agent_judge` now uses stable criterion IDs and a strict JSON response
   contract, rejects malformed or semantically incomplete judge output, and

--- a/docs/guide/writing-evals.md
+++ b/docs/guide/writing-evals.md
@@ -792,7 +792,40 @@ into the judge prompt.
 materials table into the judge prompt. When `judge.context` is omitted, the
 default profile is `standard`: `final_message` is included inline, while
 `transcript` and `workspace_diff` are provided as file references to avoid
-large prompt/argv failures.
+large prompt/argv failures. The exact evaluated Skill is also exposed through
+a `skill_source` file reference. This bounded snapshot is captured before the
+Agent runs, so files created or changed during evaluation cannot alter the
+Judge's view of the installed source. Its index records file sizes and SHA-256
+digests, while `SKILL.md` and readable source/reference files are retained up
+to the configured context byte limit. The `evals/` directory and large/binary
+assets are not copied into the judge context.
+
+The effective `skill_source` defaults are:
+
+| Context configuration | Effective `skill_source` |
+|---|---|
+| `judge.context` omitted | `file_ref` (because the default profile is `standard`) |
+| `profile: standard` | `file_ref` |
+| `profile: minimal` | `omit` |
+| Explicit `skill_source` | The explicit value overrides the profile default |
+| `without_skill` benchmark variant | Always `omit` |
+
+`file_ref` is not only a host-side path label. Readable Skill source files are
+copied into the Judge-accessible runtime context and retained in the evaluation
+artifacts, so they may be processed by the configured Judge provider. Their
+combined retained content uses `limits.max_bytes` (64 KiB by default); files
+outside that content budget may still appear in the index with path, size, and
+SHA-256 metadata. Use `skill_source: omit` when the Skill source must not be
+made available to the Judge.
+
+For failed criteria, the judge may additionally return an optional structured
+`diagnosis` in `result.json` and the HTML/Markdown reports. It contains a likely
+failure attribution, confidence, attribution evidence, and an improvement
+suggestion. This is AI-generated diagnostic guidance, not a verified root
+cause, and it never changes the pass/fail verdict. If the engine does not expose
+trustworthy Skill-use evidence, `skill_not_triggered` is rejected rather than
+inferred from silence. In a `without_skill` benchmark baseline, all
+Skill-specific attribution categories are rejected.
 
 Use `minimal` for long repository-change benchmarks where the judge should rely
 on explicit attachments or script outputs instead of the full conversation:
@@ -821,6 +854,7 @@ judge:
     transcript: file_ref                     # include auto-downgrades to file_ref above limits.max_bytes
     workspace_diff: file_ref
     generated_files: index                   # index | include | omit
+    skill_source: file_ref                    # file_ref | omit
     limits:
       max_bytes: 65536
 ```

--- a/docs/zh/guide/writing-evals.md
+++ b/docs/zh/guide/writing-evals.md
@@ -752,7 +752,34 @@ skill-up 不会把 Skill 文件内容拼接进 judge prompt。
 `agent_judge` 会将评审上下文物化为文件，并在 judge prompt 中注入一个很小的
 材料表。未配置 `judge.context` 时，默认使用 `standard` profile：
 `final_message` 内联，`transcript` 和 `workspace_diff` 以文件引用形式提供，
-避免超长 prompt/argv 导致执行失败。
+避免超长 prompt/argv 导致执行失败。被测 Skill 的精确源码也会通过
+`skill_source` 文件引用提供。这个有界快照在 Agent 执行前生成，因此评测期间新增或
+修改的文件不会改变 Judge 看到的已安装源码；索引记录文件大小和 SHA-256，
+`SKILL.md` 以及可读的源码/引用文件会在上下文字节限制内保留；`evals/`、大文件和
+二进制资产不会复制到 Judge 上下文中。
+
+`skill_source` 的实际默认值如下：
+
+| 上下文配置 | 实际生效的 `skill_source` |
+|---|---|
+| 未配置 `judge.context` | `file_ref`（因为默认 profile 是 `standard`） |
+| `profile: standard` | `file_ref` |
+| `profile: minimal` | `omit` |
+| 显式配置 `skill_source` | 显式值覆盖 profile 默认值 |
+| benchmark 的 `without_skill` 变体 | 始终为 `omit` |
+
+`file_ref` 不只是记录一个宿主机路径。可读的 Skill 源码文件会复制到 Judge 可访问的
+运行时上下文，并保留在评测产物中，因此可能由所配置的 Judge Provider 处理。保留的
+文件正文共同受 `limits.max_bytes` 限制（默认 64 KiB）；超出正文预算的文件仍可能以
+路径、大小和 SHA-256 元数据的形式出现在索引中。如果 Skill 源码不应提供给 Judge，
+请显式配置 `skill_source: omit`。
+
+对于未通过的 criterion，Judge 还可以在 `result.json`、HTML 和 Markdown 报告中
+返回可选的结构化 `diagnosis`，包括可能的失败归因、置信度、归因证据和可执行的
+修改建议。它是 AI 生成的诊断建议，不是经过验证的根因，也不会改变 PASS/FAIL
+判定。如果 Agent Engine 没有提供可信的 Skill 使用证据，skill-up 会拒绝
+`skill_not_triggered`，而不是根据“没有看到调用”进行猜测；在 `without_skill`
+基线中，所有 Skill 责任类归因都会被拒绝。
 
 长时间运行的仓库变更类评测通常适合使用 `minimal`，让 judge 依赖显式附件或脚本
 输出，而不是完整对话历史：
@@ -781,6 +808,7 @@ judge:
     transcript: file_ref                     # include 超过 limits.max_bytes 会自动降级为 file_ref
     workspace_diff: file_ref
     generated_files: index                   # index | include | omit
+    skill_source: file_ref                    # file_ref | omit
     limits:
       max_bytes: 65536
 ```

--- a/internal/cli/judge_debug.go
+++ b/internal/cli/judge_debug.go
@@ -92,18 +92,24 @@ type judgeDebugInput struct {
 
 // toJudgeInput converts the debug input to a judge.Input.
 func (d *judgeDebugInput) toJudgeInput() judge.Input {
-	return judge.Input{
+	input := judge.Input{
 		CaseID:         d.CaseID,
 		Transcript:     d.Transcript,
 		FinalMessage:   d.FinalMessage,
 		ExitCode:       d.ExitCode,
 		SkillDir:       d.SkillDir,
+		Configuration:  "with_skill",
+		SkillUsage:     judge.InferSkillUsageEvidence(d.Transcript),
 		WorkspacePath:  d.WorkspacePath,
 		WorkspaceDiff:  d.WorkspaceDiff,
 		GeneratedFiles: d.GeneratedFiles,
 		TurnsExecuted:  d.TurnsExecuted,
 		TurnsTotal:     d.TurnsTotal,
 	}
+	if d.SkillDir != "" {
+		input.SkillSources = []judge.SkillSource{{Path: d.SkillDir}}
+	}
+	return input
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/config/defaults.yaml
+++ b/internal/config/defaults.yaml
@@ -22,6 +22,13 @@ cases:
     expect: {}
   parallelism: 1
 
+judge:
+  # Material modes, including skill_source, are derived from this profile.
+  # Keep profile-specific modes unset so profile: minimal can select its own
+  # defaults instead of inheriting standard's file_ref behavior.
+  context:
+    profile: standard
+
 report:
   formats: [json]
   artifacts: []

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -176,6 +176,7 @@ type JudgeContextConfig struct {
 	Transcript     string                   `json:"transcript,omitempty"      yaml:"transcript,omitempty"`
 	WorkspaceDiff  string                   `json:"workspace_diff,omitempty"  yaml:"workspace_diff,omitempty"`
 	GeneratedFiles string                   `json:"generated_files,omitempty" yaml:"generated_files,omitempty"`
+	SkillSource    string                   `json:"skill_source,omitempty"    yaml:"skill_source,omitempty"`
 	Limits         *JudgeContextLimits      `json:"limits,omitempty"          yaml:"limits,omitempty"`
 	Attachments    []JudgeContextAttachment `json:"attachments,omitempty"     yaml:"attachments,omitempty"`
 }

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -57,6 +57,16 @@ func TestDefaultEvalConfig(t *testing.T) { //nolint:cyclop,gocyclo // exhaustive
 	if cfg.Judge.Type != "" {
 		t.Errorf("Judge.Type = %q, want empty (no global judge)", cfg.Judge.Type)
 	}
+	if cfg.Judge.Context == nil {
+		t.Fatal("Judge.Context should contain profile defaults")
+	} else {
+		if cfg.Judge.Context.Profile != "standard" {
+			t.Errorf("Judge.Context.Profile = %q, want %q", cfg.Judge.Context.Profile, "standard")
+		}
+		if cfg.Judge.Context.SkillSource != "" {
+			t.Errorf("Judge.Context.SkillSource = %q, want empty (derived from profile)", cfg.Judge.Context.SkillSource)
+		}
+	}
 
 	// Verify report defaults
 	if len(cfg.Report.Formats) != 1 || cfg.Report.Formats[0] != "json" {
@@ -188,5 +198,9 @@ func TestDefaultEvalConfig_ReturnsNewInstance(t *testing.T) {
 	cfg1.Engine.Name = "modified"
 	if cfg2.Engine.Name == "modified" {
 		t.Error("DefaultEvalConfig() should return independent instances")
+	}
+	cfg1.Judge.Context.Profile = "minimal"
+	if cfg2.Judge.Context.Profile != "standard" {
+		t.Error("DefaultEvalConfig() should deep-copy judge context defaults")
 	}
 }

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -400,6 +400,9 @@ func validateJudgeContextModes(ctx *JudgeContextConfig) []string {
 	if ctx.GeneratedFiles != "" && ctx.GeneratedFiles != "omit" && ctx.GeneratedFiles != "index" && ctx.GeneratedFiles != "include" {
 		errs = append(errs, "judge.context.generated_files must be one of: omit, index, include")
 	}
+	if ctx.SkillSource != "" && ctx.SkillSource != "omit" && ctx.SkillSource != "file_ref" {
+		errs = append(errs, "judge.context.skill_source must be one of: omit, file_ref")
+	}
 	return errs
 }
 

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -1218,6 +1218,19 @@ func TestValidator_ValidateAll(t *testing.T) {
 	})
 }
 
+func TestValidateJudgeContext_SkillSourceMode(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []string{"", "omit", "file_ref"} {
+		if errs := validateJudgeContext(&JudgeContextConfig{SkillSource: mode}); len(errs) != 0 {
+			t.Fatalf("skill_source mode %q returned errors: %v", mode, errs)
+		}
+	}
+	errs := validateJudgeContext(&JudgeContextConfig{SkillSource: "include"})
+	if len(errs) != 1 || !strings.Contains(errs[0], "judge.context.skill_source must be one of: omit, file_ref") {
+		t.Fatalf("unexpected invalid skill_source errors: %v", errs)
+	}
+}
+
 func TestValidator_JudgeSkills(t *testing.T) {
 	t.Parallel()
 	validator := NewValidator()

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -108,6 +108,10 @@ type EvalResult struct {
 
 	// Configuration is "with_skill" or "without_skill".
 	Configuration string
+
+	// skillSources is the immutable pre-execution snapshot supplied only to
+	// agent_judge. It is intentionally excluded from public result formats.
+	skillSources []judge.SkillSource
 }
 
 // CaseResult is an alias for EvalResult for backward compatibility with runner.
@@ -395,6 +399,7 @@ func (e *defaultEvaluator) executeCaseOnce(ctx context.Context, caseCfg *config.
 	logging.DebugContextf(ctx, "Runner: case %s (%s): %s", caseCfg.ID, configName, caseCfg.Title)
 
 	judgeCfg := judge.MergeJudgeConfig(e.evalCfg.Judge, caseCfg.Judge)
+	result.skillSources = e.captureEvaluatedSkillSources(ctx, configName, judgeCfg)
 
 	// Multi-turn branch: delegate to dedicated engine when the case defines
 	// input.turns AND the agent supports session resumption. Agents that do
@@ -507,15 +512,19 @@ func (e *defaultEvaluator) evaluateCaseSession(
 	sessionResult *agent.SessionResult,
 	result *EvalResult,
 ) EvalResult {
+	caseTranscript := sessionTranscript(sessionResult)
 	judgeInput := judge.Input{
 		CaseID:         caseCfg.ID,
 		FinalMessage:   result.FinalMessage,
 		ExitCode:       result.ExitCode,
 		WorkspacePath:  rt.Workspace(),
 		SkillDir:       e.skillDir,
+		Configuration:  configName,
+		SkillSources:   slices.Clone(result.skillSources),
+		SkillUsage:     judge.InferSkillUsageEvidence(caseTranscript),
 		TurnsExecuted:  result.Turns,
 		TurnsTotal:     turnsTotal,
-		Transcript:     sessionTranscript(sessionResult),
+		Transcript:     caseTranscript,
 		WorkspaceDiff:  sessionWorkspaceDiff(sessionResult),
 		GeneratedFiles: sessionGeneratedFiles(sessionResult),
 		SessionResult:  sessionResult,
@@ -542,6 +551,38 @@ func (e *defaultEvaluator) evaluateCaseSession(
 	}
 
 	return finalResult
+}
+
+func (e *defaultEvaluator) evaluatedSkillSources(configName string) []judge.SkillSource {
+	if configName == "without_skill" || len(e.evalCfg.Skills) == 0 {
+		return nil
+	}
+	skillDir := e.resolvedSkillDir()
+	sources := make([]judge.SkillSource, 0, len(e.evalCfg.Skills))
+	for _, ref := range e.evalCfg.Skills {
+		resolved := resolveSkillConfig(skillDir, ref)
+		sources = append(sources, judge.SkillSource{
+			Name:    filepath.Base(filepath.Clean(resolved.Source)),
+			Path:    resolved.Source,
+			Include: slices.Clone(resolved.Include),
+			Exclude: slices.Clone(resolved.Exclude),
+		})
+	}
+	return sources
+}
+
+func (e *defaultEvaluator) captureEvaluatedSkillSources(ctx context.Context, configName string, judgeCfg config.JudgeConfig) []judge.SkillSource {
+	if judgeCfg.Type != judgeTypeAgentJudge {
+		return nil
+	}
+	sources, err := judge.CaptureSkillSources(e.evaluatedSkillSources(configName), judgeCfg.Context)
+	if err != nil {
+		// Diagnosis context is optional and must not turn a runnable evaluation
+		// into ERROR when local source snapshotting is unavailable.
+		logging.WarnContextf(ctx, "Evaluator: evaluated Skill source snapshot unavailable: %v", err)
+		return nil
+	}
+	return sources
 }
 
 func (e *defaultEvaluator) runExpectPreCheck(

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -3739,6 +3739,34 @@ func TestGitInitUploader_InitWithRemotes(t *testing.T) {
 	}
 }
 
+func TestEvaluatedSkillSources_UsesInstalledSourceAndExcludesBaseline(t *testing.T) {
+	skillDir := t.TempDir()
+	e := &defaultEvaluator{
+		skillDir: skillDir,
+		evalCfg: &config.EvalConfig{Skills: []config.SkillRef{{
+			Source:  "local_path",
+			Path:    ".",
+			Include: []string{"SKILL.md", "references/**"},
+			Exclude: []string{"references/drafts/**"},
+		}}},
+	}
+
+	sources := e.evaluatedSkillSources("with_skill")
+	if len(sources) != 1 || filepath.Clean(sources[0].Path) != filepath.Clean(skillDir) {
+		t.Fatalf("unexpected evaluated Skill sources: %#v", sources)
+	}
+	if sources[0].Name != filepath.Base(skillDir) {
+		t.Fatalf("evaluated Skill name = %q, want %q", sources[0].Name, filepath.Base(skillDir))
+	}
+	if !slices.Equal(sources[0].Include, []string{"SKILL.md", "references/**"}) ||
+		!slices.Equal(sources[0].Exclude, []string{"references/drafts/**"}) {
+		t.Fatalf("Skill filters not preserved: %#v", sources[0])
+	}
+	if baseline := e.evaluatedSkillSources("without_skill"); baseline != nil {
+		t.Fatalf("without_skill baseline must not expose Skill sources: %#v", baseline)
+	}
+}
+
 // absoluteSecretPath returns a path that filepath.IsAbs reports as absolute on
 // the host OS. On Windows that requires a drive letter; `\tmp\secret.txt`
 // alone is considered relative.

--- a/internal/judge/agent_judge.go
+++ b/internal/judge/agent_judge.go
@@ -54,6 +54,10 @@ type CriterionResult struct {
 
 	// Failures contains unmet requirements for a failed criterion.
 	Failures []string `json:"failures"`
+
+	// Diagnosis is kept as raw JSON so optional diagnostic mistakes never
+	// invalidate an otherwise valid, strict verdict response.
+	Diagnosis json.RawMessage `json:"diagnosis,omitempty"`
 }
 
 // judgeResponse is the expected JSON structure from the agent judge output.
@@ -182,7 +186,7 @@ func (j *AgentJudge) Evaluate(ctx context.Context, in Input) (*Result, error) {
 	}
 	logging.WarnContextf(ctx, "agent_judge output failed validation; retrying once with correction guidance: %v", validationErr)
 
-	correctionPrompt := buildAgentJudgeCorrectionPrompt(j.Criteria, validationErr)
+	correctionPrompt := buildAgentJudgeCorrectionPrompt(j.Criteria, validationErr, materialized)
 	retryArtifactDir := ""
 	if in.ArtifactDir != "" {
 		retryArtifactDir = filepath.Join(in.ArtifactDir, agentJudgeRetryArtifactDir)
@@ -469,10 +473,15 @@ func appendUniqueArtifactFiles(groups ...[]agent.ArtifactFile) []agent.ArtifactF
 func (j *AgentJudge) buildResult(in Input, sessionResult *agent.SessionResult, materialized *MaterializedContext, prompt string, criterionResults []CriterionResult) *Result {
 	assertions := make([]AssertionResult, 0, len(criterionResults))
 	for i, cr := range criterionResults {
+		var diagnosis *FailureDiagnosis
+		if !*cr.Passed {
+			diagnosis = normalizeFailureDiagnosis(cr.Diagnosis, in)
+		}
 		assertions = append(assertions, AssertionResult{
-			Text:     j.Criteria[i],
-			Passed:   *cr.Passed,
-			Evidence: formatCriterionEvidence(cr),
+			Text:      j.Criteria[i],
+			Passed:    *cr.Passed,
+			Evidence:  formatCriterionEvidence(cr),
+			Diagnosis: diagnosis,
 		})
 	}
 
@@ -589,6 +598,72 @@ func formatCriterionEvidence(result CriterionResult) string {
 	return evidence
 }
 
+func normalizeFailureDiagnosis(raw json.RawMessage, in Input) *FailureDiagnosis {
+	if len(raw) == 0 || strings.TrimSpace(string(raw)) == "null" {
+		return nil
+	}
+
+	var diagnosis FailureDiagnosis
+	if err := json.Unmarshal(raw, &diagnosis); err != nil {
+		return nil
+	}
+	diagnosis.FailureAttribution = FailureAttribution(strings.TrimSpace(string(diagnosis.FailureAttribution)))
+	diagnosis.Confidence = DiagnosisConfidence(strings.TrimSpace(string(diagnosis.Confidence)))
+	diagnosis.AttributionEvidence = strings.TrimSpace(diagnosis.AttributionEvidence)
+	diagnosis.ImprovementSuggestion = strings.TrimSpace(diagnosis.ImprovementSuggestion)
+	if diagnosis.FailureAttribution == "" || diagnosis.AttributionEvidence == "" || diagnosis.ImprovementSuggestion == "" {
+		return nil
+	}
+	if !validFailureAttribution(diagnosis.FailureAttribution) {
+		diagnosis.FailureAttribution = FailureAttributionOther
+	}
+	if !validDiagnosisConfidence(diagnosis.Confidence) {
+		diagnosis.Confidence = DiagnosisConfidenceLow
+	}
+
+	if in.Configuration == configurationWithoutSkill && isSkillAttribution(diagnosis.FailureAttribution) {
+		return nil
+	}
+	if diagnosis.FailureAttribution == FailureAttributionSkillNotTriggered &&
+		(in.SkillUsage == nil || !in.SkillUsage.Reliable || in.SkillUsage.Status != SkillUsageNotTriggered) {
+		return nil
+	}
+	return &diagnosis
+}
+
+func validFailureAttribution(attribution FailureAttribution) bool {
+	switch attribution {
+	case FailureAttributionSkillNotTriggered,
+		FailureAttributionSkillMissingInfo,
+		FailureAttributionSkillMisleadingInfo,
+		FailureAttributionCaseDesignIssue,
+		FailureAttributionEnvironmentConfiguration,
+		FailureAttributionExternalDependencyUnavailable,
+		FailureAttributionInfrastructureError,
+		FailureAttributionAgentCapability,
+		FailureAttributionUndetermined,
+		FailureAttributionOther:
+		return true
+	default:
+		return false
+	}
+}
+
+func validDiagnosisConfidence(confidence DiagnosisConfidence) bool {
+	switch confidence {
+	case DiagnosisConfidenceLow, DiagnosisConfidenceMedium, DiagnosisConfidenceHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+func isSkillAttribution(attribution FailureAttribution) bool {
+	return attribution == FailureAttributionSkillNotTriggered ||
+		attribution == FailureAttributionSkillMissingInfo ||
+		attribution == FailureAttributionSkillMisleadingInfo
+}
+
 // decodeAgentJudgeResponse accepts one JSON object, optionally wrapped in one
 // complete JSON code fence, and rejects unknown fields or trailing values.
 func decodeAgentJudgeResponse(output string, v any) error {
@@ -624,6 +699,7 @@ const (
 	agentJudgeJSONResponse
 	agentJudgeJSONResults
 	agentJudgeJSONResult
+	agentJudgeJSONDiagnosis
 )
 
 // validateAgentJudgeJSONKeys scans the JSON token stream before decoding into
@@ -657,7 +733,7 @@ func scanAgentJudgeJSONValue(decoder *json.Decoder, contractContext agentJudgeJS
 			if !ok {
 				return errors.New("JSON object key is not a string")
 			}
-			if _, exists := seen[key]; exists {
+			if duplicateAgentJudgeJSONKey(seen, key, contractContext) {
 				return fmt.Errorf("duplicate JSON object key %q", key)
 			}
 			seen[key] = struct{}{}
@@ -687,6 +763,11 @@ func scanAgentJudgeJSONValue(decoder *json.Decoder, contractContext agentJudgeJS
 	return err
 }
 
+func duplicateAgentJudgeJSONKey(seen map[string]struct{}, key string, contractContext agentJudgeJSONContext) bool {
+	_, exists := seen[key]
+	return exists && contractContext != agentJudgeJSONDiagnosis
+}
+
 func agentJudgeJSONChildContext(contractContext agentJudgeJSONContext, key string) (agentJudgeJSONContext, bool) {
 	switch contractContext {
 	case agentJudgeJSONResponse:
@@ -698,9 +779,13 @@ func agentJudgeJSONChildContext(contractContext agentJudgeJSONContext, key strin
 		switch key {
 		case "criterion_id", "passed", "evidence", "failures":
 			return agentJudgeJSONAny, true
+		case "diagnosis":
+			return agentJudgeJSONDiagnosis, true
 		default:
 			return agentJudgeJSONAny, false
 		}
+	case agentJudgeJSONDiagnosis:
+		return agentJudgeJSONDiagnosis, true
 	default:
 		return agentJudgeJSONAny, true
 	}
@@ -782,6 +867,7 @@ func buildJudgePrompt(_ context.Context, criteria []string, materialized *Materi
 	sb.WriteString("- \"evidence\": a non-empty JSON array of concrete observations supporting your judgment\n")
 	sb.WriteString("- \"failures\": an empty JSON array when passed is true, otherwise a non-empty array of unmet requirements\n\n")
 	sb.WriteString("You MUST NOT pass a criterion without specific evidence.\n\n")
+	appendDiagnosisInstructions(&sb, materialized)
 	sb.WriteString("IMPORTANT: Return only the required JSON object, optionally wrapped in one JSON code fence. Do not add prose or extra fields. ")
 	sb.WriteString("Escape double quotes inside string values (e.g. \\\"example\\\").\n\n")
 
@@ -797,7 +883,7 @@ func buildJudgePrompt(_ context.Context, criteria []string, materialized *Materi
 	return sb.String()
 }
 
-func buildAgentJudgeCorrectionPrompt(criteria []string, validationErr error) string {
+func buildAgentJudgeCorrectionPrompt(criteria []string, validationErr error, materialized *MaterializedContext) string {
 	encodedError, err := json.Marshal(validationErr.Error())
 	if err != nil {
 		encodedError = []byte(`"agent_judge response validation failed"`)
@@ -812,8 +898,10 @@ func buildAgentJudgeCorrectionPrompt(criteria []string, validationErr error) str
 	sb.WriteString("\n\n")
 	sb.WriteString("Allowed root field: results.\n")
 	sb.WriteString("Required result fields with exact casing: criterion_id, passed, evidence, failures.\n")
+	sb.WriteString("The only additional result field is diagnosis, using the exact casing shown below.\n")
 	sb.WriteString("Use every configured criterion_id exactly once. Evidence must be a non-empty string array. ")
 	sb.WriteString("Failures must be empty when passed is true and non-empty when passed is false.\n")
+	appendDiagnosisInstructions(&sb, materialized)
 	appendRequiredResponseFormat(&sb, criteria)
 	return sb.String()
 }
@@ -833,6 +921,38 @@ func buildAgentJudgeFallbackCorrectionPrompt(originalPrompt, invalidResponse, co
 	sb.WriteString("\n\n")
 	sb.WriteString(correctionPrompt)
 	return sb.String()
+}
+
+func appendDiagnosisInstructions(sb *strings.Builder, materialized *MaterializedContext) {
+	configuration := configurationWithSkill
+	var usage *SkillUsageEvidence
+	if materialized != nil {
+		if materialized.Configuration != "" {
+			configuration = materialized.Configuration
+		}
+		usage = materialized.SkillUsage
+	}
+
+	sb.WriteString("For each FAILED criterion, provide a \"diagnosis\" object with:\n")
+	sb.WriteString("- \"failure_attribution\": one allowed category from the list below\n")
+	sb.WriteString("- \"confidence\": \"low\", \"medium\", or \"high\"\n")
+	sb.WriteString("- \"attribution_evidence\": why the available materials support the likely cause; do not repeat verdict evidence\n")
+	sb.WriteString("- \"improvement_suggestion\": one concrete next action\n")
+	sb.WriteString("Diagnosis is required for failed criteria and must be omitted for passed criteria. If the cause is not defensible from evidence, use \"undetermined\" and low confidence. Never invent evidence.\n")
+	sb.WriteString("Allowed failure_attribution values: skill_not_triggered, skill_missing_info, skill_misleading_info, case_design_issue, environment_configuration, external_dependency_unavailable, infrastructure_error, agent_capability, undetermined, other.\n")
+	fmt.Fprintf(sb, "Evaluation configuration: %s.\n", configuration)
+	if configuration == configurationWithoutSkill {
+		sb.WriteString("This is an intentional without_skill baseline. Do not use skill_not_triggered, skill_missing_info, or skill_misleading_info.\n")
+	}
+	if usage == nil || !usage.Reliable || usage.Status == SkillUsageUnavailable {
+		sb.WriteString("Reliable Skill-usage evidence is unavailable. Do not use skill_not_triggered.\n\n")
+		return
+	}
+	if usage.Status == SkillUsageTriggered {
+		sb.WriteString("An explicit Skill invocation was observed. Do not use skill_not_triggered.\n\n")
+		return
+	}
+	sb.WriteString("A complete engine evidence channel reports that the Skill was not triggered; skill_not_triggered may be used when relevant.\n\n")
 }
 
 func appendJudgeSkillInstructions(sb *strings.Builder, skills []SkillInfo) {
@@ -886,12 +1006,12 @@ func appendReviewMaterials(sb *strings.Builder, materialized *MaterializedContex
 
 func appendRequiredResponseFormat(sb *strings.Builder, criteria []string) {
 	sb.WriteString("\n## Required Response Format (JSON)\n")
-	sb.WriteString("Use each criterion_id exactly once. Set passed and the arrays according to your judgment.\n")
+	sb.WriteString("Use each criterion_id exactly once. Set passed and the arrays according to your judgment. Diagnosis is null/omitted for a pass and populated for a failure.\n")
 	sb.WriteString("```json\n")
 	sb.WriteString("{\n")
 	sb.WriteString("  \"results\": [\n")
 	for i := range criteria {
-		fmt.Fprintf(sb, "    {\"criterion_id\": %q, \"passed\": true, \"evidence\": [\"concrete observation\"], \"failures\": []}", criterionID(i))
+		fmt.Fprintf(sb, "    {\"criterion_id\": %q, \"passed\": true, \"evidence\": [\"concrete observation\"], \"failures\": [], \"diagnosis\": null}", criterionID(i))
 		if i < len(criteria)-1 {
 			sb.WriteString(",")
 		}

--- a/internal/judge/agent_judge_test.go
+++ b/internal/judge/agent_judge_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -898,6 +899,177 @@ func TestAgentJudge_ConfiguredCriteriaRemainAuthoritative(t *testing.T) {
 	}
 }
 
+func TestAgentJudge_FailedCriterionIncludesDiagnosis(t *testing.T) {
+	criterion := testCriterionResult(0, false, "report.md was not created")
+	criterion.Diagnosis = json.RawMessage(`{
+		"failure_attribution":"skill_missing_info",
+		"confidence":"high",
+		"attribution_evidence":"SKILL.md does not define the required filename",
+		"improvement_suggestion":"Add the required report.md filename to SKILL.md",
+		"future_optional_field":"ignored"
+	}`)
+	ag := &mockJudgeTestAgent{output: buildMockAgentOutput([]CriterionResult{criterion})}
+	j := NewAgentJudge(ag, &mockJudgeTestRuntime{}, "test-model", []string{"writes report.md"}, nil, 0)
+
+	result, err := j.Evaluate(context.Background(), Input{
+		FinalMessage:  "wrote summary.txt",
+		Configuration: "with_skill",
+		SkillUsage:    &SkillUsageEvidence{Status: SkillUsageUnavailable},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	diagnosis := result.AssertionResults[0].Diagnosis
+	if diagnosis == nil {
+		t.Fatal("expected failed criterion diagnosis")
+	}
+	if diagnosis.FailureAttribution != FailureAttributionSkillMissingInfo || diagnosis.Confidence != DiagnosisConfidenceHigh {
+		t.Fatalf("unexpected diagnosis: %#v", diagnosis)
+	}
+	if diagnosis.AttributionEvidence != "SKILL.md does not define the required filename" ||
+		diagnosis.ImprovementSuggestion != "Add the required report.md filename to SKILL.md" {
+		t.Fatalf("diagnosis text was not preserved: %#v", diagnosis)
+	}
+}
+
+func TestAgentJudge_PassedCriterionDiscardsDiagnosis(t *testing.T) {
+	criterion := testCriterionResult(0, true, "output exists")
+	criterion.Diagnosis = json.RawMessage(`{
+		"failure_attribution":"skill_missing_info",
+		"confidence":"high",
+		"attribution_evidence":"must not survive",
+		"improvement_suggestion":"must not survive"
+	}`)
+	j := NewAgentJudge(
+		&mockJudgeTestAgent{output: buildMockAgentOutput([]CriterionResult{criterion})},
+		&mockJudgeTestRuntime{},
+		"test-model",
+		[]string{"configured"},
+		nil,
+		0,
+	)
+	result, err := j.Evaluate(context.Background(), Input{FinalMessage: "test", Configuration: "with_skill"})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if result.AssertionResults[0].Diagnosis != nil {
+		t.Fatalf("passed criterion retained diagnosis: %#v", result.AssertionResults[0].Diagnosis)
+	}
+}
+
+func TestAgentJudge_MalformedOptionalDiagnosisDoesNotInvalidateVerdict(t *testing.T) {
+	criterion := testCriterionResult(0, false, "missing output")
+	criterion.Diagnosis = json.RawMessage(`{
+		"failure_attribution":"other",
+		"confidence":"low",
+		"confidence":"high",
+		"attribution_evidence":"optional metadata is malformed",
+		"improvement_suggestion":"inspect it"
+	}`)
+	j := NewAgentJudge(
+		&mockJudgeTestAgent{output: buildMockAgentOutput([]CriterionResult{criterion})},
+		&mockJudgeTestRuntime{},
+		"test-model",
+		[]string{"configured"},
+		nil,
+		0,
+	)
+	result, err := j.Evaluate(context.Background(), Input{FinalMessage: "test", Configuration: "with_skill"})
+	if err != nil {
+		t.Fatalf("optional diagnosis invalidated verdict: %v", err)
+	}
+	if result.Status != StatusFail {
+		t.Fatalf("status = %s, want FAIL", result.Status)
+	}
+}
+
+func TestNormalizeFailureDiagnosis_IsLenientAndEnforcesEvidenceBoundaries(t *testing.T) {
+	valid := func(attribution, confidence string) json.RawMessage {
+		return json.RawMessage(fmt.Sprintf(`{
+			"failure_attribution":%q,
+			"confidence":%q,
+			"attribution_evidence":"cause evidence",
+			"improvement_suggestion":"take action"
+		}`, attribution, confidence))
+	}
+
+	tests := []struct {
+		name    string
+		raw     json.RawMessage
+		input   Input
+		want    FailureAttribution
+		wantNil bool
+	}{
+		{name: "malformed type is ignored", raw: json.RawMessage(`"not-an-object"`), wantNil: true},
+		{name: "missing suggestion is ignored", raw: json.RawMessage(`{"failure_attribution":"other","attribution_evidence":"why"}`), wantNil: true},
+		{name: "unknown attribution normalizes to other", raw: valid("future_category", "future_confidence"), want: FailureAttributionOther},
+		{name: "baseline rejects skill attribution", raw: valid("skill_missing_info", "high"), input: Input{Configuration: "without_skill"}, wantNil: true},
+		{name: "unavailable usage rejects not-triggered", raw: valid("skill_not_triggered", "high"), input: Input{Configuration: "with_skill", SkillUsage: &SkillUsageEvidence{Status: SkillUsageUnavailable}}, wantNil: true},
+		{name: "reliable negative usage permits not-triggered", raw: valid("skill_not_triggered", "high"), input: Input{Configuration: "with_skill", SkillUsage: &SkillUsageEvidence{Status: SkillUsageNotTriggered, Reliable: true}}, want: FailureAttributionSkillNotTriggered},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeFailureDiagnosis(tt.raw, tt.input)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("normalizeFailureDiagnosis() = %#v, want nil", got)
+				}
+				return
+			}
+			if got == nil || got.FailureAttribution != tt.want {
+				t.Fatalf("normalizeFailureDiagnosis() = %#v, want attribution %q", got, tt.want)
+			}
+			if tt.name == "unknown attribution normalizes to other" && got.Confidence != DiagnosisConfidenceLow {
+				t.Fatalf("unknown confidence = %q, want low", got.Confidence)
+			}
+		})
+	}
+}
+
+func TestBuildJudgePrompt_ExplainsDiagnosisAndBaselineRestrictions(t *testing.T) {
+	materialized := &MaterializedContext{
+		Configuration: "without_skill",
+		SkillUsage:    &SkillUsageEvidence{Status: SkillUsageUnavailable},
+	}
+	prompt := buildJudgePrompt(context.Background(), []string{"criterion A"}, materialized)
+	for _, want := range []string{
+		`"diagnosis"`,
+		`"attribution_evidence"`,
+		"environment_configuration",
+		"undetermined",
+		"Diagnosis is required for failed criteria",
+		"intentional without_skill baseline",
+		"Do not use skill_not_triggered",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestInferSkillUsageEvidence_RequiresExplicitToolCall(t *testing.T) {
+	unavailable := InferSkillUsageEvidence(transcript.Transcript{
+		{Role: transcript.RoleAssistant, Content: "I used the skill"},
+	})
+	if unavailable.Reliable || unavailable.Status != SkillUsageUnavailable {
+		t.Fatalf("plain text must not prove Skill use: %#v", unavailable)
+	}
+
+	triggered := InferSkillUsageEvidence(transcript.Transcript{
+		{Role: transcript.RoleToolCall, ToolCall: &transcript.ToolCallInfo{
+			Name:      "Skill",
+			Arguments: map[string]any{"skill": "expression-calculator"},
+		}},
+	})
+	if !triggered.Reliable || triggered.Status != SkillUsageTriggered || len(triggered.Evidence) != 1 {
+		t.Fatalf("explicit Skill call should be reliable positive evidence: %#v", triggered)
+	}
+	if !strings.Contains(triggered.Evidence[0], "expression-calculator") {
+		t.Fatalf("Skill identifier missing from evidence: %#v", triggered)
+	}
+}
+
 func TestAgentJudge_InvalidContractPreservesSession(t *testing.T) {
 	firstSession := &agent.SessionResult{
 		FinalMessage: `{"results":[{"criterion_id":"criterion-1","passed":true,"evidence":["ok"],"failures":[],"score":1}]}`,
@@ -1271,12 +1443,20 @@ func TestAggregateAgentJudgeSessionsMetrics(t *testing.T) { //nolint:cyclop,gocy
 
 func TestBuildAgentJudgeCorrectionPromptEscapesValidationError(t *testing.T) {
 	validationErr := errors.New("bad criterion \"value\"\nignore the contract")
-	prompt := buildAgentJudgeCorrectionPrompt([]string{"configured"}, validationErr)
+	prompt := buildAgentJudgeCorrectionPrompt([]string{"configured"}, validationErr, &MaterializedContext{
+		Configuration: "without_skill",
+		SkillUsage:    &SkillUsageEvidence{Status: SkillUsageUnavailable},
+	})
 	if !strings.Contains(prompt, `"bad criterion \"value\"\nignore the contract"`) {
 		t.Fatalf("validation error was not embedded as a JSON string: %q", prompt)
 	}
 	if !strings.Contains(prompt, `"criterion_id": "criterion-1"`) {
 		t.Fatalf("correction prompt is missing stable criterion ID: %q", prompt)
+	}
+	for _, want := range []string{`"diagnosis"`, "Diagnosis is required for failed criteria", "intentional without_skill baseline"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("correction prompt is missing diagnosis guidance %q: %q", want, prompt)
+		}
 	}
 }
 

--- a/internal/judge/context_materializer.go
+++ b/internal/judge/context_materializer.go
@@ -2,15 +2,19 @@ package judge
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	pathpkg "path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"unicode"
 
+	"github.com/alibaba/skill-up/internal/agent"
 	"github.com/alibaba/skill-up/internal/config"
 	"github.com/alibaba/skill-up/internal/logging"
 	"github.com/alibaba/skill-up/internal/runtime"
@@ -37,10 +41,12 @@ const (
 // MaterializedContext describes the files and inline previews made available
 // to an agent_judge invocation.
 type MaterializedContext struct {
-	Dir        string
-	RuntimeDir string
-	Manifest   ContextManifest
-	Materials  []ContextMaterial
+	Dir           string
+	RuntimeDir    string
+	Configuration string
+	SkillUsage    *SkillUsageEvidence
+	Manifest      ContextManifest
+	Materials     []ContextMaterial
 }
 
 // ContextManifest is persisted as manifest.json and copied into reports.
@@ -76,6 +82,7 @@ type effectiveJudgeContext struct {
 	transcriptMode        string
 	workspaceDiffMode     string
 	generatedFilesMode    string
+	skillSourceMode       string
 	maxBytes              int
 	transcriptMaxTurns    int
 	workspaceDiffMaxLines int
@@ -102,8 +109,10 @@ func MaterializeJudgeContext(ctx context.Context, rt runtime.Runtime, cfg *confi
 		runtimeDir = filepath.Join(rt.Workspace(), runtimeDir)
 	}
 	mc := &MaterializedContext{
-		Dir:        hostDir,
-		RuntimeDir: runtimeDir,
+		Dir:           hostDir,
+		RuntimeDir:    runtimeDir,
+		Configuration: in.Configuration,
+		SkillUsage:    in.SkillUsage,
 		Manifest: ContextManifest{
 			Profile:         effective.profile,
 			MaterializedDir: judgeContextArtifactDir,
@@ -124,7 +133,7 @@ func MaterializeJudgeContext(ctx context.Context, rt runtime.Runtime, cfg *confi
 	if err := materializeText(ctx, rt, mc, "workspace_diff", "workspace.diff", diff, effective.workspaceDiffMode, effective.maxBytes); err != nil {
 		return nil, err
 	}
-	if err := materializeGeneratedFiles(ctx, rt, mc, in.GeneratedFiles, effective.generatedFilesMode, effective.maxBytes); err != nil {
+	if err := materializeExtendedContext(ctx, rt, mc, in, effective); err != nil {
 		return nil, err
 	}
 	if err := materializeAttachments(ctx, rt, mc, effective.attachments, in); err != nil {
@@ -157,6 +166,7 @@ func resolveJudgeContext(cfg *config.JudgeContextConfig) effectiveJudgeContext {
 		profile:               profile,
 		maxBytes:              defaultJudgeContextMaxBytes,
 		generatedFilesMode:    judgeContextGeneratedIndex,
+		skillSourceMode:       judgeContextModeFileRef,
 		workspaceDiffMaxLines: 0,
 	}
 	switch profile {
@@ -165,6 +175,7 @@ func resolveJudgeContext(cfg *config.JudgeContextConfig) effectiveJudgeContext {
 		effective.transcriptMode = judgeContextModeOmit
 		effective.workspaceDiffMode = judgeContextModeOmit
 		effective.generatedFilesMode = judgeContextGeneratedOmit
+		effective.skillSourceMode = judgeContextModeOmit
 	default:
 		effective.finalMessageMode = judgeContextModeInclude
 		effective.transcriptMode = judgeContextModeFileRef
@@ -184,6 +195,9 @@ func resolveJudgeContext(cfg *config.JudgeContextConfig) effectiveJudgeContext {
 	}
 	if cfg.GeneratedFiles != "" {
 		effective.generatedFilesMode = cfg.GeneratedFiles
+	}
+	if cfg.SkillSource != "" {
+		effective.skillSourceMode = cfg.SkillSource
 	}
 	if cfg.Limits != nil {
 		if cfg.Limits.MaxBytes > 0 {
@@ -381,6 +395,305 @@ func materializeGeneratedFiles(ctx context.Context, rt runtime.Runtime, mc *Mate
 		textMode = judgeContextModeInclude
 	}
 	return materializeText(ctx, rt, mc, "generated_files", "generated_files.txt", content, textMode, maxBytes)
+}
+
+type skillSourceIndex struct {
+	Configuration string                  `json:"configuration"`
+	Skills        []skillSourceIndexEntry `json:"skills"`
+}
+
+type skillSourceIndexEntry struct {
+	Name  string                 `json:"name"`
+	Files []skillSourceIndexFile `json:"files"`
+}
+
+type skillSourceIndexFile struct {
+	Path         string `json:"path"`
+	Bytes        int    `json:"bytes"`
+	SHA256       string `json:"sha256"`
+	MaterialPath string `json:"material_path,omitempty"`
+}
+
+// CaptureSkillSources freezes the evaluated Skill inputs before Agent
+// execution. The returned snapshots are bounded by the effective judge context
+// limit and can be materialized later without re-reading mutable source paths.
+func CaptureSkillSources(sources []SkillSource, cfg *config.JudgeContextConfig) ([]SkillSource, error) {
+	effective := resolveJudgeContext(cfg)
+	if effective.skillSourceMode == judgeContextModeOmit || len(sources) == 0 {
+		return nil, nil
+	}
+	return captureSkillSourcesWithLimit(sources, effective.maxBytes)
+}
+
+func materializeSkillSources(ctx context.Context, rt runtime.Runtime, mc *MaterializedContext, in Input, mode string, maxBytes int) error {
+	if mode == judgeContextModeOmit || in.Configuration == configurationWithoutSkill {
+		return materializeText(ctx, rt, mc, "skill_source", "skill_source/index.json", "", judgeContextModeOmit, maxBytes)
+	}
+
+	sources := append([]SkillSource(nil), in.SkillSources...)
+	if len(sources) == 0 {
+		return materializeText(ctx, rt, mc, "skill_source", "skill_source/index.json", "", judgeContextModeOmit, maxBytes)
+	}
+	if !skillSourcesCaptured(sources) {
+		var err error
+		sources, err = captureSkillSourcesWithLimit(sources, maxBytes)
+		if err != nil {
+			return err
+		}
+	}
+
+	index := skillSourceIndex{Configuration: normalizedConfiguration(in.Configuration)}
+	for sourceIndex, source := range sources {
+		entry, err := materializeCapturedSkillSource(ctx, rt, mc, sourceIndex, source)
+		if err != nil {
+			return err
+		}
+		index.Skills = append(index.Skills, entry)
+	}
+
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal skill source index: %w", err)
+	}
+	data = append(data, '\n')
+	return materializeText(ctx, rt, mc, "skill_source", "skill_source/index.json", string(data), judgeContextModeFileRef, maxBytes)
+}
+
+func materializeDiagnosticContext(ctx context.Context, rt runtime.Runtime, mc *MaterializedContext, in Input, effective effectiveJudgeContext) error {
+	if err := materializeSkillSources(ctx, rt, mc, in, effective.skillSourceMode, effective.maxBytes); err != nil {
+		// Skill source is diagnostic enrichment, not verdict input required by
+		// the existing contract. Preserve evaluation compatibility by recording
+		// it as unavailable when snapshotting fails.
+		logging.WarnContextf(ctx, "Judge context: evaluated Skill source unavailable: %v", err)
+		if fallbackErr := materializeText(ctx, rt, mc, "skill_source", "skill_source/index.json", "", judgeContextModeOmit, effective.maxBytes); fallbackErr != nil {
+			return fallbackErr
+		}
+	}
+	return materializeSkillUsage(ctx, rt, mc, in.SkillUsage, effective.maxBytes)
+}
+
+func materializeExtendedContext(ctx context.Context, rt runtime.Runtime, mc *MaterializedContext, in Input, effective effectiveJudgeContext) error {
+	if err := materializeGeneratedFiles(ctx, rt, mc, in.GeneratedFiles, effective.generatedFilesMode, effective.maxBytes); err != nil {
+		return err
+	}
+	return materializeDiagnosticContext(ctx, rt, mc, in, effective)
+}
+
+func captureSkillSourcesWithLimit(sources []SkillSource, maxBytes int) ([]SkillSource, error) {
+	captured := make([]SkillSource, 0, len(sources))
+	remainingBytes := maxBytes
+	for _, source := range sources {
+		snapshot, nextRemaining, err := captureOneSkillSource(source, remainingBytes)
+		if err != nil {
+			return nil, err
+		}
+		captured = append(captured, snapshot)
+		remainingBytes = nextRemaining
+	}
+	return captured, nil
+}
+
+func captureOneSkillSource(source SkillSource, remainingBytes int) (SkillSource, int, error) {
+	if source.Captured {
+		return cloneCapturedSkillSource(source, remainingBytes)
+	}
+
+	files, err := agent.ListSkillFiles(source.Path, source.Include, source.Exclude)
+	if err != nil {
+		return SkillSource{}, remainingBytes, fmt.Errorf("list evaluated skill source %q: %w", source.Path, err)
+	}
+	sortSkillSourceFiles(files)
+
+	snapshot := SkillSource{
+		Name:     skillSourceName(source),
+		Path:     source.Path,
+		Include:  append([]string(nil), source.Include...),
+		Exclude:  append([]string(nil), source.Exclude...),
+		Captured: true,
+		Files:    []SkillSourceFile{},
+	}
+	for _, rel := range files {
+		sourcePath := filepath.Join(source.Path, rel)
+		info, statErr := os.Lstat(sourcePath)
+		if statErr != nil {
+			return SkillSource{}, remainingBytes, fmt.Errorf("stat evaluated skill source %q: %w", sourcePath, statErr)
+		}
+		// Do not follow symlinks while creating judge-only review material: a
+		// Skill source may contain a link outside its root, and the diagnostic
+		// snapshot must not turn that into an unintended file disclosure.
+		if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		var content *boundedCaptureWriter
+		if isReadableSkillSourceFile(rel) {
+			content = &boundedCaptureWriter{limit: remainingBytes}
+		}
+		file, captureErr := captureSkillSourceFile(sourcePath, rel, content)
+		if captureErr != nil {
+			return SkillSource{}, remainingBytes, captureErr
+		}
+		if file.HasContent {
+			remainingBytes -= file.Bytes
+		}
+		snapshot.Files = append(snapshot.Files, file)
+	}
+	return snapshot, remainingBytes, nil
+}
+
+func materializeCapturedSkillSource(
+	ctx context.Context,
+	rt runtime.Runtime,
+	mc *MaterializedContext,
+	sourceIndex int,
+	source SkillSource,
+) (skillSourceIndexEntry, error) {
+	name := skillSourceName(source)
+	entry := skillSourceIndexEntry{Name: name, Files: []skillSourceIndexFile{}}
+	for _, snapshot := range source.Files {
+		file := skillSourceIndexFile{Path: snapshot.Path, Bytes: snapshot.Bytes, SHA256: snapshot.SHA256}
+		if snapshot.HasContent {
+			materialSubdir := fmt.Sprintf("%02d-%s", sourceIndex+1, name)
+			materialName := filepath.Join("skill_source", materialSubdir, filepath.FromSlash(snapshot.Path))
+			if _, _, writeErr := writeMaterialFile(ctx, rt, mc, materialName, string(snapshot.Content)); writeErr != nil {
+				return skillSourceIndexEntry{}, writeErr
+			}
+			file.MaterialPath = filepath.ToSlash(filepath.Join(materialSubdir, filepath.FromSlash(snapshot.Path)))
+		}
+		entry.Files = append(entry.Files, file)
+	}
+	return entry, nil
+}
+
+func materializeSkillUsage(ctx context.Context, rt runtime.Runtime, mc *MaterializedContext, usage *SkillUsageEvidence, maxBytes int) error {
+	if usage == nil {
+		usage = &SkillUsageEvidence{Status: SkillUsageUnavailable}
+	}
+	mc.SkillUsage = usage
+	data, err := json.MarshalIndent(usage, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal skill usage evidence: %w", err)
+	}
+	data = append(data, '\n')
+	return materializeText(ctx, rt, mc, "skill_usage", "skill_usage.json", string(data), judgeContextModeInclude, maxBytes)
+}
+
+func normalizedConfiguration(configuration string) string {
+	if configuration == configurationWithoutSkill {
+		return configuration
+	}
+	return configurationWithSkill
+}
+
+func captureSkillSourceFile(path, rel string, content *boundedCaptureWriter) (SkillSourceFile, error) {
+	// #nosec G304 -- path is selected from an evaluated Skill source directory by ListSkillFiles.
+	file, err := os.Open(path)
+	if err != nil {
+		return SkillSourceFile{}, fmt.Errorf("read evaluated skill source %q: %w", path, err)
+	}
+	hash := sha256.New()
+	writer := io.Writer(hash)
+	if content != nil {
+		writer = io.MultiWriter(hash, content)
+	}
+	bytes, copyErr := io.Copy(writer, file)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return SkillSourceFile{}, fmt.Errorf("snapshot evaluated skill source %q: %w", path, copyErr)
+	}
+	if closeErr != nil {
+		return SkillSourceFile{}, fmt.Errorf("close evaluated skill source %q: %w", path, closeErr)
+	}
+	if bytes > int64(^uint(0)>>1) {
+		return SkillSourceFile{}, fmt.Errorf("evaluated skill source %q is too large", path)
+	}
+	snapshot := SkillSourceFile{
+		Path:   filepath.ToSlash(rel),
+		Bytes:  int(bytes),
+		SHA256: hex.EncodeToString(hash.Sum(nil)),
+	}
+	if content != nil && !content.overflow {
+		snapshot.Content = content.data
+		snapshot.HasContent = true
+	}
+	return snapshot, nil
+}
+
+type boundedCaptureWriter struct {
+	limit    int
+	data     []byte
+	overflow bool
+}
+
+func (w *boundedCaptureWriter) Write(p []byte) (int, error) {
+	remaining := w.limit - len(w.data)
+	if remaining > 0 {
+		copyBytes := min(remaining, len(p))
+		w.data = append(w.data, p[:copyBytes]...)
+	}
+	if len(p) > remaining {
+		w.overflow = true
+	}
+	return len(p), nil
+}
+
+func skillSourcesCaptured(sources []SkillSource) bool {
+	for _, source := range sources {
+		if !source.Captured {
+			return false
+		}
+	}
+	return true
+}
+
+func sortSkillSourceFiles(files []string) {
+	sort.SliceStable(files, func(i, j int) bool {
+		iSkill := strings.EqualFold(filepath.Base(files[i]), "SKILL.md")
+		jSkill := strings.EqualFold(filepath.Base(files[j]), "SKILL.md")
+		if iSkill != jSkill {
+			return iSkill
+		}
+		return filepath.ToSlash(files[i]) < filepath.ToSlash(files[j])
+	})
+}
+
+func skillSourceName(source SkillSource) string {
+	name := source.Name
+	if strings.TrimSpace(name) == "" {
+		name = filepath.Base(filepath.Clean(source.Path))
+	}
+	return safeMaterialName(name)
+}
+
+func cloneCapturedSkillSource(source SkillSource, remainingBytes int) (SkillSource, int, error) {
+	clone := source
+	clone.Include = append([]string(nil), source.Include...)
+	clone.Exclude = append([]string(nil), source.Exclude...)
+	clone.Files = make([]SkillSourceFile, len(source.Files))
+	for i, file := range source.Files {
+		clone.Files[i] = file
+		clone.Files[i].Content = append([]byte(nil), file.Content...)
+		if file.HasContent {
+			if file.Bytes <= remainingBytes {
+				remainingBytes -= file.Bytes
+				continue
+			}
+			clone.Files[i].Content = nil
+			clone.Files[i].HasContent = false
+		}
+	}
+	return clone, remainingBytes, nil
+}
+
+func isReadableSkillSourceFile(path string) bool {
+	if strings.EqualFold(filepath.Base(path), "SKILL.md") {
+		return true
+	}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".md", ".txt", ".yaml", ".yml", ".json", ".toml", ".go", ".py", ".js", ".ts", ".tsx", ".jsx", ".sh", ".ps1":
+		return true
+	default:
+		return false
+	}
 }
 
 func materializeAttachments(ctx context.Context, rt runtime.Runtime, mc *MaterializedContext, attachments []config.JudgeContextAttachment, in Input) error {

--- a/internal/judge/context_materializer_test.go
+++ b/internal/judge/context_materializer_test.go
@@ -3,6 +3,7 @@ package judge
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,6 +41,8 @@ func TestMaterializeJudgeContext_StandardProfileUsesFileRefs(t *testing.T) {
 	assertMaterialMode(t, mc.Manifest.Materials, "final_message", "include")
 	assertMaterialMode(t, mc.Manifest.Materials, "transcript", "file_ref")
 	assertMaterialMode(t, mc.Manifest.Materials, "workspace_diff", "file_ref")
+	assertMaterialMode(t, mc.Manifest.Materials, "skill_source", "omit")
+	assertMaterialMode(t, mc.Manifest.Materials, "skill_usage", "include")
 	assertMaterialPath(t, mc.Manifest.Materials, "transcript", "judge/context/transcript.json")
 	if _, err := os.Stat(filepath.Join(mc.Dir, "transcript.json")); err != nil {
 		t.Fatalf("transcript material missing: %v", err)
@@ -47,6 +50,177 @@ func TestMaterializeJudgeContext_StandardProfileUsesFileRefs(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(mc.Dir, "workspace.diff")); err != nil {
 		t.Fatalf("workspace diff material missing: %v", err)
 	}
+}
+
+func TestMaterializeJudgeContext_SnapshotsEvaluatedSkillSource(t *testing.T) {
+	skillDir := writeSkillSourceFixture(t)
+	mc, err := MaterializeJudgeContext(context.Background(), &mockJudgeTestRuntime{}, nil, Input{
+		Configuration: "with_skill",
+		SkillSources:  []SkillSource{{Path: skillDir}},
+		SkillUsage: &SkillUsageEvidence{
+			Status:   SkillUsageTriggered,
+			Reliable: true,
+			Evidence: []string{"observed explicit Skill tool call"},
+		},
+	}, filepath.Join(t.TempDir(), "judge", "run"))
+	if err != nil {
+		t.Fatalf("MaterializeJudgeContext returned error: %v", err)
+	}
+	assertMaterialMode(t, mc.Manifest.Materials, "skill_source", "file_ref")
+	assertMaterialMode(t, mc.Manifest.Materials, "skill_usage", "include")
+
+	indexData, err := os.ReadFile(filepath.Join(mc.Dir, "skill_source", "index.json"))
+	if err != nil {
+		t.Fatalf("read skill source index: %v", err)
+	}
+	var index skillSourceIndex
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		t.Fatalf("parse skill source index: %v", err)
+	}
+	assertSkillSourceIndex(t, index, mc.Dir)
+}
+
+func TestCaptureSkillSources_FreezesPreExecutionContent(t *testing.T) {
+	skillDir := t.TempDir()
+	skillPath := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillPath, []byte("# Before agent run\n"), 0o600); err != nil {
+		t.Fatalf("write initial SKILL.md: %v", err)
+	}
+	captured, err := CaptureSkillSources([]SkillSource{{Path: skillDir}}, nil)
+	if err != nil {
+		t.Fatalf("CaptureSkillSources returned error: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("# Mutated after capture\n"), 0o600); err != nil {
+		t.Fatalf("mutate SKILL.md: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(skillDir, "output"), 0o755); err != nil {
+		t.Fatalf("create post-capture output: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "output", "report.json"), []byte(`{"generated":true}`), 0o600); err != nil {
+		t.Fatalf("write post-capture output: %v", err)
+	}
+
+	mc, err := MaterializeJudgeContext(context.Background(), &mockJudgeTestRuntime{}, nil, Input{
+		Configuration: "with_skill",
+		SkillSources:  captured,
+	}, filepath.Join(t.TempDir(), "judge", "run"))
+	if err != nil {
+		t.Fatalf("MaterializeJudgeContext returned error: %v", err)
+	}
+	index := readSkillSourceIndex(t, mc.Dir)
+	if len(index.Skills) != 1 || len(index.Skills[0].Files) != 1 || index.Skills[0].Files[0].Path != "SKILL.md" {
+		t.Fatalf("post-capture files leaked into snapshot: %#v", index)
+	}
+	materialPath := index.Skills[0].Files[0].MaterialPath
+	content, err := os.ReadFile(filepath.Join(mc.Dir, "skill_source", filepath.FromSlash(materialPath)))
+	if err != nil {
+		t.Fatalf("read captured SKILL.md: %v", err)
+	}
+	if string(content) != "# Before agent run\n" {
+		t.Fatalf("materialized mutable source instead of snapshot: %q", content)
+	}
+}
+
+func writeSkillSourceFixture(t *testing.T) string {
+	t.Helper()
+	skillDir := t.TempDir()
+	files := map[string][]byte{
+		"SKILL.md":            []byte("# Calculator\nFollow references/rules.md.\n"),
+		"references/rules.md": []byte("Use one operation at a time.\n"),
+		"scripts/add.py":      []byte("print(1 + 2)\n"),
+		"assets/blob.bin":     {0x00, 0xff, 0x01},
+		"evals/secret.yaml":   []byte("must-not-be-materialized: true\n"),
+	}
+	for rel, content := range files {
+		path := filepath.Join(skillDir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	if err := os.WriteFile(outside, []byte("must-not-be-read\n"), 0o600); err != nil {
+		t.Fatalf("write external symlink target: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(skillDir, "linked-secret.md")); err != nil {
+		t.Fatalf("create source symlink: %v", err)
+	}
+	return skillDir
+}
+
+func assertSkillSourceIndex(t *testing.T, index skillSourceIndex, materializedDir string) {
+	t.Helper()
+	if index.Configuration != "with_skill" || len(index.Skills) != 1 {
+		t.Fatalf("unexpected skill source index: %#v", index)
+	}
+	indexed := make(map[string]skillSourceIndexFile)
+	for _, file := range index.Skills[0].Files {
+		indexed[file.Path] = file
+		if len(file.SHA256) != 64 {
+			t.Fatalf("%s has invalid SHA-256 %q", file.Path, file.SHA256)
+		}
+	}
+	if _, ok := indexed["evals/secret.yaml"]; ok {
+		t.Fatal("evals directory must not appear in the evaluated Skill source index")
+	}
+	if _, ok := indexed["linked-secret.md"]; ok {
+		t.Fatal("symlinked files must not appear in the evaluated Skill source index")
+	}
+	for _, rel := range []string{"SKILL.md", "references/rules.md", "scripts/add.py"} {
+		file, ok := indexed[rel]
+		if !ok || file.MaterialPath == "" {
+			t.Fatalf("readable source %q not materialized: %#v", rel, file)
+		}
+		if _, err := os.Stat(filepath.Join(materializedDir, "skill_source", filepath.FromSlash(file.MaterialPath))); err != nil {
+			t.Fatalf("materialized source %q missing: %v", rel, err)
+		}
+	}
+	if blob := indexed["assets/blob.bin"]; blob.MaterialPath != "" {
+		t.Fatalf("binary asset should be indexed without copied content: %#v", blob)
+	}
+}
+
+func readSkillSourceIndex(t *testing.T, materializedDir string) skillSourceIndex {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(materializedDir, "skill_source", "index.json"))
+	if err != nil {
+		t.Fatalf("read skill source index: %v", err)
+	}
+	var index skillSourceIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		t.Fatalf("parse skill source index: %v", err)
+	}
+	return index
+}
+
+func TestMaterializeJudgeContext_WithoutSkillOmitsSkillSource(t *testing.T) {
+	skillDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Skill\n"), 0o600); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	mc, err := MaterializeJudgeContext(context.Background(), &mockJudgeTestRuntime{}, &config.JudgeContextConfig{
+		SkillSource: "file_ref",
+	}, Input{
+		Configuration: "without_skill",
+		SkillSources:  []SkillSource{{Path: skillDir}},
+	}, filepath.Join(t.TempDir(), "judge", "run"))
+	if err != nil {
+		t.Fatalf("MaterializeJudgeContext returned error: %v", err)
+	}
+	assertMaterialMode(t, mc.Manifest.Materials, "skill_source", "omit")
+}
+
+func TestMaterializeJudgeContext_UnavailableSkillSourceDoesNotFailEvaluation(t *testing.T) {
+	mc, err := MaterializeJudgeContext(context.Background(), &mockJudgeTestRuntime{}, nil, Input{
+		Configuration: "with_skill",
+		SkillSources:  []SkillSource{{Path: filepath.Join(t.TempDir(), "missing")}},
+	}, filepath.Join(t.TempDir(), "judge", "run"))
+	if err != nil {
+		t.Fatalf("optional Skill source snapshot must degrade gracefully: %v", err)
+	}
+	assertMaterialMode(t, mc.Manifest.Materials, "skill_source", "omit")
 }
 
 func TestMaterializeJudgeContext_MinimalProfileOmitsLargeMaterials(t *testing.T) {
@@ -66,6 +240,7 @@ func TestMaterializeJudgeContext_MinimalProfileOmitsLargeMaterials(t *testing.T)
 	assertMaterialMode(t, mc.Manifest.Materials, "final_message", "truncate")
 	assertMaterialMode(t, mc.Manifest.Materials, "transcript", "omit")
 	assertMaterialMode(t, mc.Manifest.Materials, "workspace_diff", "omit")
+	assertMaterialMode(t, mc.Manifest.Materials, "skill_source", "omit")
 	var final ContextMaterial
 	for _, m := range mc.Materials {
 		if m.Key == "final_message" {

--- a/internal/judge/context_materializer_test.go
+++ b/internal/judge/context_materializer_test.go
@@ -52,6 +52,24 @@ func TestMaterializeJudgeContext_StandardProfileUsesFileRefs(t *testing.T) {
 	}
 }
 
+func TestResolveJudgeContext_DefaultProfileDoesNotOverrideMinimalSkillSource(t *testing.T) {
+	cfg := config.DefaultEvalConfig()
+	if cfg.Judge.Context == nil {
+		t.Fatal("default judge context is nil")
+	}
+
+	standard := resolveJudgeContext(cfg.Judge.Context)
+	if standard.profile != judgeContextProfileStandard || standard.skillSourceMode != judgeContextModeFileRef {
+		t.Fatalf("standard defaults = profile %q, skill_source %q; want standard, file_ref", standard.profile, standard.skillSourceMode)
+	}
+
+	cfg.Judge.Context.Profile = judgeContextProfileMinimal
+	minimal := resolveJudgeContext(cfg.Judge.Context)
+	if minimal.skillSourceMode != judgeContextModeOmit {
+		t.Fatalf("minimal skill_source = %q, want omit", minimal.skillSourceMode)
+	}
+}
+
 func TestMaterializeJudgeContext_SnapshotsEvaluatedSkillSource(t *testing.T) {
 	skillDir := writeSkillSourceFixture(t)
 	mc, err := MaterializeJudgeContext(context.Background(), &mockJudgeTestRuntime{}, nil, Input{

--- a/internal/judge/factory.go
+++ b/internal/judge/factory.go
@@ -115,6 +115,9 @@ func MergeJudgeContextConfig(global, caseLevel *config.JudgeContextConfig) *conf
 	if caseLevel.GeneratedFiles != "" {
 		merged.GeneratedFiles = caseLevel.GeneratedFiles
 	}
+	if caseLevel.SkillSource != "" {
+		merged.SkillSource = caseLevel.SkillSource
+	}
 	merged.Limits = mergeJudgeContextLimits(global.Limits, caseLevel.Limits)
 	if caseLevel.Attachments != nil {
 		merged.Attachments = append([]config.JudgeContextAttachment(nil), caseLevel.Attachments...)

--- a/internal/judge/factory_test.go
+++ b/internal/judge/factory_test.go
@@ -308,6 +308,7 @@ func TestMergeJudgeConfig_CaseContextOverridesGlobalFields(t *testing.T) {
 			Profile:       "standard",
 			Transcript:    "file_ref",
 			WorkspaceDiff: "file_ref",
+			SkillSource:   "file_ref",
 			Limits: &config.JudgeContextLimits{
 				MaxBytes:              100,
 				WorkspaceDiffMaxLines: 50,
@@ -320,6 +321,7 @@ func TestMergeJudgeConfig_CaseContextOverridesGlobalFields(t *testing.T) {
 		Context: &config.JudgeContextConfig{
 			Profile:      "minimal",
 			FinalMessage: "truncate",
+			SkillSource:  "omit",
 			Limits:       &config.JudgeContextLimits{TranscriptMaxTurns: 20},
 		},
 	}
@@ -336,6 +338,9 @@ func TestMergeJudgeConfig_CaseContextOverridesGlobalFields(t *testing.T) {
 	}
 	if merged.Context.FinalMessage != "truncate" {
 		t.Fatalf("final_message = %q, want truncate", merged.Context.FinalMessage)
+	}
+	if merged.Context.SkillSource != "omit" {
+		t.Fatalf("skill_source = %q, want case override omit", merged.Context.SkillSource)
 	}
 	if merged.Context.Limits == nil {
 		t.Fatalf("limits not inherited: %#v", merged.Context.Limits)

--- a/internal/judge/judge.go
+++ b/internal/judge/judge.go
@@ -13,6 +13,11 @@ import (
 	"github.com/alibaba/skill-up/pkg/transcript"
 )
 
+const (
+	configurationWithSkill    = "with_skill"
+	configurationWithoutSkill = "without_skill"
+)
+
 // Status represents the overall evaluation outcome for a case.
 type Status string
 
@@ -73,6 +78,21 @@ type Input struct {
 	// Fixture-style references such as golden_file are resolved from here.
 	SkillDir string
 
+	// Configuration identifies the evaluated variant: "with_skill" or
+	// "without_skill". Agent-judge diagnosis uses it to avoid attributing an
+	// intentional benchmark baseline failure to a missing Skill.
+	Configuration string
+
+	// SkillSources carries immutable snapshots of the exact Skill sources used
+	// by the evaluated run. It is judge-only input and is materialized
+	// separately from the run agent's installed Skill directory.
+	SkillSources []SkillSource
+
+	// SkillUsage records trustworthy Skill invocation evidence when the engine
+	// exposes it. A nil or unavailable value must not be treated as proof that
+	// the Skill was not triggered.
+	SkillUsage *SkillUsageEvidence
+
 	// WorkspaceDiff is the git diff of workspace changes after engine execution.
 	WorkspaceDiff string
 
@@ -95,6 +115,80 @@ type Input struct {
 
 	// TurnsTotal is the total number of turns defined in the case.
 	TurnsTotal int
+}
+
+// SkillSource identifies one local Skill source as installed for evaluation.
+// Include and Exclude use the same doublestar filters as config.SkillRef.
+type SkillSource struct {
+	Name    string
+	Path    string
+	Include []string
+	Exclude []string
+
+	// Captured reports that Files is an immutable pre-execution snapshot. A
+	// captured source is never re-read from Path during judging.
+	Captured bool
+	Files    []SkillSourceFile
+}
+
+// SkillSourceFile is one file in an immutable evaluated-Skill snapshot.
+// Content is retained only for readable files that fit the configured context
+// budget; every file still carries its pre-execution size and digest.
+type SkillSourceFile struct {
+	Path       string
+	Bytes      int
+	SHA256     string
+	Content    []byte
+	HasContent bool
+}
+
+// SkillUsageStatus describes what the captured engine evidence proves about
+// Skill use. Unavailable means the evidence channel cannot support either a
+// positive or negative conclusion.
+type SkillUsageStatus string
+
+const (
+	// SkillUsageUnavailable means the engine did not expose trustworthy Skill
+	// usage evidence.
+	SkillUsageUnavailable SkillUsageStatus = "unavailable"
+	// SkillUsageTriggered means at least one explicit Skill invocation was
+	// observed.
+	SkillUsageTriggered SkillUsageStatus = "triggered"
+	// SkillUsageNotTriggered means a complete engine evidence channel proved
+	// that the Skill was available but never invoked.
+	SkillUsageNotTriggered SkillUsageStatus = "not_triggered"
+)
+
+// SkillUsageEvidence is a reportable summary of engine/session Skill evidence.
+type SkillUsageEvidence struct {
+	Status   SkillUsageStatus `json:"status"`
+	Reliable bool             `json:"reliable"`
+	Evidence []string         `json:"evidence,omitempty"`
+}
+
+// InferSkillUsageEvidence extracts only positive, explicit Skill tool calls
+// from a transcript. No matching call yields unavailable rather than
+// not_triggered because not every engine exposes a complete Skill-use channel.
+func InferSkillUsageEvidence(trans transcript.Transcript) *SkillUsageEvidence {
+	evidence := &SkillUsageEvidence{Status: SkillUsageUnavailable}
+	for _, message := range trans.ToolCalls() {
+		if message.ToolCall == nil || !strings.EqualFold(strings.TrimSpace(message.ToolCall.Name), "skill") {
+			continue
+		}
+		detail := "observed explicit Skill tool call"
+		for _, key := range []string{"skill", "name"} {
+			if value, ok := message.ToolCall.Arguments[key].(string); ok && strings.TrimSpace(value) != "" {
+				detail = fmt.Sprintf("observed explicit Skill tool call for %q", strings.TrimSpace(value))
+				break
+			}
+		}
+		evidence.Evidence = append(evidence.Evidence, detail)
+	}
+	if len(evidence.Evidence) > 0 {
+		evidence.Status = SkillUsageTriggered
+		evidence.Reliable = true
+	}
+	return evidence
 }
 
 // Result corresponds to grading.json summary fields.
@@ -183,7 +277,8 @@ func SessionResultFromError(err error) *agent.SessionResult {
 
 // AssertionResult records the outcome of a single assertion or criterion.
 //
-// Mapping to grading.json assertion_results[]:
+// Mapping to result.json assertion_results[]; the Anthropic-compatible
+// grading.json projection intentionally excludes Diagnosis:
 //
 //	{ "text": "...", "passed": true, "evidence": "..." }
 type AssertionResult struct {
@@ -195,6 +290,48 @@ type AssertionResult struct {
 
 	// Evidence provides the concrete reason for the pass/fail determination.
 	Evidence string `json:"evidence"`
+
+	// Diagnosis describes the likely cause and next action for a failed
+	// agent-judge criterion. It is optional and never changes the verdict.
+	Diagnosis *FailureDiagnosis `json:"diagnosis,omitempty"`
+}
+
+// FailureAttribution is the primary likely cause assigned to a failure.
+type FailureAttribution string
+
+// Supported failure attribution categories.
+const (
+	FailureAttributionSkillNotTriggered             FailureAttribution = "skill_not_triggered"
+	FailureAttributionSkillMissingInfo              FailureAttribution = "skill_missing_info"
+	FailureAttributionSkillMisleadingInfo           FailureAttribution = "skill_misleading_info"
+	FailureAttributionCaseDesignIssue               FailureAttribution = "case_design_issue"
+	FailureAttributionEnvironmentConfiguration      FailureAttribution = "environment_configuration"
+	FailureAttributionExternalDependencyUnavailable FailureAttribution = "external_dependency_unavailable"
+	FailureAttributionInfrastructureError           FailureAttribution = "infrastructure_error"
+	FailureAttributionAgentCapability               FailureAttribution = "agent_capability"
+	FailureAttributionUndetermined                  FailureAttribution = "undetermined"
+	FailureAttributionOther                         FailureAttribution = "other"
+)
+
+// DiagnosisConfidence expresses confidence in a failure attribution, not in
+// the original pass/fail verdict.
+type DiagnosisConfidence string
+
+// Supported diagnostic confidence levels.
+const (
+	DiagnosisConfidenceLow    DiagnosisConfidence = "low"
+	DiagnosisConfidenceMedium DiagnosisConfidence = "medium"
+	DiagnosisConfidenceHigh   DiagnosisConfidence = "high"
+)
+
+// FailureDiagnosis is an optional, AI-generated explanation of a failure.
+// AttributionEvidence explains the causal classification, while the existing
+// AssertionResult.Evidence remains the evidence for the verdict itself.
+type FailureDiagnosis struct {
+	FailureAttribution    FailureAttribution  `json:"failure_attribution"`
+	Confidence            DiagnosisConfidence `json:"confidence,omitempty"`
+	AttributionEvidence   string              `json:"attribution_evidence"`
+	ImprovementSuggestion string              `json:"improvement_suggestion"`
 }
 
 // ResultSummary aggregates assertion statistics.

--- a/internal/report/grading_test.go
+++ b/internal/report/grading_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alibaba/skill-up/internal/judge"
@@ -83,6 +84,29 @@ func TestConvertToAnthropicGrading(t *testing.T) {
 			t.Fatalf("unexpected judge context: %#v", grading.JudgeContext)
 		}
 	})
+}
+
+func TestConvertToAnthropicGrading_DiagnosisStaysOutOfCompatibilityFormat(t *testing.T) {
+	t.Parallel()
+	result := judge.NewResult([]judge.AssertionResult{{
+		Text:     "check",
+		Passed:   false,
+		Evidence: "missing",
+		Diagnosis: &judge.FailureDiagnosis{
+			FailureAttribution:    judge.FailureAttributionSkillMissingInfo,
+			Confidence:            judge.DiagnosisConfidenceHigh,
+			AttributionEvidence:   "SKILL.md omits the requirement",
+			ImprovementSuggestion: "Add the requirement",
+		},
+	}}, 1, 1)
+	grading := ConvertToAnthropicGrading(result)
+	data, err := json.Marshal(grading)
+	if err != nil {
+		t.Fatalf("marshal grading: %v", err)
+	}
+	if strings.Contains(string(data), "diagnosis") || strings.Contains(string(data), "skill_missing_info") {
+		t.Fatalf("Anthropic grading must remain unchanged: %s", data)
+	}
 }
 
 func TestConvertToAnthropicGrading_JSONFormat(t *testing.T) {

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -120,9 +120,10 @@ type embeddedGrading struct {
 }
 
 type embeddedExpectation struct {
-	Text     string `json:"text"`
-	Passed   bool   `json:"passed"`
-	Evidence string `json:"evidence"`
+	Text      string                  `json:"text"`
+	Passed    bool                    `json:"passed"`
+	Evidence  string                  `json:"evidence"`
+	Diagnosis *judge.FailureDiagnosis `json:"diagnosis,omitempty"`
 }
 
 type embeddedGradingSummary struct {
@@ -179,9 +180,10 @@ func caseResultToEmbeddedCase(cr CaseResult) embeddedCase {
 		}
 		for _, ar := range cr.Grading.AssertionResults {
 			eg.Expectations = append(eg.Expectations, embeddedExpectation{
-				Text:     ar.Text,
-				Passed:   ar.Passed,
-				Evidence: ar.Evidence,
+				Text:      ar.Text,
+				Passed:    ar.Passed,
+				Evidence:  ar.Evidence,
+				Diagnosis: ar.Diagnosis,
 			})
 		}
 		ec.Grading = eg

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -152,6 +152,12 @@ func writeMarkdownCaseDetails(sb *strings.Builder, cr CaseResult) {
 			if ar.Evidence != "" {
 				fmt.Fprintf(sb, "  - Evidence: %s\n", markdownText(ar.Evidence))
 			}
+			if ar.Diagnosis != nil {
+				fmt.Fprintf(sb, "  - AI-generated likely cause: %s (confidence: %s)\n",
+					markdownText(string(ar.Diagnosis.FailureAttribution)), markdownText(string(ar.Diagnosis.Confidence)))
+				fmt.Fprintf(sb, "  - Attribution evidence: %s\n", markdownText(ar.Diagnosis.AttributionEvidence))
+				fmt.Fprintf(sb, "  - Improvement suggestion: %s\n", markdownText(ar.Diagnosis.ImprovementSuggestion))
+			}
 		}
 	}
 	for _, tr := range cr.TurnResults {

--- a/internal/report/markdown.go
+++ b/internal/report/markdown.go
@@ -153,7 +153,7 @@ func writeMarkdownCaseDetails(sb *strings.Builder, cr CaseResult) {
 				fmt.Fprintf(sb, "  - Evidence: %s\n", markdownText(ar.Evidence))
 			}
 			if ar.Diagnosis != nil {
-				fmt.Fprintf(sb, "  - AI-generated likely cause: %s (confidence: %s)\n",
+				fmt.Fprintf(sb, "  - Likely cause: %s (confidence: %s)\n",
 					markdownText(string(ar.Diagnosis.FailureAttribution)), markdownText(string(ar.Diagnosis.Confidence)))
 				fmt.Fprintf(sb, "  - Attribution evidence: %s\n", markdownText(ar.Diagnosis.AttributionEvidence))
 				fmt.Fprintf(sb, "  - Improvement suggestion: %s\n", markdownText(ar.Diagnosis.ImprovementSuggestion))

--- a/internal/report/reporter_test.go
+++ b/internal/report/reporter_test.go
@@ -393,7 +393,7 @@ func TestHTMLReporter_ContainsAssertionDetails(t *testing.T) {
 	if !strings.Contains(content, "graceful") {
 		t.Fatal("html should contain failure evidence")
 	}
-	for _, want := range []string{"AI-generated likely cause", "skill_missing_info", "SKILL.md does not define graceful null handling", "Add a null-handling section to SKILL.md"} {
+	for _, want := range []string{"Likely cause", "skill_missing_info", "SKILL.md does not define graceful null handling", "Add a null-handling section to SKILL.md"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("html should contain diagnosis detail %q", want)
 		}
@@ -476,7 +476,7 @@ func TestMarkdownReporter_Write(t *testing.T) {
 		"### edge-case-null",
 		"output_contains: &#39;graceful&#39;",
 		"output does not contain &#39;graceful&#39;",
-		"AI-generated likely cause: skill_missing_info (confidence: high)",
+		"Likely cause: skill_missing_info (confidence: high)",
 		"Attribution evidence: SKILL.md does not define graceful null handling",
 		"Improvement suggestion: Add a null-handling section to SKILL.md",
 		"### error-case",

--- a/internal/report/reporter_test.go
+++ b/internal/report/reporter_test.go
@@ -61,22 +61,7 @@ func sampleInput() Input {
 					Summary: judge.ResultSummary{Passed: 2, Failed: 0, Total: 2, PassRate: 1.0},
 				},
 			},
-			{
-				CaseID:     "edge-case-null",
-				Title:      "Handle null input gracefully",
-				Status:     judge.StatusFail,
-				DurationMs: 62100,
-				Turns:      8,
-				Grading: &judge.Result{
-					Status:        judge.StatusFail,
-					TurnsExecuted: 8,
-					TurnsTotal:    8,
-					AssertionResults: []judge.AssertionResult{
-						{Text: "output_contains: 'graceful'", Passed: false, Evidence: "output does not contain 'graceful'"},
-					},
-					Summary: judge.ResultSummary{Passed: 0, Failed: 1, Total: 1, PassRate: 0.0},
-				},
-			},
+			sampleFailingCase(),
 			{
 				CaseID:     "skipped-case",
 				Title:      "Skipped due to post_condition",
@@ -92,6 +77,33 @@ func sampleInput() Input {
 				DurationMs: 300000,
 				Error:      "engine process killed after 300s",
 			},
+		},
+	}
+}
+
+func sampleFailingCase() CaseResult {
+	return CaseResult{
+		CaseID:     "edge-case-null",
+		Title:      "Handle null input gracefully",
+		Status:     judge.StatusFail,
+		DurationMs: 62100,
+		Turns:      8,
+		Grading: &judge.Result{
+			Status:        judge.StatusFail,
+			TurnsExecuted: 8,
+			TurnsTotal:    8,
+			AssertionResults: []judge.AssertionResult{{
+				Text:     "output_contains: 'graceful'",
+				Passed:   false,
+				Evidence: "output does not contain 'graceful'",
+				Diagnosis: &judge.FailureDiagnosis{
+					FailureAttribution:    judge.FailureAttributionSkillMissingInfo,
+					Confidence:            judge.DiagnosisConfidenceHigh,
+					AttributionEvidence:   "SKILL.md does not define graceful null handling",
+					ImprovementSuggestion: "Add a null-handling section to SKILL.md",
+				},
+			}},
+			Summary: judge.ResultSummary{Passed: 0, Failed: 1, Total: 1, PassRate: 0.0},
 		},
 	}
 }
@@ -137,10 +149,19 @@ func TestJSONReporter_Write(t *testing.T) {
 	if len(parsed.CaseResults[0].JudgeSkills) != 1 || parsed.CaseResults[0].JudgeSkills[0].Path != "evals/fixtures/judge-skill" {
 		t.Fatalf("judge_skills not preserved in JSON: %#v", parsed.CaseResults[0].JudgeSkills)
 	}
+	assertJSONDiagnosis(t, parsed.CaseResults[1])
 	parsedSkill := parsed.CaseResults[0].JudgeSkills[0]
 	if len(parsedSkill.Include) != 2 || parsedSkill.Include[1] != "references/**" ||
 		len(parsedSkill.Exclude) != 1 || parsedSkill.Exclude[0] != "references/drafts/**" {
 		t.Fatalf("judge skill filters not preserved in JSON: %#v", parsedSkill)
+	}
+}
+
+func assertJSONDiagnosis(t *testing.T, result CaseResult) {
+	t.Helper()
+	diagnosis := result.Grading.AssertionResults[0].Diagnosis
+	if diagnosis == nil || diagnosis.FailureAttribution != judge.FailureAttributionSkillMissingInfo {
+		t.Fatalf("criterion diagnosis not preserved in JSON: %#v", diagnosis)
 	}
 }
 
@@ -372,6 +393,11 @@ func TestHTMLReporter_ContainsAssertionDetails(t *testing.T) {
 	if !strings.Contains(content, "graceful") {
 		t.Fatal("html should contain failure evidence")
 	}
+	for _, want := range []string{"AI-generated likely cause", "skill_missing_info", "SKILL.md does not define graceful null handling", "Add a null-handling section to SKILL.md"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("html should contain diagnosis detail %q", want)
+		}
+	}
 	if !strings.Contains(content, "25%") {
 		t.Fatal("html should contain pass rate (1 of 4 = 25%)")
 	}
@@ -450,6 +476,9 @@ func TestMarkdownReporter_Write(t *testing.T) {
 		"### edge-case-null",
 		"output_contains: &#39;graceful&#39;",
 		"output does not contain &#39;graceful&#39;",
+		"AI-generated likely cause: skill_missing_info (confidence: high)",
+		"Attribution evidence: SKILL.md does not define graceful null handling",
+		"Improvement suggestion: Add a null-handling section to SKILL.md",
 		"### error-case",
 		"engine process killed after 300s",
 	} {

--- a/internal/report/templates/report.html
+++ b/internal/report/templates/report.html
@@ -109,6 +109,9 @@
     .assertion-status.a-pass { color: var(--green); }
     .assertion-status.a-fail { color: var(--red); }
     .assertion-evidence { color: var(--text-muted); font-size: 0.75rem; margin-top: 0.25rem; padding-left: 1.5rem; }
+    .assertion-diagnosis { margin: 0.5rem 0 0 1.5rem; padding: 0.625rem 0.75rem; border-left: 3px solid var(--accent); background: #f0f4ff; border-radius: 0 4px 4px 0; font-size: 0.75rem; color: var(--text); }
+    .assertion-diagnosis-label { color: var(--accent); font-weight: 600; margin-bottom: 0.25rem; }
+    .assertion-diagnosis-row { margin-top: 0.2rem; }
 
     .prompt-box { background: #f8fafc; border: 1px solid var(--border); border-radius: 4px; padding: 0.75rem 1rem; font-size: 0.875rem; color: #555; margin-bottom: 0.5rem; }
     .prompt-box strong { color: var(--text); }
@@ -563,6 +566,14 @@
         html += '<li class="assertion-item"><span class="assertion-status ' + sc + '">' + icon + '</span>';
         html += '<span>' + esc(exp.text) + '</span>';
         if (exp.evidence) html += '<div class="assertion-evidence">' + esc(exp.evidence) + '</div>';
+        if (!exp.passed && exp.diagnosis) {
+          var d = exp.diagnosis;
+          html += '<div class="assertion-diagnosis">';
+          html += '<div class="assertion-diagnosis-label">AI-generated likely cause: ' + esc(d.failure_attribution) + ' (confidence: ' + esc(d.confidence || "low") + ')</div>';
+          html += '<div class="assertion-diagnosis-row"><strong>Attribution evidence:</strong> ' + esc(d.attribution_evidence) + '</div>';
+          html += '<div class="assertion-diagnosis-row"><strong>Improvement suggestion:</strong> ' + esc(d.improvement_suggestion) + '</div>';
+          html += '</div>';
+        }
         html += '</li>';
       }
       html += '</ul>';

--- a/internal/report/templates/report.html
+++ b/internal/report/templates/report.html
@@ -569,7 +569,7 @@
         if (!exp.passed && exp.diagnosis) {
           var d = exp.diagnosis;
           html += '<div class="assertion-diagnosis">';
-          html += '<div class="assertion-diagnosis-label">AI-generated likely cause: ' + esc(d.failure_attribution) + ' (confidence: ' + esc(d.confidence || "low") + ')</div>';
+          html += '<div class="assertion-diagnosis-label">Likely cause: ' + esc(d.failure_attribution) + ' (confidence: ' + esc(d.confidence || "low") + ')</div>';
           html += '<div class="assertion-diagnosis-row"><strong>Attribution evidence:</strong> ' + esc(d.attribution_evidence) + '</div>';
           html += '<div class="assertion-diagnosis-row"><strong>Improvement suggestion:</strong> ' + esc(d.improvement_suggestion) + '</div>';
           html += '</div>';


### PR DESCRIPTION
## Summary

- add an optional structured `diagnosis` to failed `agent_judge` criteria with failure attribution, confidence, attribution evidence, and an actionable improvement suggestion
- freeze a bounded, hashed snapshot of the evaluated Skill source before Agent execution and provide conservative Skill-usage evidence to the Judge
- render diagnosis details in JSON, HTML, and Markdown reports while keeping the Anthropic-compatible `grading.json` schema unchanged
- document `judge.context.skill_source` defaults, data handling, baseline restrictions, and configuration overrides

## Why

Evaluation reports currently explain whether a criterion passed and show verdict evidence, but they do not help users distinguish Skill defects, case-design problems, environment failures, or Agent limitations. This leaves the next debugging action ambiguous.

This change adds diagnostic guidance to the existing Judge response rather than adding a second model invocation.

Closes #210

## Behavior and safety

- diagnosis never changes the configured PASS/FAIL verdict
- malformed or missing optional diagnosis data does not invalidate an otherwise valid verdict
- `skill_not_triggered` is accepted only with reliable negative usage evidence
- `without_skill` baselines reject Skill-specific attribution and omit Skill source
- `standard` defaults to `skill_source: file_ref`; `minimal` defaults to `omit`
- readable source content is bounded by `limits.max_bytes`, symlinks are not followed, and `evals/` is excluded
- the Judge correction retry introduced on current `main` retains the same diagnosis contract

## Validation

- `go test -race ./...`
- `make verify` (go vet, revive, golangci-lint; 0 issues)
- real QoderCLI Agent/Judge evaluation against the expression-calculator Skill, including an intentional conflicting criterion; the Judge returned `case_design_issue` with high confidence and an actionable correction
