### PR TITLE
fix(qwen-code): exclude hidden thoughts from transcripts

### DIFF
--- a/internal/agent/qwen_code.go
+++ b/internal/agent/qwen_code.go
@@ -318,6 +318,7 @@ type qwenSessionMessage struct {
 
 type qwenSessionPart struct {
 	Text             string                `json:"text,omitempty"`
+	Thought          bool                  `json:"thought,omitempty"`
 	FunctionCall     *qwenFunctionCall     `json:"functionCall,omitempty"`
 	FunctionResponse *qwenFunctionResponse `json:"functionResponse,omitempty"`
 }
@@ -406,6 +407,11 @@ func appendQwenMessageParts(messages *[]transcript.Message, ev qwenSessionEvent,
 	var textParts []string
 	for _, p := range ev.Message.Parts {
 		switch {
+		case p.Thought:
+			// Qwen records hidden reasoning as ordinary text parts annotated with
+			// thought=true. Keep those parts out of the user-visible transcript and
+			// FinalMessage while preserving tool calls and the final answer.
+			continue
 		case p.FunctionCall != nil:
 			*messages = append(*messages, transcript.Message{
 				Role: transcript.RoleToolCall,

--- a/internal/agent/qwen_code_test.go
+++ b/internal/agent/qwen_code_test.go
@@ -242,6 +242,37 @@ func TestParseQwenSessionFile(t *testing.T) {
 	}
 }
 
+func TestParseQwenSessionFile_SkipsThoughtText(t *testing.T) {
+	t.Parallel()
+
+	lines := []string{
+		`{"type":"user","message":{"role":"user","parts":[{"text":"List the files."}]}}`,
+		`{"type":"assistant","message":{"role":"model","parts":[{"text":"I should inspect the workspace.","thought":true}]}}`,
+		`{"type":"assistant","message":{"role":"model","parts":[{"functionCall":{"id":"call_1","name":"run_shell_command","args":{"command":"ls"}}}]}}`,
+		`{"type":"user","message":{"role":"user","parts":[{"functionResponse":{"id":"call_1","name":"run_shell_command","response":{"output":"a.txt"}}}]}}`,
+		`{"type":"assistant","message":{"role":"model","parts":[{"text":"The workspace contains a.txt."}]}}`,
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	trans, finalMsg, _, _ := parseQwenSessionFile(path)
+
+	if finalMsg != "The workspace contains a.txt." {
+		t.Fatalf("unexpected final message: %q", finalMsg)
+	}
+	if len(trans) != 4 {
+		t.Fatalf("expected user, tool call, tool result, and final answer; got %d messages: %#v", len(trans), trans)
+	}
+	for _, msg := range trans {
+		if strings.Contains(msg.Content, "inspect the workspace") {
+			t.Fatalf("thought text leaked into transcript: %#v", trans)
+		}
+	}
+}
+
 func TestParseQwenSessionFile_Missing(t *testing.T) {
 	t.Parallel()
 	trans, finalMsg, inTok, outTok := parseQwenSessionFile(filepath.Join(t.TempDir(), "nope.jsonl"))


### PR DESCRIPTION
## Summary

Qwen Code session JSONL can contain assistant text parts annotated with `thought: true`. The parser currently treats these hidden reasoning parts as visible assistant messages, so they can replace or contaminate `FinalMessage` and downstream transcript consumers.

This change:
- models the `thought` marker and skips those text parts
- preserves visible assistant text, tool calls, and tool results
- adds a regression test covering the full sequence

## Validation

- `make verify`
- `go test ./internal/agent -run Qwen -count=1`
- `env -u QODER_PERSONAL_ACCESS_TOKEN -u OPENAI_API_KEY go test -race ./internal/agent ./internal/runtime`

The initial full `make test` run was otherwise green but hit one host-environment credential test and one timing-sensitive runtime test; both affected packages passed cleanly when rerun with credential variables removed.