### PR TITLE
ci(qoder): route US e2e to regional endpoint

### DIFF
--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -128,6 +128,7 @@ jobs:
           OPENAI_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
           OPENAI_MODEL: qwen3.6-plus
           DASHSCOPE_MODEL: qwen3.6-plus
+          QODER_ENV: prod-us
           QODER_PERSONAL_ACCESS_TOKEN: ${{ secrets.QODER_ACCESS_TOKEN }}
 
       - name: Upload e2e workspace artifacts


### PR DESCRIPTION
## Summary

- set `QODER_ENV=prod-us` for the global Qoder cases in Model E2E
- route the pinned Qoder CLI to its US regional inference endpoint
- keep the existing trusted runner labels and Qoder CN path unchanged

## Verification

- `make verify`
- `make test`
- [Model E2E `none-runtime` canary](https://github.com/alibaba/skill-up/actions/runs/33582775658)
  - `TestAgent_QoderCLI_AgentJudgeUltimate_FullRun`: passed with `QODER_CONTRACT_OK`
  - `TestAgent_QoderCLI_NoneRuntime_FullRun`: passed with response `hello`
  - workspace artifact digest: `sha256:54d8bb7ff979ac7a7ce9f0ae4315fa0b7042b0ed63a1100bff716b68214b898c`
