### PR TITLE
refactor(evaluator): introduce execution plans

### DIFF
--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -46,6 +46,13 @@ type ProgressObserver interface {
 	OnCaseComplete(index, total int, caseID string, status judge.Status, passRate float64)
 }
 
+// TaskObserver receives stable planned-task lifecycle notifications.
+// Implementations must be safe for concurrent use.
+type TaskObserver interface {
+	OnTaskStart(ctx context.Context, task PlannedTask)
+	OnTaskComplete(ctx context.Context, task PlannedTask, result EvalResult)
+}
+
 // EvalOptions controls evaluation behavior.
 type EvalOptions struct {
 	WithBaseline bool
@@ -60,8 +67,9 @@ type EvalOptions struct {
 	Agent           agent.Agent
 	RunnerConfig    credential.ResolvedAgentConfig
 
-	EvalCfg  *config.EvalConfig
-	Observer ProgressObserver
+	EvalCfg      *config.EvalConfig
+	Observer     ProgressObserver
+	TaskObserver TaskObserver
 }
 
 // EvalResult holds the complete evaluation output for a single case execution.
@@ -115,11 +123,6 @@ type EvalResult struct {
 // Deprecated: Use EvalResult instead.
 type CaseResult = EvalResult
 
-type task struct {
-	caseCfg    *config.CaseConfig
-	configName string
-}
-
 type workspaceDiffState struct {
 	enabled     bool
 	baselineRev string
@@ -128,6 +131,7 @@ type workspaceDiffState struct {
 // Evaluator orchestrates the evaluation pipeline for test cases.
 type Evaluator interface {
 	EvaluateAll(ctx context.Context, cases []*config.CaseConfig) ([]EvalResult, error)
+	EvaluatePlan(ctx context.Context, tasks []PlannedTask) ([]EvalResult, error)
 }
 
 // defaultEvaluator is the default implementation of Evaluator.
@@ -146,6 +150,7 @@ type defaultEvaluator struct {
 	fixtures        *fixtureRegistry
 	deleteWorkspace bool
 	observer        ProgressObserver
+	taskObserver    TaskObserver
 	mcpOnce         sync.Once
 	mcpCfg          runtime.MCPConfig
 	mcpEnv          map[string]string
@@ -178,15 +183,26 @@ func NewEvaluator(opts EvalOptions) Evaluator {
 		fixtures:        newFixtureRegistry(),
 		deleteWorkspace: opts.DeleteWorkspace,
 		observer:        opts.Observer,
+		taskObserver:    opts.TaskObserver,
 	}
 }
 
 // EvaluateAll executes all cases through the evaluation pipeline and returns results.
 func (e *defaultEvaluator) EvaluateAll(ctx context.Context, cases []*config.CaseConfig) ([]EvalResult, error) {
+	configurations := []string{ConfigurationWithSkill}
+	if e.withBaseline {
+		configurations = append(configurations, ConfigurationWithoutSkill)
+	}
+	plan := BuildPlan(cases, 1, 1, configurations)
+	return e.EvaluatePlan(ctx, plan.Iterations[0].Tasks)
+}
+
+// EvaluatePlan executes pre-expanded tasks through the evaluation pipeline and returns results.
+func (e *defaultEvaluator) EvaluatePlan(ctx context.Context, tasks []PlannedTask) ([]EvalResult, error) {
 	ctx, span := observability.Tracer().Start(ctx, "evaluator.evaluate_all")
 	defer span.End()
 	span.SetAttributes(
-		attribute.Int("skill_up.cases.count", len(cases)),
+		attribute.Int("skill_up.cases.count", plannedCaseCount(tasks)),
 		attribute.Int("skill_up.concurrency", e.concurrency),
 		attribute.Bool("skill_up.baseline.enabled", e.withBaseline),
 	)
@@ -194,19 +210,6 @@ func (e *defaultEvaluator) EvaluateAll(ctx context.Context, cases []*config.Case
 	if e.ag != nil {
 		if err := e.ag.CheckCredentials(ctx); err != nil {
 			return nil, fmt.Errorf("agent credential check failed: %w", err)
-		}
-	}
-
-	configCount := 1
-	if e.withBaseline {
-		configCount = 2
-	}
-
-	tasks := make([]task, 0, len(cases)*configCount)
-	for _, c := range cases {
-		tasks = append(tasks, task{caseCfg: c, configName: "with_skill"})
-		if e.withBaseline {
-			tasks = append(tasks, task{caseCfg: c, configName: "without_skill"})
 		}
 	}
 
@@ -219,26 +222,42 @@ func (e *defaultEvaluator) EvaluateAll(ctx context.Context, cases []*config.Case
 		wg.Add(1)
 		sem <- struct{}{}
 		caseNum := i + 1
-		go func(idx int, tk task, cn int) {
+		go func(idx int, plannedTask PlannedTask, cn int) {
 			defer wg.Done()
 			defer func() { <-sem }()
 			if e.observer != nil {
-				e.observer.OnCaseStart(cn, totalCases, tk.caseCfg.ID, tk.caseCfg.Title)
+				e.observer.OnCaseStart(cn, totalCases, plannedTask.Case.ID, plannedTask.Case.Title)
 			}
-			results[idx] = e.executeCase(ctx, tk.caseCfg, tk.configName, nil, nil)
+			if e.taskObserver != nil {
+				e.taskObserver.OnTaskStart(ctx, plannedTask)
+			}
+			results[idx] = e.executeCase(ctx, plannedTask.Case, plannedTask.Configuration, nil, nil)
 			if e.observer != nil {
 				res := results[idx]
 				passRate := float64(-1)
 				if res.Grading != nil {
 					passRate = res.Grading.Summary.PassRate
 				}
-				e.observer.OnCaseComplete(cn, totalCases, tk.caseCfg.ID, res.Status, passRate)
+				e.observer.OnCaseComplete(cn, totalCases, plannedTask.Case.ID, res.Status, passRate)
+			}
+			if e.taskObserver != nil {
+				e.taskObserver.OnTaskComplete(ctx, plannedTask, results[idx])
 			}
 		}(i, t, caseNum)
 	}
 	wg.Wait()
 
 	return results, nil
+}
+
+func plannedCaseCount(tasks []PlannedTask) int {
+	count := 0
+	for _, task := range tasks {
+		if task.Configuration == ConfigurationWithSkill {
+			count++
+		}
+	}
+	return count
 }
 
 func casePromptAndTurnsTotal(caseCfg *config.CaseConfig) (string, int) {

--- a/internal/evaluator/plan.go
+++ b/internal/evaluator/plan.go
@@ -1,0 +1,89 @@
+package evaluator
+
+import (
+	"fmt"
+
+	"github.com/alibaba/skill-up/internal/config"
+)
+
+const (
+	// ConfigurationWithSkill executes a case with the evaluated skill installed.
+	ConfigurationWithSkill = "with_skill"
+	// ConfigurationWithoutSkill executes a case without the evaluated skill.
+	ConfigurationWithoutSkill = "without_skill"
+)
+
+// Plan is the immutable task expansion for one evaluation invocation.
+type Plan struct {
+	StartIteration int
+	Iterations     []IterationPlan
+	TaskTotal      int
+}
+
+// IterationPlan contains the tasks assigned to one iteration.
+type IterationPlan struct {
+	Number int
+	Tasks  []PlannedTask
+}
+
+// PlannedTask identifies one case and configuration execution within a Plan.
+type PlannedTask struct {
+	ID            string
+	GlobalIndex   int
+	GlobalTotal   int
+	Iteration     int
+	Case          *config.CaseConfig
+	Configuration string
+}
+
+// BuildPlan deterministically expands cases, iterations, and configurations.
+func BuildPlan(cases []*config.CaseConfig, startIteration, iterationCount int, configurations []string) Plan {
+	if startIteration < 1 {
+		startIteration = 1
+	}
+	if iterationCount < 1 {
+		iterationCount = 1
+	}
+
+	configurationCount := len(configurations)
+	taskTotal := len(cases) * iterationCount * configurationCount
+	plan := Plan{
+		StartIteration: startIteration,
+		Iterations:     make([]IterationPlan, 0, iterationCount),
+		TaskTotal:      taskTotal,
+	}
+
+	globalIndex := 0
+	for iterationOffset := range iterationCount {
+		iteration := IterationPlan{
+			Number: startIteration + iterationOffset,
+			Tasks:  make([]PlannedTask, 0, len(cases)*configurationCount),
+		}
+		for _, caseCfg := range cases {
+			for _, configuration := range configurations {
+				globalIndex++
+				iteration.Tasks = append(iteration.Tasks, newPlannedTask(
+					globalIndex,
+					taskTotal,
+					iteration.Number,
+					caseCfg,
+					configuration,
+				))
+			}
+		}
+		plan.Iterations = append(plan.Iterations, iteration)
+	}
+
+	return plan
+}
+
+func newPlannedTask(index, total, iteration int, caseCfg *config.CaseConfig, configuration string) PlannedTask {
+	return PlannedTask{
+		ID:            fmt.Sprintf("task-%d", index),
+		GlobalIndex:   index,
+		GlobalTotal:   total,
+		Iteration:     iteration,
+		Case:          caseCfg,
+		Configuration: configuration,
+	}
+}

--- a/internal/evaluator/plan_test.go
+++ b/internal/evaluator/plan_test.go
@@ -1,0 +1,213 @@
+package evaluator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/alibaba/skill-up/internal/config"
+	"github.com/alibaba/skill-up/internal/judge"
+)
+
+func TestBuildPlanExpandsTasksDeterministically(t *testing.T) {
+	t.Parallel()
+
+	cases := []*config.CaseConfig{
+		{ID: "case/alpha", Title: "Alpha"},
+		{ID: "用例-beta", Title: "Beta"},
+	}
+
+	plan := BuildPlan(cases, 3, 2, []string{ConfigurationWithSkill, ConfigurationWithoutSkill})
+
+	if plan.StartIteration != 3 {
+		t.Fatalf("StartIteration = %d, want 3", plan.StartIteration)
+	}
+	if plan.TaskTotal != 8 {
+		t.Fatalf("TaskTotal = %d, want 8", plan.TaskTotal)
+	}
+	if len(plan.Iterations) != 2 {
+		t.Fatalf("len(Iterations) = %d, want 2", len(plan.Iterations))
+	}
+
+	type expectedTask struct {
+		id            string
+		index         int
+		iteration     int
+		caseID        string
+		configuration string
+	}
+	want := []expectedTask{
+		{id: "task-1", index: 1, iteration: 3, caseID: "case/alpha", configuration: "with_skill"},
+		{id: "task-2", index: 2, iteration: 3, caseID: "case/alpha", configuration: "without_skill"},
+		{id: "task-3", index: 3, iteration: 3, caseID: "用例-beta", configuration: "with_skill"},
+		{id: "task-4", index: 4, iteration: 3, caseID: "用例-beta", configuration: "without_skill"},
+		{id: "task-5", index: 5, iteration: 4, caseID: "case/alpha", configuration: "with_skill"},
+		{id: "task-6", index: 6, iteration: 4, caseID: "case/alpha", configuration: "without_skill"},
+		{id: "task-7", index: 7, iteration: 4, caseID: "用例-beta", configuration: "with_skill"},
+		{id: "task-8", index: 8, iteration: 4, caseID: "用例-beta", configuration: "without_skill"},
+	}
+
+	got := make([]PlannedTask, 0, plan.TaskTotal)
+	for iterationIndex, iteration := range plan.Iterations {
+		if iteration.Number != 3+iterationIndex {
+			t.Errorf("Iterations[%d].Number = %d, want %d", iterationIndex, iteration.Number, 3+iterationIndex)
+		}
+		got = append(got, iteration.Tasks...)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("planned task count = %d, want %d", len(got), len(want))
+	}
+	for i, expected := range want {
+		task := got[i]
+		if task.ID != expected.id {
+			t.Errorf("task[%d].ID = %q, want %q", i, task.ID, expected.id)
+		}
+		if task.GlobalIndex != expected.index {
+			t.Errorf("task[%d].GlobalIndex = %d, want %d", i, task.GlobalIndex, expected.index)
+		}
+		if task.GlobalTotal != plan.TaskTotal {
+			t.Errorf("task[%d].GlobalTotal = %d, want %d", i, task.GlobalTotal, plan.TaskTotal)
+		}
+		if task.Iteration != expected.iteration {
+			t.Errorf("task[%d].Iteration = %d, want %d", i, task.Iteration, expected.iteration)
+		}
+		if task.Case.ID != expected.caseID {
+			t.Errorf("task[%d].Case.ID = %q, want %q", i, task.Case.ID, expected.caseID)
+		}
+		if task.Configuration != expected.configuration {
+			t.Errorf("task[%d].Configuration = %q, want %q", i, task.Configuration, expected.configuration)
+		}
+	}
+}
+
+func TestBuildPlanDefaultsInvalidIterationBounds(t *testing.T) {
+	t.Parallel()
+
+	plan := BuildPlan([]*config.CaseConfig{{ID: "case-1"}}, 0, 0, []string{ConfigurationWithSkill})
+
+	if plan.StartIteration != 1 {
+		t.Fatalf("StartIteration = %d, want 1", plan.StartIteration)
+	}
+	if len(plan.Iterations) != 1 || plan.Iterations[0].Number != 1 {
+		t.Fatalf("Iterations = %#v, want one iteration numbered 1", plan.Iterations)
+	}
+	if plan.TaskTotal != 1 || len(plan.Iterations[0].Tasks) != 1 {
+		t.Fatalf("plan task shape = total %d, tasks %d; want 1 and 1", plan.TaskTotal, len(plan.Iterations[0].Tasks))
+	}
+}
+
+func TestEvaluatePlanNotifiesTaskAndProgressObservers(t *testing.T) {
+	t.Parallel()
+
+	cases := []*config.CaseConfig{{
+		ID:    "case-1",
+		Title: "Case 1",
+		Input: config.Input{Prompt: "hello"},
+	}}
+	plan := BuildPlan(cases, 4, 1, []string{ConfigurationWithSkill, ConfigurationWithoutSkill})
+	taskObserver := &recordingTaskObserver{}
+	progressObserver := &recordingProgressObserver{}
+	e := newTestEvaluator(EvalOptions{
+		Concurrency:  1,
+		WithBaseline: true,
+		Agent:        &mockAgent{name: "test", output: "ok"},
+		EvalCfg: &config.EvalConfig{
+			Environment: config.Environment{Type: "none"},
+		},
+		Observer:     progressObserver,
+		TaskObserver: taskObserver,
+	})
+
+	results, err := e.EvaluatePlan(context.Background(), plan.Iterations[0].Tasks)
+	if err != nil {
+		t.Fatalf("EvaluatePlan returned error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].Configuration != "with_skill" || results[1].Configuration != "without_skill" {
+		t.Fatalf("result configurations = %q, %q; want with_skill, without_skill", results[0].Configuration, results[1].Configuration)
+	}
+
+	wantTaskEvents := []string{
+		"start:task-1:4:with_skill",
+		"complete:task-1:4:with_skill",
+		"start:task-2:4:without_skill",
+		"complete:task-2:4:without_skill",
+	}
+	if got := taskObserver.snapshot(); !equalStrings(got, wantTaskEvents) {
+		t.Fatalf("task events = %v, want %v", got, wantTaskEvents)
+	}
+	wantProgressEvents := []string{
+		"start:1/2:case-1",
+		"complete:1/2:case-1",
+		"start:2/2:case-1",
+		"complete:2/2:case-1",
+	}
+	if got := progressObserver.snapshot(); !equalStrings(got, wantProgressEvents) {
+		t.Fatalf("progress events = %v, want %v", got, wantProgressEvents)
+	}
+}
+
+type recordingTaskObserver struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (o *recordingTaskObserver) OnTaskStart(_ context.Context, task PlannedTask) {
+	o.record("start", task)
+}
+
+func (o *recordingTaskObserver) OnTaskComplete(_ context.Context, task PlannedTask, _ EvalResult) {
+	o.record("complete", task)
+}
+
+func (o *recordingTaskObserver) record(kind string, task PlannedTask) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.events = append(o.events, fmt.Sprintf("%s:%s:%d:%s", kind, task.ID, task.Iteration, task.Configuration))
+}
+
+func (o *recordingTaskObserver) snapshot() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.events...)
+}
+
+type recordingProgressObserver struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (o *recordingProgressObserver) OnCaseStart(index, total int, caseID, _ string) {
+	o.record("start", index, total, caseID)
+}
+
+func (o *recordingProgressObserver) OnCaseComplete(index, total int, caseID string, _ judge.Status, _ float64) {
+	o.record("complete", index, total, caseID)
+}
+
+func (o *recordingProgressObserver) record(kind string, index, total int, caseID string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.events = append(o.events, fmt.Sprintf("%s:%d/%d:%s", kind, index, total, caseID))
+}
+
+func (o *recordingProgressObserver) snapshot() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.events...)
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runner/execution_plan_test.go
+++ b/internal/runner/execution_plan_test.go
@@ -1,0 +1,164 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/alibaba/skill-up/internal/config"
+	"github.com/alibaba/skill-up/internal/credential"
+	"github.com/alibaba/skill-up/internal/evaluator"
+)
+
+func TestBuildExecutionPlanResolvesInvocationMetadataWithoutWorkspaceMutation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "directory-name")
+	evalsDir := filepath.Join(skillDir, "evals")
+	if err := os.MkdirAll(evalsDir, 0o755); err != nil {
+		t.Fatalf("create evals directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: declared-name\n---\n"), 0o600); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	workspaceDir := filepath.Join(root, "workspace")
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "iteration-2"), 0o755); err != nil {
+		t.Fatalf("create existing iteration: %v", err)
+	}
+
+	r := NewRunner(&config.EvalConfig{
+		Benchmark: config.BenchmarkConfig{Enabled: true},
+	}, config.NewLoader(filepath.Join(evalsDir, "eval.yaml")), nil, credential.ResolvedAgentConfig{})
+	cases := []*config.CaseConfig{
+		{ID: "case-1", Title: "Case 1"},
+		{ID: "case-2", Title: "Case 2"},
+	}
+
+	plan := r.BuildExecutionPlan(cases, EvaluateOptions{OutputDir: workspaceDir})
+
+	if plan.SkillDir != skillDir {
+		t.Errorf("SkillDir = %q, want %q", plan.SkillDir, skillDir)
+	}
+	if plan.SkillName != "directory-name" {
+		t.Errorf("SkillName = %q, want directory-name", plan.SkillName)
+	}
+	if plan.ReportName != "declared-name" {
+		t.Errorf("ReportName = %q, want declared-name", plan.ReportName)
+	}
+	if plan.WorkspaceDir != workspaceDir {
+		t.Errorf("WorkspaceDir = %q, want %q", plan.WorkspaceDir, workspaceDir)
+	}
+	if plan.CaseCount != 2 {
+		t.Errorf("CaseCount = %d, want 2", plan.CaseCount)
+	}
+	if plan.TaskPlan.StartIteration != 3 || len(plan.TaskPlan.Iterations) != 1 {
+		t.Fatalf("task iterations = start %d count %d, want start 3 count 1", plan.TaskPlan.StartIteration, len(plan.TaskPlan.Iterations))
+	}
+	if plan.TaskPlan.TaskTotal != 4 {
+		t.Errorf("TaskTotal = %d, want 4", plan.TaskPlan.TaskTotal)
+	}
+	if _, err := os.Stat(filepath.Join(workspaceDir, "iteration-3")); !os.IsNotExist(err) {
+		t.Fatalf("BuildExecutionPlan mutated future workspace, stat err = %v", err)
+	}
+}
+
+func TestEvaluatePlanForwardsIterationAndGlobalTaskBoundaries(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "test-skill")
+	evalsDir := filepath.Join(skillDir, "evals")
+	if err := os.MkdirAll(evalsDir, 0o755); err != nil {
+		t.Fatalf("create evals directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: test-skill\n---\n"), 0o600); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	r := NewRunner(&config.EvalConfig{
+		Environment: config.Environment{Type: "none"},
+		Cases:       config.CasesConfig{Parallelism: 1},
+	}, config.NewLoader(filepath.Join(evalsDir, "eval.yaml")), nil, credential.ResolvedAgentConfig{})
+	observer := &recordingExecutionObserver{}
+	opts := EvaluateOptions{
+		OutputDir:         filepath.Join(root, "workspace"),
+		Iteration:         2,
+		TaskObserver:      observer,
+		IterationObserver: observer,
+	}
+	plan := r.BuildExecutionPlan([]*config.CaseConfig{{
+		ID:    "case-1",
+		Title: "Case 1",
+		Input: config.Input{Prompt: "hello"},
+	}}, opts)
+
+	results, err := r.EvaluatePlan(context.Background(), plan, &runnerTestAgent{}, opts)
+	if err != nil {
+		t.Fatalf("EvaluatePlan returned error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	want := []string{
+		"iteration-start:1",
+		"task-start:task-1:1/2:1",
+		"task-complete:task-1:1/2:1",
+		"iteration-complete:1:1",
+		"iteration-start:2",
+		"task-start:task-2:2/2:2",
+		"task-complete:task-2:2/2:2",
+		"iteration-complete:2:1",
+	}
+	if got := observer.snapshot(); !equalStringSlices(got, want) {
+		t.Fatalf("observer events = %v, want %v", got, want)
+	}
+}
+
+type recordingExecutionObserver struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (o *recordingExecutionObserver) OnIterationStart(_ context.Context, iteration evaluator.IterationPlan) {
+	o.append(fmt.Sprintf("iteration-start:%d", iteration.Number))
+}
+
+func (o *recordingExecutionObserver) OnIterationComplete(_ context.Context, iteration evaluator.IterationPlan, results []evaluator.EvalResult) {
+	o.append(fmt.Sprintf("iteration-complete:%d:%d", iteration.Number, len(results)))
+}
+
+func (o *recordingExecutionObserver) OnTaskStart(_ context.Context, task evaluator.PlannedTask) {
+	o.append(fmt.Sprintf("task-start:%s:%d/%d:%d", task.ID, task.GlobalIndex, task.GlobalTotal, task.Iteration))
+}
+
+func (o *recordingExecutionObserver) OnTaskComplete(_ context.Context, task evaluator.PlannedTask, _ evaluator.EvalResult) {
+	o.append(fmt.Sprintf("task-complete:%s:%d/%d:%d", task.ID, task.GlobalIndex, task.GlobalTotal, task.Iteration))
+}
+
+func (o *recordingExecutionObserver) append(event string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.events = append(o.events, event)
+}
+
+func (o *recordingExecutionObserver) snapshot() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.events...)
+}
+
+func equalStringSlices(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -37,13 +37,31 @@ import (
 
 var newEvaluator = evaluator.NewEvaluator
 
+// IterationObserver receives iteration lifecycle notifications.
+type IterationObserver interface {
+	OnIterationStart(ctx context.Context, iteration evaluator.IterationPlan)
+	OnIterationComplete(ctx context.Context, iteration evaluator.IterationPlan, results []evaluator.EvalResult)
+}
+
 // EvaluateOptions controls evaluation behavior.
 type EvaluateOptions struct {
-	DeleteWorkspace bool
-	OutputDir       string
-	Iteration       int
-	Formats         []string
-	Observer        evaluator.ProgressObserver
+	DeleteWorkspace   bool
+	OutputDir         string
+	Iteration         int
+	Formats           []string
+	Observer          evaluator.ProgressObserver
+	TaskObserver      evaluator.TaskObserver
+	IterationObserver IterationObserver
+}
+
+// ExecutionPlan contains the immutable invocation metadata and expanded tasks.
+type ExecutionPlan struct {
+	SkillDir     string
+	SkillName    string
+	ReportName   string
+	WorkspaceDir string
+	CaseCount    int
+	TaskPlan     evaluator.Plan
 }
 
 // Runner coordinates eval execution end-to-end.
@@ -93,15 +111,8 @@ func (r *Runner) Workspace() *report.IterationWorkspace {
 	return r.workspace
 }
 
-// Evaluate runs all cases through evaluator and agent, returns results.
-func (r *Runner) Evaluate(ctx context.Context, cases []*config.CaseConfig, ag agent.Agent, opts EvaluateOptions) ([]evaluator.EvalResult, error) {
-	ctx, span := observability.Tracer().Start(ctx, "runner.evaluate")
-	defer span.End()
-	span.SetAttributes(
-		attribute.Int("skill_up.cases.count", len(cases)),
-		attribute.String("skill_up.engine", ag.Name()),
-	)
-
+// BuildExecutionPlan resolves workspace metadata and expands all invocation tasks.
+func (r *Runner) BuildExecutionPlan(cases []*config.CaseConfig, opts EvaluateOptions) ExecutionPlan {
 	skillDir := r.loader.SkillDir()
 	cleanDir, _ := filepath.Abs(filepath.Clean(skillDir))
 	skillName := filepath.Base(cleanDir)
@@ -118,8 +129,6 @@ func (r *Runner) Evaluate(ctx context.Context, cases []*config.CaseConfig, ag ag
 	if name, ok := r.loader.SkillName(); ok {
 		reportName = name
 	}
-	concurrency := r.evalCfg.Cases.Parallelism
-
 	workspaceDir := opts.OutputDir
 	if workspaceDir == "" {
 		// Default workspace sits alongside the skill directory, not inside it,
@@ -133,48 +142,90 @@ func (r *Runner) Evaluate(ctx context.Context, cases []*config.CaseConfig, ag ag
 		runCount = 1
 		startIteration = nextIterationNumber(workspaceDir)
 	}
+	configurations := []string{evaluator.ConfigurationWithSkill}
+	if r.evalCfg.Benchmark.Enabled {
+		configurations = append(configurations, evaluator.ConfigurationWithoutSkill)
+	}
+
+	return ExecutionPlan{
+		SkillDir:     skillDir,
+		SkillName:    skillName,
+		ReportName:   reportName,
+		WorkspaceDir: workspaceDir,
+		CaseCount:    len(cases),
+		TaskPlan: evaluator.BuildPlan(
+			cases,
+			startIteration,
+			runCount,
+			configurations,
+		),
+	}
+}
+
+// Evaluate runs all cases through evaluator and agent, returns results.
+func (r *Runner) Evaluate(ctx context.Context, cases []*config.CaseConfig, ag agent.Agent, opts EvaluateOptions) ([]evaluator.EvalResult, error) {
+	return r.EvaluatePlan(ctx, r.BuildExecutionPlan(cases, opts), ag, opts)
+}
+
+// EvaluatePlan executes a previously built invocation plan.
+func (r *Runner) EvaluatePlan(ctx context.Context, plan ExecutionPlan, ag agent.Agent, opts EvaluateOptions) ([]evaluator.EvalResult, error) {
+	ctx, span := observability.Tracer().Start(ctx, "runner.evaluate")
+	defer span.End()
 	span.SetAttributes(
-		attribute.Int("skill_up.iteration.start", startIteration),
+		attribute.Int("skill_up.cases.count", plan.CaseCount),
+		attribute.String("skill_up.engine", ag.Name()),
+	)
+
+	runCount := len(plan.TaskPlan.Iterations)
+	span.SetAttributes(
+		attribute.Int("skill_up.iteration.start", plan.TaskPlan.StartIteration),
 		attribute.Int("skill_up.iteration.count", runCount),
 	)
-	allResults := make([]evaluator.EvalResult, 0, len(cases)*runCount)
-	for i := range runCount {
+	allResults := make([]evaluator.EvalResult, 0, plan.TaskPlan.TaskTotal)
+	for _, iteration := range plan.TaskPlan.Iterations {
 		iterationStartTime := r.now()
-		runNumber := startIteration + i
-		if err := r.setupWorkspace(ctx, workspaceDir, skillName, runNumber); err != nil {
+		runNumber := iteration.Number
+		if err := r.setupWorkspace(ctx, plan.WorkspaceDir, plan.SkillName, runNumber); err != nil {
 			return allResults, fmt.Errorf("failed to init workspace for run %d: %w", runNumber, err)
+		}
+		if opts.IterationObserver != nil {
+			opts.IterationObserver.OnIterationStart(ctx, iteration)
 		}
 
 		if runCount == 1 {
-			logging.DebugContextf(ctx, "Runner: running %d case(s) with agent %s", len(cases), ag.Name())
+			logging.DebugContextf(ctx, "Runner: running %d case(s) with agent %s", plan.CaseCount, ag.Name())
 		} else {
-			logging.DebugContextf(ctx, "Runner: running %d case(s) with agent %s (run %d/%d)", len(cases), ag.Name(), runNumber, runCount)
+			logging.DebugContextf(ctx, "Runner: running %d case(s) with agent %s (run %d/%d)", plan.CaseCount, ag.Name(), runNumber, runCount)
 		}
-		logging.DebugContextf(ctx, "Runner: benchmark=%t concurrency=%d output_dir=%s iteration=%d", r.evalCfg.Benchmark.Enabled, concurrency, workspaceDir, runNumber)
+		logging.DebugContextf(ctx, "Runner: benchmark=%t concurrency=%d output_dir=%s iteration=%d", r.evalCfg.Benchmark.Enabled, r.evalCfg.Cases.Parallelism, plan.WorkspaceDir, runNumber)
 
 		ev := newEvaluator(evaluator.EvalOptions{
-			SkillName:       reportName,
-			SkillDir:        skillDir,
+			SkillName:       plan.ReportName,
+			SkillDir:        plan.SkillDir,
 			EvalCfg:         r.evalCfg,
 			Loader:          r.loader,
 			Resolver:        r.resolver,
 			Agent:           ag,
 			RunnerConfig:    r.runnerConfig,
 			OutputDir:       r.workspace.IterationDir(),
-			Concurrency:     concurrency,
+			Concurrency:     r.evalCfg.Cases.Parallelism,
 			DeleteWorkspace: opts.DeleteWorkspace,
 			WithBaseline:    r.evalCfg.Benchmark.Enabled,
 			Observer:        opts.Observer,
+			TaskObserver:    opts.TaskObserver,
 		})
 
-		results, err := ev.EvaluateAll(ctx, cases)
+		results, err := ev.EvaluatePlan(ctx, iteration.Tasks)
 		if err != nil {
 			return allResults, err
+		}
+		if opts.IterationObserver != nil {
+			opts.IterationObserver.OnIterationComplete(ctx, iteration, results)
 		}
 		allResults = append(allResults, results...)
 		iterationEndTime := r.now()
 
-		if err := r.WriteResults(ctx, results, reportName, skillDir, runNumber, opts.Formats, iterationStartTime, iterationEndTime); err != nil {
+		if err := r.WriteResults(ctx, results, plan.ReportName, plan.SkillDir, runNumber, opts.Formats, iterationStartTime, iterationEndTime); err != nil {
 			logging.WarnContextf(ctx, "Runner: failed to write results for run %d: %v", runNumber, err)
 		}
 	}

--- a/internal/runner/workspace_options_test.go
+++ b/internal/runner/workspace_options_test.go
@@ -538,6 +538,16 @@ func (s evaluatorStub) EvaluateAll(ctx context.Context, cases []*config.CaseConf
 	return s.evaluateAll(ctx, cases)
 }
 
+func (s evaluatorStub) EvaluatePlan(ctx context.Context, tasks []evaluator.PlannedTask) ([]evaluator.EvalResult, error) {
+	cases := make([]*config.CaseConfig, 0, len(tasks))
+	for _, task := range tasks {
+		if task.Configuration == evaluator.ConfigurationWithSkill {
+			cases = append(cases, task.Case)
+		}
+	}
+	return s.evaluateAll(ctx, cases)
+}
+
 type runnerTestAgent struct{}
 
 func (a *runnerTestAgent) Name() string { return "test-agent" }


### PR DESCRIPTION
## Summary

- build one deterministic invocation-wide plan across iterations, cases, and benchmark configurations
- execute the planned tasks through preserved Runner.Evaluate and Evaluator.EvaluateAll compatibility entry points
- add optional task and iteration lifecycle observer boundaries for the later event-log integration

## Compatibility

User-visible changes: none.

This PR does not add CLI flags or event files. It preserves existing cancellation scheduling, terminal progress, report handling, result ordering, and exit behavior.

## Validation

- make fmt
- make verify
- make test
- make e2e

Part of #206.