### PR TITLE
refactor(credential): add protocol-aware model connection primitives

### DIFF
--- a/internal/agent/capabilities.go
+++ b/internal/agent/capabilities.go
@@ -15,17 +15,17 @@ import (
 )
 
 // Protocol identifies the wire protocol selected by an agent adapter.
-type Protocol string
+type Protocol = credential.Protocol
 
 const (
 	// ProtocolAnthropic is the Anthropic-compatible messages protocol.
-	ProtocolAnthropic Protocol = "anthropic"
+	ProtocolAnthropic = credential.ProtocolAnthropic
 	// ProtocolOpenAI is the OpenAI-compatible protocol used by Codex and Qwen Code.
-	ProtocolOpenAI Protocol = "openai"
+	ProtocolOpenAI = credential.ProtocolOpenAI
 	// ProtocolQoder is Qoder CLI's managed local protocol and authentication flow.
-	ProtocolQoder Protocol = "qoder"
+	ProtocolQoder = credential.ProtocolQoder
 	// ProtocolCustom delegates protocol behavior to a custom engine definition.
-	ProtocolCustom Protocol = "custom"
+	ProtocolCustom = credential.ProtocolCustom
 )
 
 // ModelPolicy describes how an adapter handles an explicitly requested model.

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -131,9 +131,35 @@ type providerFileConfig struct {
 	Anthropic *providerEndpointFileConfig `yaml:"anthropic,omitempty"`
 }
 
+func (p *providerFileConfig) UnmarshalYAML(node *yaml.Node) error {
+	type plainProviderFileConfig providerFileConfig
+	var decoded plainProviderFileConfig
+	if err := node.Decode(&decoded); err != nil {
+		return err
+	}
+	*p = providerFileConfig(decoded)
+	return decodeOptionalFileValues(node, map[string]*optionalFileValue{
+		"api_key":  &p.APIKey,
+		"base_url": &p.BaseURL,
+	})
+}
+
 type providerEndpointFileConfig struct {
 	BaseURL optionalFileValue `yaml:"base_url"`
 	APIKey  optionalFileValue `yaml:"api_key,omitempty"`
+}
+
+func (p *providerEndpointFileConfig) UnmarshalYAML(node *yaml.Node) error {
+	type plainProviderEndpointFileConfig providerEndpointFileConfig
+	var decoded plainProviderEndpointFileConfig
+	if err := node.Decode(&decoded); err != nil {
+		return err
+	}
+	*p = providerEndpointFileConfig(decoded)
+	return decodeOptionalFileValues(node, map[string]*optionalFileValue{
+		"api_key":  &p.APIKey,
+		"base_url": &p.BaseURL,
+	})
 }
 
 type optionalFileValue struct {
@@ -143,11 +169,26 @@ type optionalFileValue struct {
 
 func (v *optionalFileValue) UnmarshalYAML(node *yaml.Node) error {
 	v.set = true
-	if node.Tag == "!!null" {
-		v.value = ""
-		return nil
-	}
 	return node.Decode(&v.value)
+}
+
+func decodeOptionalFileValues(node *yaml.Node, fields map[string]*optionalFileValue) error {
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		field, ok := fields[node.Content[i].Value]
+		if !ok {
+			continue
+		}
+		field.set = true
+		valueNode := node.Content[i+1]
+		if valueNode.Tag == "!!null" {
+			field.value = ""
+			continue
+		}
+		if err := valueNode.Decode(&field.value); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *Resolver) loadFromFile(path string) error {

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -41,16 +41,18 @@ func DefaultConfPath() string {
 
 // Resolver resolves credentials for model providers.
 type Resolver struct {
-	mu       sync.RWMutex
-	confPath string
-	creds    map[string]*config.APIKeyConfig
+	mu        sync.RWMutex
+	confPath  string
+	creds     map[string]*config.APIKeyConfig
+	providers map[string]ProviderConfiguration
 }
 
 // NewResolver creates a new credential resolver.
 func NewResolver(confPath string) *Resolver {
 	return &Resolver{
-		confPath: confPath,
-		creds:    make(map[string]*config.APIKeyConfig),
+		confPath:  confPath,
+		creds:     make(map[string]*config.APIKeyConfig),
+		providers: make(map[string]ProviderConfiguration),
 	}
 }
 
@@ -117,24 +119,35 @@ func (r *Resolver) logEffectiveConfig() {
 }
 
 type configFile struct {
-	SchemaVersion string                    `yaml:"schema_version"`
-	Providers     map[string]ProviderConfig `yaml:"providers"`
+	SchemaVersion string                        `yaml:"schema_version"`
+	Providers     map[string]providerFileConfig `yaml:"providers"`
 }
 
-// ProviderConfig holds configuration for a provider's endpoints.
-// Supports both flat format (api_key, base_url directly) and nested format (openai, anthropic).
-type ProviderConfig struct {
-	APIKey  string `yaml:"api_key,omitempty"`
-	BaseURL string `yaml:"base_url,omitempty"`
+type providerFileConfig struct {
+	APIKey  optionalFileValue `yaml:"api_key,omitempty"`
+	BaseURL optionalFileValue `yaml:"base_url,omitempty"`
 
-	OpenAI    *ProviderEndpointConfig `yaml:"openai,omitempty"`
-	Anthropic *ProviderEndpointConfig `yaml:"anthropic,omitempty"`
+	OpenAI    *providerEndpointFileConfig `yaml:"openai,omitempty"`
+	Anthropic *providerEndpointFileConfig `yaml:"anthropic,omitempty"`
 }
 
-// ProviderEndpointConfig holds configuration for a single endpoint.
-type ProviderEndpointConfig struct {
-	BaseURL string `yaml:"base_url"`
-	APIKey  string `yaml:"api_key,omitempty"`
+type providerEndpointFileConfig struct {
+	BaseURL optionalFileValue `yaml:"base_url"`
+	APIKey  optionalFileValue `yaml:"api_key,omitempty"`
+}
+
+type optionalFileValue struct {
+	value string
+	set   bool
+}
+
+func (v *optionalFileValue) UnmarshalYAML(node *yaml.Node) error {
+	v.set = true
+	if node.Tag == "!!null" {
+		v.value = ""
+		return nil
+	}
+	return node.Decode(&v.value)
 }
 
 func (r *Resolver) loadFromFile(path string) error {
@@ -149,32 +162,56 @@ func (r *Resolver) loadFromFile(path string) error {
 	}
 
 	for name, p := range cfg.Providers {
+		providerConfig := ProviderConfiguration{
+			Provider:  name,
+			APIKey:    fileConnectionValue(p.APIKey),
+			BaseURL:   fileConnectionValue(p.BaseURL),
+			Endpoints: map[Protocol]ProviderEndpointConfig{},
+		}
+		if p.OpenAI != nil {
+			providerConfig.Endpoints[ProtocolOpenAI] = ProviderEndpointConfig{
+				APIKey:  fileConnectionValue(p.OpenAI.APIKey),
+				BaseURL: fileConnectionValue(p.OpenAI.BaseURL),
+			}
+		}
+		if p.Anthropic != nil {
+			providerConfig.Endpoints[ProtocolAnthropic] = ProviderEndpointConfig{
+				APIKey:  fileConnectionValue(p.Anthropic.APIKey),
+				BaseURL: fileConnectionValue(p.Anthropic.BaseURL),
+			}
+		}
+		r.providers[name] = providerConfig
+
 		cred := &config.APIKeyConfig{
 			Provider: name,
 		}
 
-		if p.APIKey != "" {
-			cred.APIKey = p.APIKey
+		if p.APIKey.value != "" {
+			cred.APIKey = p.APIKey.value
 		}
-		if p.BaseURL != "" {
-			cred.BaseURL = p.BaseURL
+		if p.BaseURL.value != "" {
+			cred.BaseURL = p.BaseURL.value
 		}
 
 		if p.OpenAI != nil {
 			if cred.BaseURL == "" {
-				cred.BaseURL = p.OpenAI.BaseURL
+				cred.BaseURL = p.OpenAI.BaseURL.value
 			}
-			if cred.APIKey == "" && p.OpenAI.APIKey != "" {
-				cred.APIKey = p.OpenAI.APIKey
+			if cred.APIKey == "" && p.OpenAI.APIKey.value != "" {
+				cred.APIKey = p.OpenAI.APIKey.value
 			}
 		}
 		if p.Anthropic != nil {
-			if cred.APIKey == "" && p.Anthropic.APIKey != "" {
-				cred.APIKey = p.Anthropic.APIKey
+			if cred.APIKey == "" && p.Anthropic.APIKey.value != "" {
+				cred.APIKey = p.Anthropic.APIKey.value
 			}
 		}
 		r.creds[name] = cred
 	}
 
 	return nil
+}
+
+func fileConnectionValue(value optionalFileValue) ConnectionValue {
+	return ConnectionValue{Value: value.value, Source: ValueSourceResolver, Set: value.set}
 }

--- a/internal/credential/model_connection.go
+++ b/internal/credential/model_connection.go
@@ -1,0 +1,181 @@
+package credential
+
+import "maps"
+
+// Protocol identifies the wire protocol selected by an agent adapter.
+type Protocol string
+
+const (
+	// ProtocolAnthropic is the Anthropic-compatible messages protocol.
+	ProtocolAnthropic Protocol = "anthropic"
+	// ProtocolOpenAI is the OpenAI-compatible protocol.
+	ProtocolOpenAI Protocol = "openai"
+	// ProtocolQoder is Qoder CLI's managed local protocol and authentication flow.
+	ProtocolQoder Protocol = "qoder"
+	// ProtocolCustom delegates protocol behavior to a custom engine definition.
+	ProtocolCustom Protocol = "custom"
+)
+
+// AuthMode records whether skill-up injects authentication or delegates it to
+// the agent's local state. Delegation does not prove that a local login exists.
+type AuthMode string
+
+const (
+	// AuthModeInjected means skill-up selected a non-empty credential to inject.
+	AuthModeInjected AuthMode = "injected"
+	// AuthModeAgentLocal means skill-up leaves authentication to the agent.
+	AuthModeAgentLocal AuthMode = "agent_local"
+)
+
+// RoutingMode records how endpoint routing is materialized.
+type RoutingMode string
+
+const (
+	// RoutingModeExplicit means skill-up selected an explicit endpoint.
+	RoutingModeExplicit RoutingMode = "explicit"
+	// RoutingModeNativeConfig means an adapter materializes native agent config.
+	RoutingModeNativeConfig RoutingMode = "native_config"
+	// RoutingModeAgentLocal means endpoint selection is delegated to the agent.
+	RoutingModeAgentLocal RoutingMode = "agent_local"
+	// RoutingModeUnresolved means an adapter has not selected a routing strategy.
+	RoutingModeUnresolved RoutingMode = "unresolved"
+)
+
+// ConnectionValue retains both presence and source. Set distinguishes an
+// absent value from an explicit empty value that suppresses inheritance.
+type ConnectionValue struct {
+	Value  string
+	Source ValueSource
+	Set    bool
+}
+
+// ExplicitConnectionValue constructs a present connection value.
+func ExplicitConnectionValue(value string, source ValueSource) ConnectionValue {
+	return ConnectionValue{Value: value, Source: source, Set: true}
+}
+
+// ProviderEndpointConfig holds protocol-specific provider configuration.
+type ProviderEndpointConfig struct {
+	APIKey  ConnectionValue `json:"-" yaml:"-"`
+	BaseURL ConnectionValue
+}
+
+// ProviderConfiguration is the static credential and endpoint configuration
+// for one provider namespace. Protocol values inherit flat values only when
+// the corresponding protocol field is absent.
+type ProviderConfiguration struct {
+	Provider  string
+	APIKey    ConnectionValue `json:"-" yaml:"-"`
+	BaseURL   ConnectionValue
+	Endpoints map[Protocol]ProviderEndpointConfig
+}
+
+// ModelConnectionSpec selects one provider and adapter protocol. Explicit
+// values take precedence over environment and credential-file values; an
+// explicit empty value intentionally suppresses those lower-priority layers.
+type ModelConnectionSpec struct {
+	Provider string
+	Protocol Protocol
+	APIKey   ConnectionValue `json:"-" yaml:"-"`
+	BaseURL  ConnectionValue
+}
+
+// ResolvedModelConnection describes the connection selected for an adapter.
+// It is requested/applied configuration, not observed runtime state. Secrets
+// held in APIKey must never be serialized into reports or logs.
+type ResolvedModelConnection struct {
+	Provider string
+	Protocol Protocol
+
+	APIKey        string `json:"-" yaml:"-"`
+	BaseURL       string
+	APIKeySet     bool
+	BaseURLSet    bool
+	APIKeySource  ValueSource
+	BaseURLSource ValueSource
+	AuthMode      AuthMode
+	RoutingMode   RoutingMode
+}
+
+// GetProviderConfiguration returns a copy of the static provider configuration.
+func (r *Resolver) GetProviderConfiguration(provider string) (ProviderConfiguration, bool) {
+	if r == nil {
+		return ProviderConfiguration{}, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	providerConfig, ok := r.providers[provider]
+	if !ok {
+		return ProviderConfiguration{}, false
+	}
+	providerConfig.Endpoints = cloneProviderEndpoints(providerConfig.Endpoints)
+	return providerConfig, true
+}
+
+// ResolveModelConnection selects credentials and an endpoint for one
+// (provider, protocol) pair without probing the agent or making a model call.
+func (r *Resolver) ResolveModelConnection(spec ModelConnectionSpec) ResolvedModelConnection {
+	resolved := ResolvedModelConnection{
+		Provider:    spec.Provider,
+		Protocol:    spec.Protocol,
+		AuthMode:    AuthModeAgentLocal,
+		RoutingMode: RoutingModeAgentLocal,
+	}
+
+	providerConfig, _ := r.GetProviderConfiguration(spec.Provider)
+	resolved.APIKey, resolved.APIKeySet, resolved.APIKeySource = resolveConnectionValue(
+		spec.APIKey,
+		providerEnvironmentValue(spec.Provider, valueAPIKey),
+		providerConfigValue(providerConfig, spec.Protocol, valueAPIKey),
+	)
+	resolved.BaseURL, resolved.BaseURLSet, resolved.BaseURLSource = resolveConnectionValue(
+		spec.BaseURL,
+		providerEnvironmentValue(spec.Provider, valueBaseURL),
+		providerConfigValue(providerConfig, spec.Protocol, valueBaseURL),
+	)
+	if resolved.APIKey != "" {
+		resolved.AuthMode = AuthModeInjected
+	}
+	if resolved.BaseURL != "" {
+		resolved.RoutingMode = RoutingModeExplicit
+	}
+
+	return resolved
+}
+
+func resolveConnectionValue(values ...ConnectionValue) (string, bool, ValueSource) {
+	for _, value := range values {
+		if value.Set {
+			return value.Value, true, value.Source
+		}
+	}
+	return "", false, ""
+}
+
+func providerEnvironmentValue(provider string, kind scopedValueKind) ConnectionValue {
+	value, _, ok := lookupProviderEnv(provider, kind)
+	if !ok {
+		return ConnectionValue{}
+	}
+	return ExplicitConnectionValue(value, ValueSourceEnv)
+}
+
+func providerConfigValue(providerConfig ProviderConfiguration, protocol Protocol, kind scopedValueKind) ConnectionValue {
+	endpoint := providerConfig.Endpoints[protocol]
+	var protocolValue, flatValue ConnectionValue
+	switch kind {
+	case valueAPIKey:
+		protocolValue, flatValue = endpoint.APIKey, providerConfig.APIKey
+	case valueBaseURL:
+		protocolValue, flatValue = endpoint.BaseURL, providerConfig.BaseURL
+	}
+	if protocolValue.Set {
+		return protocolValue
+	}
+	return flatValue
+}
+
+func cloneProviderEndpoints(source map[Protocol]ProviderEndpointConfig) map[Protocol]ProviderEndpointConfig {
+	return maps.Clone(source)
+}

--- a/internal/credential/model_connection_test.go
+++ b/internal/credential/model_connection_test.go
@@ -1,0 +1,181 @@
+package credential
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestResolveModelConnection_SelectsProtocolEndpoint(t *testing.T) {
+	t.Parallel()
+
+	resolver := loadConnectionResolver(t, `
+providers:
+  gateway:
+    api_key: flat-key
+    base_url: https://flat.example.test
+    openai:
+      api_key: openai-key
+      base_url: https://openai.example.test/v1
+    anthropic:
+      api_key: test-anthropic-value
+      base_url: https://anthropic.example.test
+`)
+
+	tests := []struct {
+		name     string
+		protocol Protocol
+		apiKey   string
+		baseURL  string
+	}{
+		{name: "openai", protocol: ProtocolOpenAI, apiKey: "openai-key", baseURL: "https://openai.example.test/v1"},
+		{name: "anthropic", protocol: ProtocolAnthropic, apiKey: "test-anthropic-value", baseURL: "https://anthropic.example.test"}, //nolint:gosec // test credential
+		{name: "other protocol inherits flat values", protocol: ProtocolCustom, apiKey: "flat-key", baseURL: "https://flat.example.test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			resolved := resolver.ResolveModelConnection(ModelConnectionSpec{Provider: "gateway", Protocol: tt.protocol})
+			if resolved.Provider != "gateway" || resolved.Protocol != tt.protocol {
+				t.Fatalf("identity = %q/%q, want gateway/%q", resolved.Provider, resolved.Protocol, tt.protocol)
+			}
+			if resolved.APIKey != tt.apiKey || resolved.BaseURL != tt.baseURL {
+				t.Fatalf("connection = %#v, want api key %q and base URL %q", resolved, tt.apiKey, tt.baseURL)
+			}
+			if !resolved.APIKeySet || !resolved.BaseURLSet || resolved.APIKeySource != ValueSourceResolver || resolved.BaseURLSource != ValueSourceResolver {
+				t.Fatalf("resolver sources were not retained: %#v", resolved)
+			}
+			if resolved.AuthMode != AuthModeInjected || resolved.RoutingMode != RoutingModeExplicit {
+				t.Fatalf("modes = %q/%q, want injected/explicit", resolved.AuthMode, resolved.RoutingMode)
+			}
+		})
+	}
+}
+
+func TestResolver_NestedConfigKeepsLegacyFlattenedLookup(t *testing.T) {
+	t.Parallel()
+
+	resolver := loadConnectionResolver(t, `
+providers:
+  gateway:
+    openai:
+      api_key: openai-key
+      base_url: https://openai.example.test/v1
+    anthropic:
+      api_key: anthropic-key
+      base_url: https://anthropic.example.test
+`)
+
+	legacy, ok := resolver.Get("gateway")
+	if !ok {
+		t.Fatal("legacy credential not found")
+	}
+	if legacy.APIKey != "openai-key" || legacy.BaseURL != "https://openai.example.test/v1" {
+		t.Fatalf("legacy flattened credential changed: %#v", legacy)
+	}
+}
+
+func TestResolveModelConnection_ExplicitEmptySuppressesInheritance(t *testing.T) {
+	t.Parallel()
+
+	resolver := loadConnectionResolver(t, `
+providers:
+  empty_endpoint:
+    api_key: flat-key
+    base_url: https://flat.example.test
+    anthropic:
+      api_key: ""
+      base_url: ""
+`)
+
+	providerConfig, ok := resolver.GetProviderConfiguration("empty_endpoint")
+	if !ok {
+		t.Fatal("provider configuration not found")
+	}
+	endpoint := providerConfig.Endpoints[ProtocolAnthropic]
+	if !endpoint.APIKey.Set || endpoint.APIKey.Value != "" || !endpoint.BaseURL.Set || endpoint.BaseURL.Value != "" {
+		t.Fatalf("explicit empty endpoint values were not retained: %#v", endpoint)
+	}
+
+	resolved := resolver.ResolveModelConnection(ModelConnectionSpec{
+		Provider: "empty_endpoint",
+		Protocol: ProtocolAnthropic,
+	})
+	if resolved.APIKey != "" || resolved.BaseURL != "" || !resolved.APIKeySet || !resolved.BaseURLSet {
+		t.Fatalf("explicit empty values did not suppress flat inheritance: %#v", resolved)
+	}
+	if resolved.APIKeySource != ValueSourceResolver || resolved.BaseURLSource != ValueSourceResolver {
+		t.Fatalf("explicit empty sources were not retained: %#v", resolved)
+	}
+	if resolved.AuthMode != AuthModeAgentLocal || resolved.RoutingMode != RoutingModeAgentLocal {
+		t.Fatalf("modes = %q/%q, want delegated agent-local state", resolved.AuthMode, resolved.RoutingMode)
+	}
+}
+
+func TestResolveModelConnection_PreservesPrecedenceAndExplicitSuppression(t *testing.T) {
+	const provider = "connection_precedence_test"
+	t.Setenv("CONNECTION_PRECEDENCE_TEST_API_KEY", "env-key")
+	t.Setenv("CONNECTION_PRECEDENCE_TEST_BASE_URL", "https://env.example.test")
+
+	resolver := loadConnectionResolver(t, `
+providers:
+  connection_precedence_test:
+    api_key: file-key
+    base_url: https://file.example.test
+`)
+
+	fromEnvironment := resolver.ResolveModelConnection(ModelConnectionSpec{Provider: provider, Protocol: ProtocolOpenAI})
+	if fromEnvironment.APIKey != "env-key" || fromEnvironment.BaseURL != "https://env.example.test" {
+		t.Fatalf("environment did not override credential file: %#v", fromEnvironment)
+	}
+	if fromEnvironment.APIKeySource != ValueSourceEnv || fromEnvironment.BaseURLSource != ValueSourceEnv {
+		t.Fatalf("environment sources were not retained: %#v", fromEnvironment)
+	}
+
+	explicit := resolver.ResolveModelConnection(ModelConnectionSpec{
+		Provider: provider,
+		Protocol: ProtocolOpenAI,
+		APIKey:   ExplicitConnectionValue("", ValueSourceCLI),
+		BaseURL:  ExplicitConnectionValue("https://config.example.test", ValueSourceConfig),
+	})
+	if explicit.APIKey != "" || !explicit.APIKeySet || explicit.APIKeySource != ValueSourceCLI {
+		t.Fatalf("explicit empty API key did not suppress lower layers: %#v", explicit)
+	}
+	if explicit.BaseURL != "https://config.example.test" || explicit.BaseURLSource != ValueSourceConfig {
+		t.Fatalf("explicit base URL did not win: %#v", explicit)
+	}
+	if explicit.AuthMode != AuthModeAgentLocal || explicit.RoutingMode != RoutingModeExplicit {
+		t.Fatalf("modes = %q/%q, want agent_local/explicit", explicit.AuthMode, explicit.RoutingMode)
+	}
+}
+
+func TestResolvedModelConnection_MarksAPIKeyNonSerializable(t *testing.T) {
+	t.Parallel()
+
+	field, ok := reflect.TypeFor[ResolvedModelConnection]().FieldByName("APIKey")
+	if !ok {
+		t.Fatal("ResolvedModelConnection.APIKey field not found")
+	}
+	if got := field.Tag.Get("json"); got != "-" {
+		t.Fatalf("APIKey json tag = %q, want -", got)
+	}
+	if got := field.Tag.Get("yaml"); got != "-" {
+		t.Fatalf("APIKey yaml tag = %q, want -", got)
+	}
+}
+
+func loadConnectionResolver(t *testing.T, content string) *Resolver {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "credentials.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write credential config: %v", err)
+	}
+	resolver := NewResolver(path)
+	if err := resolver.Load(); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	return resolver
+}

--- a/internal/credential/model_connection_test.go
+++ b/internal/credential/model_connection_test.go
@@ -88,29 +88,34 @@ providers:
     anthropic:
       api_key: ""
       base_url: ""
+    openai:
+      api_key: null
+      base_url: null
 `)
 
 	providerConfig, ok := resolver.GetProviderConfiguration("empty_endpoint")
 	if !ok {
 		t.Fatal("provider configuration not found")
 	}
-	endpoint := providerConfig.Endpoints[ProtocolAnthropic]
-	if !endpoint.APIKey.Set || endpoint.APIKey.Value != "" || !endpoint.BaseURL.Set || endpoint.BaseURL.Value != "" {
-		t.Fatalf("explicit empty endpoint values were not retained: %#v", endpoint)
-	}
+	for _, protocol := range []Protocol{ProtocolAnthropic, ProtocolOpenAI} {
+		endpoint := providerConfig.Endpoints[protocol]
+		if !endpoint.APIKey.Set || endpoint.APIKey.Value != "" || !endpoint.BaseURL.Set || endpoint.BaseURL.Value != "" {
+			t.Fatalf("explicit empty %s endpoint values were not retained: %#v", protocol, endpoint)
+		}
 
-	resolved := resolver.ResolveModelConnection(ModelConnectionSpec{
-		Provider: "empty_endpoint",
-		Protocol: ProtocolAnthropic,
-	})
-	if resolved.APIKey != "" || resolved.BaseURL != "" || !resolved.APIKeySet || !resolved.BaseURLSet {
-		t.Fatalf("explicit empty values did not suppress flat inheritance: %#v", resolved)
-	}
-	if resolved.APIKeySource != ValueSourceResolver || resolved.BaseURLSource != ValueSourceResolver {
-		t.Fatalf("explicit empty sources were not retained: %#v", resolved)
-	}
-	if resolved.AuthMode != AuthModeAgentLocal || resolved.RoutingMode != RoutingModeAgentLocal {
-		t.Fatalf("modes = %q/%q, want delegated agent-local state", resolved.AuthMode, resolved.RoutingMode)
+		resolved := resolver.ResolveModelConnection(ModelConnectionSpec{
+			Provider: "empty_endpoint",
+			Protocol: protocol,
+		})
+		if resolved.APIKey != "" || resolved.BaseURL != "" || !resolved.APIKeySet || !resolved.BaseURLSet {
+			t.Fatalf("explicit empty %s values did not suppress flat inheritance: %#v", protocol, resolved)
+		}
+		if resolved.APIKeySource != ValueSourceResolver || resolved.BaseURLSource != ValueSourceResolver {
+			t.Fatalf("explicit empty %s sources were not retained: %#v", protocol, resolved)
+		}
+		if resolved.AuthMode != AuthModeAgentLocal || resolved.RoutingMode != RoutingModeAgentLocal {
+			t.Fatalf("%s modes = %q/%q, want delegated agent-local state", protocol, resolved.AuthMode, resolved.RoutingMode)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- add provider configuration and resolved model connection types shared with adapter protocols
- select credentials and endpoints by `(provider, protocol)` while retaining value sources and auth/routing modes
- preserve explicit-empty values so protocol-specific configuration can suppress flat inheritance
- keep the legacy flattened `Resolver.Get` path unchanged until adapter migration

## Why this scope

This is PR 4a of #196. It introduces and tests the protocol-aware connection boundary without changing CLI, adapter materialization, reports, or native agent configuration. Those remain follow-up phases so existing v1alpha1 YAML, GitHub Action inputs, legacy `--model provider/name`, and local-login behavior are unchanged.

## Testing

- `make build`
- `make verify`
- `make test`

Pairs with #196.