### PR TITLE
feat(evalevent): add event protocol foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,7 @@ internal/           Private implementation — never import from outside the mod
   mcp/              MCP provisioner (mock / real)
   skill/            Install Skill files into Engine's conventional path (excluding evals/)
   evaluator/        Evaluator: iterates cases, calls agent.Run, returns CaseResult
+  evalevent/        Internal evaluation event model, publisher, lifecycle, and JSONL sink
   judge/            Judges: rule_based, script, agent_judge
   report/           Report generators: JSON / JUnit / HTML / Anthropic grading & benchmark
   runner/           End-to-end orchestration for `skill-up run`
@@ -144,6 +145,7 @@ e2e/                End-to-end tests (build-tag gated) + testdata/
 examples/           Example fixtures and debug inputs
 docs/               Design docs, user manuals, and the VitePress site
                     (built & deployed to GitHub Pages by .github/workflows/docs.yml)
+schemas/evalevent/  Versioned machine-readable evaluation event protocol schemas
 ```
 
 ### Boundary rules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ skill-up/
 │   ├── credential/          # Model credential resolution (CLI / env vars / user config)
 │   ├── runtime/             # Eval runtime: none / opensandbox
 │   ├── agent/               # Agent Engine adapters (claude_code, codex, custom)
+│   ├── evalevent/           # Internal evaluation event protocol and JSONL publisher
 │   ├── judge/               # Evaluators: rule_based, agent_judge, script
 │   ├── report/              # Report output: JSON, JUnit, HTML
 │   ├── runner/              # End-to-end orchestration (config → environment → cases → report)
@@ -63,6 +64,7 @@ skill-up/
 │       ├── references/      #     Reference docs for CLI, schema, judges, migration
 │       └── evals/           #     Evals for the skill-upper Skill itself
 ├── docs/                    # VitePress documentation site (guide/, zh/, user-manual/, .vitepress/, public/)
+├── schemas/evalevent/       # Versioned JSON Schemas for the evaluation event protocol
 ├── .githooks/               # Git hooks (commit message, pre-commit checks); see "Engineering Constraints" below
 ├── .github/workflows/       # CI (build & test) and Release (GoReleaser)
 ├── Makefile                 # Common build and check commands
@@ -106,6 +108,11 @@ skill-up/
 - **Meaning**: Invokes each Agent Engine, turning prompts and workspace constraints into a session execution and collecting a contract-compliant `SessionResult` (with transcript).
 - **Relation to design**: Corresponds to the "Engine Adapter" and the custom Engine contract.
 
+### `internal/evalevent/`
+
+- **Meaning**: Defines the internal typed evaluation event envelope and payloads, invocation lifecycle state, publisher, and JSONL sink. It is not a public stable API.
+- **Relation to design**: Implements the producer-side protocol defined by SUP-0005 without coupling it to CLI, runner, evaluator, report, or UI packages.
+
 ### `internal/judge/`
 
 - **Meaning**: Performs evaluation on top of Engine output: `rule_based`, `agent_judge`, `script`, producing results aligned with `grading.json`.
@@ -146,6 +153,11 @@ skill-up/
 
 - **Meaning**: VitePress-powered documentation site (English `guide/`, Chinese `zh/guide/`, legacy `user-manual/`); built and deployed to GitHub Pages by `.github/workflows/docs.yml`. Not part of `go build`.
 - **Maintenance advice**: User-visible behavior changes should be reflected in the relevant pages under `docs/guide/` and `docs/zh/guide/` (and the legacy `docs/user-manual/` where applicable) in the same commit.
+
+### `schemas/evalevent/`
+
+- **Meaning**: Publishes the common envelope schema and one schema for every supported evaluation event/version tuple.
+- **Maintenance advice**: Keep the schema bundle aligned with SUP-0005 and `internal/evalevent`; known event schemas must remain forward-compatible with additive fields.
 
 ### `.github/workflows/`
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,28 @@ separate Action release tag process is introduced, use a post-refresh commit SHA
 for an immutable reference or `@main` when intentionally following Action
 updates.
 
+## Project Structure
+
+```text
+skill-up/
+├── cmd/skill-up/          # CLI entry point
+├── internal/              # Private implementation packages
+│   ├── cli/               # Commands and flags
+│   ├── evaluator/         # Case execution and judging orchestration
+│   ├── evalevent/         # Evaluation event model, lifecycle, publisher, and JSONL sink
+│   ├── runner/            # End-to-end run orchestration
+│   └── report/            # JSON, JUnit, HTML, and benchmark reports
+├── pkg/                   # Publicly importable APIs
+├── schemas/evalevent/     # Versioned evaluation event JSON Schemas
+├── skills/skill-upper/    # Distributable workflow Skill
+├── docs/                  # VitePress documentation
+├── e2e/                   # End-to-end tests and fixtures
+└── examples/              # Example evaluations and fixtures
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md#directory-overview) for the complete
+directory map and architectural responsibilities.
+
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE).

--- a/internal/evalevent/event.go
+++ b/internal/evalevent/event.go
@@ -1,0 +1,392 @@
+// Package evalevent defines skill-up's internal evaluation event protocol.
+package evalevent
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+	"unicode/utf8"
+)
+
+// Type identifies an event payload on the wire.
+type Type string
+
+const (
+	// ProtocolVersion is the current event envelope and ordered-log version.
+	ProtocolVersion uint64 = 1
+	// MaxSafeInteger is the largest integer that can be represented exactly by JavaScript.
+	MaxSafeInteger uint64 = 9007199254740991
+	// EventVersionV1 is the initial version of every core payload.
+	EventVersionV1 uint64 = 1
+)
+
+const (
+	// EventRunStarted identifies the core invocation-start event.
+	EventRunStarted Type = "run_started"
+	// EventRunProgress identifies an invocation progress snapshot.
+	EventRunProgress Type = "run_progress"
+	// EventIterationStarted identifies an iteration-start event.
+	EventIterationStarted Type = "iteration_started"
+	// EventCaseStarted identifies a planned task-start event.
+	EventCaseStarted Type = "case_started"
+	// EventCaseCompleted identifies a terminal task event.
+	EventCaseCompleted Type = "case_completed"
+	// EventIterationCompleted identifies an iteration-completion event.
+	EventIterationCompleted Type = "iteration_completed"
+	// EventRunFinished identifies the invocation lifecycle-ending event.
+	EventRunFinished Type = "run_finished"
+)
+
+// Configuration identifies how a case task is executed.
+type Configuration string
+
+const (
+	// ConfigurationWithSkill executes a case with the evaluated skill installed.
+	ConfigurationWithSkill Configuration = "with_skill"
+	// ConfigurationWithoutSkill executes a case without the evaluated skill.
+	ConfigurationWithoutSkill Configuration = "without_skill"
+)
+
+// CaseStatus is a terminal case outcome.
+type CaseStatus string
+
+const (
+	// CaseStatusPass records a passing task outcome.
+	CaseStatusPass CaseStatus = "PASS"
+	// CaseStatusFail records a failing task outcome.
+	CaseStatusFail CaseStatus = "FAIL"
+	// CaseStatusError records a task execution error.
+	CaseStatusError CaseStatus = "ERROR"
+	// CaseStatusSkip records a skipped task outcome.
+	CaseStatusSkip CaseStatus = "SKIP"
+)
+
+// RunStatus is a terminal invocation lifecycle state.
+type RunStatus string
+
+const (
+	// RunStatusCompleted means every planned task reached a terminal case status.
+	RunStatusCompleted RunStatus = "COMPLETED"
+	// RunStatusError means an invocation-level failure prevented normal completion.
+	RunStatusError RunStatus = "ERROR"
+	// RunStatusCancelled means the invocation stopped after cancellation.
+	RunStatusCancelled RunStatus = "CANCELLED"
+)
+
+// RunPhase is the current invocation-level execution phase.
+type RunPhase string
+
+const (
+	// RunPhasePreparing is the initial event-log startup phase.
+	RunPhasePreparing RunPhase = "preparing"
+	// RunPhaseExecuting is the active task-execution phase.
+	RunPhaseExecuting RunPhase = "executing"
+	// RunPhaseFinalizing is the invocation finalization phase.
+	RunPhaseFinalizing RunPhase = "finalizing"
+)
+
+// Payload is a sealed, typed v1 event payload.
+type Payload interface {
+	eventType() Type
+	eventVersion() uint64
+	snapshot() Payload
+	validate() error
+}
+
+// Event is one fully enveloped evaluation event.
+type Event struct {
+	ProtocolVersion uint64            `json:"protocol_version"`
+	EventVersion    uint64            `json:"event_version"`
+	SequenceNumber  uint64            `json:"sequence_number"`
+	InvocationID    string            `json:"invocation_id"`
+	Time            time.Time         `json:"time"`
+	Type            Type              `json:"event"`
+	LastEvent       bool              `json:"last_event,omitempty"`
+	Attributes      map[string]string `json:"attributes,omitempty"`
+	Payload         Payload           `json:"payload"`
+}
+
+// RunStartedPayload announces the immutable invocation task plan.
+type RunStartedPayload struct {
+	Engine          string `json:"engine"`
+	SkillName       string `json:"skill_name"`
+	TaskTotal       uint64 `json:"task_total"`
+	IterationsTotal uint64 `json:"iterations_total"`
+}
+
+func (RunStartedPayload) eventType() Type      { return EventRunStarted }
+func (RunStartedPayload) eventVersion() uint64 { return EventVersionV1 }
+func (p RunStartedPayload) snapshot() Payload  { return p }
+func (p RunStartedPayload) validate() error {
+	if err := validateNonEmptyString("engine", p.Engine); err != nil {
+		return err
+	}
+	if err := validateNonEmptyString("skill_name", p.SkillName); err != nil {
+		return err
+	}
+	if err := validatePositiveInteger("task_total", p.TaskTotal); err != nil {
+		return err
+	}
+	return validatePositiveInteger("iterations_total", p.IterationsTotal)
+}
+
+// ResultCounts contains terminal task counts grouped by outcome.
+type ResultCounts struct {
+	Passed  uint64 `json:"passed"`
+	Failed  uint64 `json:"failed"`
+	Errored uint64 `json:"errored"`
+	Skipped uint64 `json:"skipped"`
+}
+
+func (c ResultCounts) validate() error {
+	for name, value := range map[string]uint64{
+		"passed": c.Passed, "failed": c.Failed, "errored": c.Errored, "skipped": c.Skipped,
+	} {
+		if err := validateSafeInteger(name, value); err != nil {
+			return err
+		}
+	}
+	if c.Passed > MaxSafeInteger-c.Failed || c.Passed+c.Failed > MaxSafeInteger-c.Errored ||
+		c.Passed+c.Failed+c.Errored > MaxSafeInteger-c.Skipped {
+		return fmt.Errorf("result count sum exceeds %d", MaxSafeInteger)
+	}
+	return nil
+}
+
+func (c ResultCounts) total() uint64 {
+	return c.Passed + c.Failed + c.Errored + c.Skipped
+}
+
+// RunProgressPayload is a replaceable invocation-level progress snapshot.
+type RunProgressPayload struct {
+	ResultCounts
+
+	Phase          RunPhase `json:"phase"`
+	TaskTotal      uint64   `json:"task_total"`
+	CompletedTasks uint64   `json:"completed_tasks"`
+	RunningTasks   uint64   `json:"running_tasks"`
+	ElapsedMS      uint64   `json:"elapsed_ms"`
+}
+
+func (RunProgressPayload) eventType() Type      { return EventRunProgress }
+func (RunProgressPayload) eventVersion() uint64 { return EventVersionV1 }
+func (p RunProgressPayload) snapshot() Payload  { return p }
+func (p RunProgressPayload) validate() error {
+	if !p.Phase.valid() {
+		return fmt.Errorf("invalid phase %q", p.Phase)
+	}
+	if err := validatePositiveInteger("task_total", p.TaskTotal); err != nil {
+		return err
+	}
+	if err := validateSafeInteger("completed_tasks", p.CompletedTasks); err != nil {
+		return err
+	}
+	if err := validateSafeInteger("running_tasks", p.RunningTasks); err != nil {
+		return err
+	}
+	if err := validateSafeInteger("elapsed_ms", p.ElapsedMS); err != nil {
+		return err
+	}
+	if err := p.ResultCounts.validate(); err != nil {
+		return err
+	}
+	if p.CompletedTasks != p.total() {
+		return errors.New("completed_tasks must equal the result count sum")
+	}
+	if p.CompletedTasks > p.TaskTotal || p.RunningTasks > p.TaskTotal-p.CompletedTasks {
+		return errors.New("completed_tasks + running_tasks exceeds task_total")
+	}
+	return nil
+}
+
+// IterationStartedPayload announces an evaluation iteration.
+type IterationStartedPayload struct {
+	Iteration uint64 `json:"iteration"`
+}
+
+func (IterationStartedPayload) eventType() Type      { return EventIterationStarted }
+func (IterationStartedPayload) eventVersion() uint64 { return EventVersionV1 }
+func (p IterationStartedPayload) snapshot() Payload  { return p }
+func (p IterationStartedPayload) validate() error {
+	return validatePositiveInteger("iteration", p.Iteration)
+}
+
+// TaskFields identifies one planned case/configuration execution.
+type TaskFields struct {
+	TaskID        string        `json:"task_id"`
+	Iteration     uint64        `json:"iteration"`
+	CaseID        string        `json:"case_id"`
+	Configuration Configuration `json:"configuration"`
+	TaskIndex     uint64        `json:"task_index"`
+	TaskTotal     uint64        `json:"task_total"`
+	Title         string        `json:"title"`
+}
+
+func (f TaskFields) validate() error {
+	if err := validateNonEmptyString("task_id", f.TaskID); err != nil {
+		return err
+	}
+	if err := validatePositiveInteger("iteration", f.Iteration); err != nil {
+		return err
+	}
+	if err := validateNonEmptyString("case_id", f.CaseID); err != nil {
+		return err
+	}
+	if !f.Configuration.valid() {
+		return fmt.Errorf("invalid configuration %q", f.Configuration)
+	}
+	if err := validatePositiveInteger("task_total", f.TaskTotal); err != nil {
+		return err
+	}
+	if err := validatePositiveInteger("task_index", f.TaskIndex); err != nil {
+		return err
+	}
+	if f.TaskIndex > f.TaskTotal {
+		return errors.New("task_index exceeds task_total")
+	}
+	return validateString("title", f.Title)
+}
+
+// CaseStartedPayload announces a task execution start.
+type CaseStartedPayload struct {
+	TaskFields
+}
+
+func (CaseStartedPayload) eventType() Type      { return EventCaseStarted }
+func (CaseStartedPayload) eventVersion() uint64 { return EventVersionV1 }
+func (p CaseStartedPayload) snapshot() Payload  { return p }
+func (p CaseStartedPayload) validate() error    { return p.TaskFields.validate() }
+
+// CaseCompletedPayload records one terminal task outcome.
+type CaseCompletedPayload struct {
+	TaskFields
+
+	CompletedTasks uint64     `json:"completed_tasks"`
+	Status         CaseStatus `json:"status"`
+	PassRate       *float64   `json:"pass_rate,omitempty"`
+	DurationMS     uint64     `json:"duration_ms"`
+}
+
+func (CaseCompletedPayload) eventType() Type      { return EventCaseCompleted }
+func (CaseCompletedPayload) eventVersion() uint64 { return EventVersionV1 }
+func (p CaseCompletedPayload) snapshot() Payload {
+	p.PassRate = copyPassRate(p.PassRate)
+	return p
+}
+
+func (p CaseCompletedPayload) validate() error {
+	if err := p.TaskFields.validate(); err != nil {
+		return err
+	}
+	if err := validateSafeInteger("completed_tasks", p.CompletedTasks); err != nil {
+		return err
+	}
+	if p.CompletedTasks > p.TaskTotal {
+		return errors.New("completed_tasks exceeds task_total")
+	}
+	if !p.Status.valid() {
+		return fmt.Errorf("invalid case status %q", p.Status)
+	}
+	if p.PassRate != nil && (math.IsNaN(*p.PassRate) || math.IsInf(*p.PassRate, 0) || *p.PassRate < 0 || *p.PassRate > 1) {
+		return errors.New("pass_rate must be finite and between 0 and 1")
+	}
+	return validateSafeInteger("duration_ms", p.DurationMS)
+}
+
+// IterationCompletedPayload records terminal counts for one iteration.
+type IterationCompletedPayload struct {
+	ResultCounts
+
+	Iteration                uint64 `json:"iteration"`
+	InvocationCompletedTasks uint64 `json:"invocation_completed_tasks"`
+	DurationMS               uint64 `json:"duration_ms"`
+}
+
+func (IterationCompletedPayload) eventType() Type      { return EventIterationCompleted }
+func (IterationCompletedPayload) eventVersion() uint64 { return EventVersionV1 }
+func (p IterationCompletedPayload) snapshot() Payload  { return p }
+func (p IterationCompletedPayload) validate() error {
+	if err := validatePositiveInteger("iteration", p.Iteration); err != nil {
+		return err
+	}
+	if err := validateSafeInteger("invocation_completed_tasks", p.InvocationCompletedTasks); err != nil {
+		return err
+	}
+	if err := p.ResultCounts.validate(); err != nil {
+		return err
+	}
+	return validateSafeInteger("duration_ms", p.DurationMS)
+}
+
+// RunFinishedPayload records the terminal invocation lifecycle state.
+type RunFinishedPayload struct {
+	ResultCounts
+
+	Status         RunStatus `json:"status"`
+	CompletedTasks uint64    `json:"completed_tasks"`
+	DurationMS     uint64    `json:"duration_ms"`
+}
+
+func (RunFinishedPayload) eventType() Type      { return EventRunFinished }
+func (RunFinishedPayload) eventVersion() uint64 { return EventVersionV1 }
+func (p RunFinishedPayload) snapshot() Payload  { return p }
+func (p RunFinishedPayload) validate() error {
+	if !p.Status.valid() {
+		return fmt.Errorf("invalid run status %q", p.Status)
+	}
+	if err := validateSafeInteger("completed_tasks", p.CompletedTasks); err != nil {
+		return err
+	}
+	if err := p.ResultCounts.validate(); err != nil {
+		return err
+	}
+	if p.CompletedTasks != p.total() {
+		return errors.New("completed_tasks must equal the result count sum")
+	}
+	return validateSafeInteger("duration_ms", p.DurationMS)
+}
+
+func (c Configuration) valid() bool {
+	return c == ConfigurationWithSkill || c == ConfigurationWithoutSkill
+}
+
+func (s CaseStatus) valid() bool {
+	return s == CaseStatusPass || s == CaseStatusFail || s == CaseStatusError || s == CaseStatusSkip
+}
+
+func (s RunStatus) valid() bool {
+	return s == RunStatusCompleted || s == RunStatusError || s == RunStatusCancelled
+}
+
+func (p RunPhase) valid() bool {
+	return p == RunPhasePreparing || p == RunPhaseExecuting || p == RunPhaseFinalizing
+}
+
+func validatePositiveInteger(name string, value uint64) error {
+	if value == 0 {
+		return fmt.Errorf("%s must be at least 1", name)
+	}
+	return validateSafeInteger(name, value)
+}
+
+func validateSafeInteger(name string, value uint64) error {
+	if value > MaxSafeInteger {
+		return fmt.Errorf("%s exceeds %d", name, MaxSafeInteger)
+	}
+	return nil
+}
+
+func validateNonEmptyString(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s must not be empty", name)
+	}
+	return validateString(name, value)
+}
+
+func validateString(name, value string) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s must be valid UTF-8", name)
+	}
+	return nil
+}

--- a/internal/evalevent/event_test.go
+++ b/internal/evalevent/event_test.go
@@ -1,0 +1,95 @@
+package evalevent
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPayloadValidation(t *testing.T) {
+	t.Parallel()
+
+	validTask := TaskFields{
+		TaskID:        "task-1",
+		Iteration:     1,
+		CaseID:        "目录/用例%1",
+		Configuration: ConfigurationWithSkill,
+		TaskIndex:     1,
+		TaskTotal:     2,
+		Title:         "Basic flow",
+	}
+	invalidRate := math.NaN()
+	tests := []struct {
+		name    string
+		payload Payload
+		wantErr string
+	}{
+		{name: "run started", payload: RunStartedPayload{Engine: "qoder-cli", SkillName: "skill", TaskTotal: 2, IterationsTotal: 1}},
+		{name: "run started empty engine", payload: RunStartedPayload{SkillName: "skill", TaskTotal: 2, IterationsTotal: 1}, wantErr: "engine"},
+		{name: "progress", payload: RunProgressPayload{Phase: RunPhaseExecuting, TaskTotal: 2, CompletedTasks: 1, RunningTasks: 1, ResultCounts: ResultCounts{Passed: 1}}},
+		{name: "progress count mismatch", payload: RunProgressPayload{Phase: RunPhaseExecuting, TaskTotal: 2, CompletedTasks: 1}, wantErr: "result count sum"},
+		{name: "progress exceeds total", payload: RunProgressPayload{Phase: RunPhaseExecuting, TaskTotal: 1, RunningTasks: 2}, wantErr: "exceeds task_total"},
+		{name: "iteration started", payload: IterationStartedPayload{Iteration: 3}},
+		{name: "case started", payload: CaseStartedPayload{TaskFields: validTask}},
+		{name: "case invalid configuration", payload: CaseStartedPayload{TaskFields: TaskFields{TaskID: "task", Iteration: 1, CaseID: "case", Configuration: "other", TaskIndex: 1, TaskTotal: 1}}, wantErr: "configuration"},
+		{name: "case complete", payload: CaseCompletedPayload{TaskFields: validTask, CompletedTasks: 1, Status: CaseStatusPass, DurationMS: 12}},
+		{name: "case invalid pass rate", payload: CaseCompletedPayload{TaskFields: validTask, CompletedTasks: 1, Status: CaseStatusPass, PassRate: &invalidRate}, wantErr: "pass_rate"},
+		{name: "iteration complete", payload: IterationCompletedPayload{Iteration: 1, InvocationCompletedTasks: 2, ResultCounts: ResultCounts{Passed: 1, Failed: 1}, DurationMS: 30}},
+		{name: "run finished", payload: RunFinishedPayload{Status: RunStatusCompleted, CompletedTasks: 2, ResultCounts: ResultCounts{Passed: 1, Failed: 1}, DurationMS: 30}},
+		{name: "run finished mismatch", payload: RunFinishedPayload{Status: RunStatusCompleted, CompletedTasks: 2, ResultCounts: ResultCounts{Passed: 1}}, wantErr: "result count sum"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.payload.validate()
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("validate() error = %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("validate() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEventJSONUsesNormativeEnvelopeAndOmissions(t *testing.T) {
+	t.Parallel()
+
+	event := Event{
+		ProtocolVersion: 1,
+		EventVersion:    1,
+		SequenceNumber:  1,
+		InvocationID:    "018f8f20-7a7d-7d90-a192-4f5ec8f07a2a",
+		Time:            time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC),
+		Type:            EventCaseCompleted,
+		Payload: CaseCompletedPayload{
+			TaskFields: TaskFields{
+				TaskID: "task-1", Iteration: 1, CaseID: "case-1",
+				Configuration: ConfigurationWithSkill, TaskIndex: 1, TaskTotal: 1, Title: "Case",
+			},
+			CompletedTasks: 1,
+			Status:         CaseStatusSkip,
+			DurationMS:     7,
+		},
+	}
+
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	text := string(encoded)
+	for _, field := range []string{`"protocol_version":1`, `"event_version":1`, `"sequence_number":1`, `"event":"case_completed"`, `"payload":{`} {
+		if !strings.Contains(text, field) {
+			t.Errorf("encoded event missing %s: %s", field, text)
+		}
+	}
+	for _, omitted := range []string{`"last_event"`, `"attributes"`, `"pass_rate"`} {
+		if strings.Contains(text, omitted) {
+			t.Errorf("encoded event unexpectedly contains %s: %s", omitted, text)
+		}
+	}
+}

--- a/internal/evalevent/jsonl.go
+++ b/internal/evalevent/jsonl.go
@@ -1,0 +1,95 @@
+package evalevent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+const maxJSONEventSize = 1 << 20
+
+var errJSONLSinkClosed = errors.New("JSONL event sink is closed")
+
+// JSONLSink writes complete, newline-terminated event records synchronously.
+type JSONLSink struct {
+	mu sync.Mutex
+
+	writer   io.WriteCloser
+	closed   bool
+	closeErr error
+}
+
+// NewJSONLFileSink creates or truncates path and requests mode 0600 for a new file.
+func NewJSONLFileSink(path string) (*JSONLSink, error) {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open JSONL event log: %w", err)
+	}
+	return NewJSONLSink(file), nil
+}
+
+// NewJSONLSink wraps an unbuffered writer. The sink takes ownership of writer.
+func NewJSONLSink(writer io.WriteCloser) *JSONLSink {
+	return &JSONLSink{writer: writer}
+}
+
+// Publish writes one UTF-8 JSON object followed by a newline.
+func (s *JSONLSink) Publish(ctx context.Context, event Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	record, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal event: %w", err)
+	}
+	if len(record) > maxJSONEventSize {
+		return fmt.Errorf("serialized event is %d bytes; limit is %d", len(record), maxJSONEventSize)
+	}
+	record = append(record, '\n')
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return errJSONLSinkClosed
+	}
+	if s.writer == nil {
+		return errors.New("JSONL writer must not be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for len(record) > 0 {
+		written, writeErr := s.writer.Write(record)
+		if written < 0 || written > len(record) {
+			return fmt.Errorf("write JSONL event: invalid write count %d", written)
+		}
+		record = record[written:]
+		if writeErr != nil {
+			return fmt.Errorf("write JSONL event: %w", writeErr)
+		}
+		if written == 0 {
+			return fmt.Errorf("write JSONL event: %w", io.ErrShortWrite)
+		}
+	}
+	return nil
+}
+
+// Close idempotently closes the owned writer.
+func (s *JSONLSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return s.closeErr
+	}
+	s.closed = true
+	if s.writer == nil {
+		s.closeErr = errors.New("JSONL writer must not be nil")
+		return s.closeErr
+	}
+	s.closeErr = s.writer.Close()
+	return s.closeErr
+}

--- a/internal/evalevent/jsonl_test.go
+++ b/internal/evalevent/jsonl_test.go
@@ -1,0 +1,203 @@
+package evalevent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJSONLSinkHandlesShortWritesAndTerminatesRecord(t *testing.T) {
+	t.Parallel()
+
+	writer := &chunkWriteCloser{maxWrite: 7}
+	sink := NewJSONLSink(writer)
+	event := testEvent(RunStartedPayload{Engine: "test", SkillName: "skill", TaskTotal: 1, IterationsTotal: 1})
+	if err := sink.Publish(context.Background(), event); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if !bytes.HasSuffix(writer.Bytes(), []byte{'\n'}) {
+		t.Fatalf("record is not newline terminated: %q", writer.Bytes())
+	}
+	if bytes.Count(writer.Bytes(), []byte{'\n'}) != 1 {
+		t.Fatalf("record contains unexpected newlines: %q", writer.Bytes())
+	}
+	if writer.closeCount != 1 {
+		t.Fatalf("writer close count = %d, want 1", writer.closeCount)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("repeated Close() error = %v", err)
+	}
+	if writer.closeCount != 1 {
+		t.Fatalf("writer close count after repeated close = %d, want 1", writer.closeCount)
+	}
+}
+
+func TestJSONLSinkReportsPartialAndZeroWrites(t *testing.T) {
+	t.Parallel()
+
+	writeFailure := errors.New("write failed")
+	tests := []struct {
+		name   string
+		writer io.WriteCloser
+		want   string
+	}{
+		{name: "partial error", writer: &failingWriteCloser{n: 3, err: writeFailure}, want: "write failed"},
+		{name: "zero write", writer: &failingWriteCloser{}, want: "short write"},
+		{name: "nil writer", writer: nil, want: "must not be nil"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := NewJSONLSink(tt.writer)
+			err := sink.Publish(context.Background(), testEvent(validProgressPayload()))
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Publish() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestJSONLSinkHonorsCanceledContextBeforeWriting(t *testing.T) {
+	t.Parallel()
+
+	writer := &chunkWriteCloser{maxWrite: 10}
+	sink := NewJSONLSink(writer)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := sink.Publish(ctx, testEvent(validProgressPayload())); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Publish() error = %v, want context.Canceled", err)
+	}
+	if writer.Len() != 0 {
+		t.Fatalf("writer received %d bytes after cancellation", writer.Len())
+	}
+}
+
+func TestJSONLSinkRejectsOversizedRecord(t *testing.T) {
+	t.Parallel()
+
+	writer := &chunkWriteCloser{maxWrite: maxJSONEventSize}
+	sink := NewJSONLSink(writer)
+	payload := CaseStartedPayload{TaskFields: TaskFields{
+		TaskID: "task-1", Iteration: 1, CaseID: "case-1", Configuration: ConfigurationWithSkill,
+		TaskIndex: 1, TaskTotal: 1, Title: strings.Repeat("x", maxJSONEventSize),
+	}}
+	if err := sink.Publish(context.Background(), testEvent(payload)); err == nil || !strings.Contains(err.Error(), "limit") {
+		t.Fatalf("Publish() error = %v, want size-limit error", err)
+	}
+	if writer.Len() != 0 {
+		t.Fatalf("writer received %d bytes for oversized record", writer.Len())
+	}
+}
+
+//nolint:cyclop // The test verifies create, write, truncate, and mode preservation as one file lifecycle.
+func TestJSONLFileSinkCreatesTruncatesAndPreservesMode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	sink, err := NewJSONLFileSink(path)
+	if err != nil {
+		t.Fatalf("NewJSONLFileSink() error = %v", err)
+	}
+	if err := sink.Publish(context.Background(), testEvent(validProgressPayload())); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("new file mode = %o, want no group/other permissions", info.Mode().Perm())
+	}
+
+	if err := os.Chmod(path, 0o640); err != nil { //nolint:gosec // The test verifies preservation of an existing mode.
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte("stale trailing data"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	sink, err = NewJSONLFileSink(path)
+	if err != nil {
+		t.Fatalf("NewJSONLFileSink(existing) error = %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close(existing) error = %v", err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if len(contents) != 0 {
+		t.Fatalf("existing file was not truncated: %q", contents)
+	}
+	info, err = os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(existing) error = %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o640 {
+		t.Errorf("existing file mode = %o, want 640", info.Mode().Perm())
+	}
+}
+
+func TestJSONLFileSinkRequiresExistingParent(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "missing", "events.jsonl")
+	if _, err := NewJSONLFileSink(path); err == nil {
+		t.Fatal("NewJSONLFileSink() succeeded with missing parent")
+	}
+}
+
+func testEvent(payload Payload) Event {
+	return Event{
+		ProtocolVersion: 1,
+		EventVersion:    payload.eventVersion(),
+		SequenceNumber:  1,
+		InvocationID:    "018f8f20-7a7d-7d90-a192-4f5ec8f07a2a",
+		Time:            time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC),
+		Type:            payload.eventType(),
+		Payload:         payload,
+	}
+}
+
+type chunkWriteCloser struct {
+	bytes.Buffer
+
+	maxWrite   int
+	closeCount int
+}
+
+func (w *chunkWriteCloser) Write(p []byte) (int, error) {
+	limit := min(len(p), w.maxWrite)
+	return w.Buffer.Write(p[:limit])
+}
+
+func (w *chunkWriteCloser) Close() error {
+	w.closeCount++
+	return nil
+}
+
+type failingWriteCloser struct {
+	n   int
+	err error
+}
+
+func (w *failingWriteCloser) Write(p []byte) (int, error) {
+	return min(w.n, len(p)), w.err
+}
+
+func (w *failingWriteCloser) Close() error { return nil }

--- a/internal/evalevent/lifecycle.go
+++ b/internal/evalevent/lifecycle.go
@@ -1,0 +1,572 @@
+package evalevent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+)
+
+const defaultHeartbeatInterval = 30 * time.Second
+
+// Task is the lifecycle emitter's immutable view of one planned evaluation task.
+type Task struct {
+	ID            string
+	Iteration     uint64
+	CaseID        string
+	Configuration Configuration
+	Index         uint64
+	Title         string
+}
+
+// Iteration is the lifecycle emitter's immutable view of one planned iteration.
+type Iteration struct {
+	Number uint64
+	Tasks  []Task
+}
+
+// Plan contains all tasks announced by run_started.
+type Plan struct {
+	Iterations []Iteration
+}
+
+// Ticker is the minimal periodic clock contract used by Lifecycle.
+type Ticker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+// Clock supplies monotonic-capable times and tickers for lifecycle timing.
+type Clock interface {
+	Now() time.Time
+	NewTicker(interval time.Duration) Ticker
+}
+
+// LifecycleOptions controls lifecycle timing. Zero values use production defaults.
+type LifecycleOptions struct {
+	Clock             Clock
+	HeartbeatInterval time.Duration
+}
+
+// Lifecycle serializes task state transitions and their progress snapshots.
+type Lifecycle struct {
+	mu sync.Mutex
+
+	publisher *Publisher
+	clock     Clock
+	interval  time.Duration
+
+	tasks      map[string]*lifecycleTask
+	iterations map[uint64]*lifecycleIteration
+	taskTotal  uint64
+
+	started       bool
+	finished      bool
+	phase         RunPhase
+	runStartedAt  time.Time
+	completed     uint64
+	resultCounts  ResultCounts
+	activeTaskIDs map[string]struct{}
+
+	heartbeatStopOnce sync.Once
+	heartbeatStop     chan struct{}
+	heartbeatDone     chan struct{}
+	heartbeatStarted  bool
+}
+
+type lifecycleTask struct {
+	task      Task
+	started   bool
+	completed bool
+	startedAt time.Time
+}
+
+type lifecycleIteration struct {
+	iteration  Iteration
+	started    bool
+	completed  bool
+	startedAt  time.Time
+	result     ResultCounts
+	completedN uint64
+}
+
+// NewLifecycle validates and snapshots a plan without importing runner or evaluator types.
+func NewLifecycle(publisher *Publisher, plan Plan, opts LifecycleOptions) (*Lifecycle, error) {
+	if publisher == nil {
+		return nil, errors.New("publisher must not be nil")
+	}
+	tasks, iterations, taskTotal, err := snapshotPlan(plan)
+	if err != nil {
+		return nil, err
+	}
+	clock := opts.Clock
+	if clock == nil {
+		clock = systemClock{}
+	}
+	interval := opts.HeartbeatInterval
+	if interval == 0 {
+		interval = defaultHeartbeatInterval
+	}
+	if interval < 0 {
+		return nil, errors.New("heartbeat interval must not be negative")
+	}
+	return &Lifecycle{
+		publisher:     publisher,
+		clock:         clock,
+		interval:      interval,
+		tasks:         tasks,
+		iterations:    iterations,
+		taskTotal:     taskTotal,
+		activeTaskIDs: make(map[string]struct{}),
+		heartbeatStop: make(chan struct{}),
+		heartbeatDone: make(chan struct{}),
+	}, nil
+}
+
+// Start publishes run_started and the initial preparing snapshot, then starts heartbeats.
+func (l *Lifecycle) Start(ctx context.Context, engine, skillName string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.started {
+		return errors.New("lifecycle already started")
+	}
+	if err := validateNonEmptyString("engine", engine); err != nil {
+		return err
+	}
+	if err := validateNonEmptyString("skill_name", skillName); err != nil {
+		return err
+	}
+	l.started = true
+	l.phase = RunPhasePreparing
+	l.runStartedAt = l.clock.Now()
+	if err := l.publishLocked(ctx, RunStartedPayload{
+		Engine:          engine,
+		SkillName:       skillName,
+		TaskTotal:       l.taskTotal,
+		IterationsTotal: uint64(len(l.iterations)),
+	}); err != nil {
+		return err
+	}
+	if err := l.publishProgressLocked(ctx); err != nil {
+		return err
+	}
+	l.startHeartbeatLocked(context.WithoutCancel(ctx))
+	return nil
+}
+
+// SetPhase moves the active invocation to a later execution phase and publishes progress.
+func (l *Lifecycle) SetPhase(ctx context.Context, phase RunPhase) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.ensureActiveLocked(); err != nil {
+		return err
+	}
+	if !phase.valid() {
+		return fmt.Errorf("invalid phase %q", phase)
+	}
+	if phase == RunPhaseFinalizing {
+		return errors.New("finalizing phase is owned by Finish")
+	}
+	if phaseRank(phase) <= phaseRank(l.phase) {
+		return fmt.Errorf("phase transition from %q to %q is not forward", l.phase, phase)
+	}
+	l.phase = phase
+	return l.publishProgressLocked(ctx)
+}
+
+// Heartbeat publishes a progress snapshot with refreshed elapsed time.
+func (l *Lifecycle) Heartbeat(ctx context.Context) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.ensureActiveLocked(); err != nil {
+		return err
+	}
+	return l.publishProgressLocked(ctx)
+}
+
+// IterationStarted announces one known iteration before any of its tasks start.
+func (l *Lifecycle) IterationStarted(ctx context.Context, number uint64) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.ensureExecutingLocked(); err != nil {
+		return err
+	}
+	iteration, ok := l.iterations[number]
+	if !ok {
+		return fmt.Errorf("unknown iteration %d", number)
+	}
+	if iteration.started {
+		return fmt.Errorf("iteration %d already started", number)
+	}
+	iteration.started = true
+	iteration.startedAt = l.clock.Now()
+	return l.publishLocked(ctx, IterationStartedPayload{Iteration: number})
+}
+
+// CaseStarted announces one known planned task and refreshes progress.
+func (l *Lifecycle) CaseStarted(ctx context.Context, taskID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.ensureExecutingLocked(); err != nil {
+		return err
+	}
+	task, ok := l.tasks[taskID]
+	if !ok {
+		return fmt.Errorf("unknown task %q", taskID)
+	}
+	iteration := l.iterations[task.task.Iteration]
+	if !iteration.started || iteration.completed {
+		return fmt.Errorf("iteration %d is not active", task.task.Iteration)
+	}
+	if task.started {
+		return fmt.Errorf("task %q already started", taskID)
+	}
+	task.started = true
+	task.startedAt = l.clock.Now()
+	l.activeTaskIDs[taskID] = struct{}{}
+	if err := l.publishLocked(ctx, CaseStartedPayload{TaskFields: l.taskFields(task.task)}); err != nil {
+		return err
+	}
+	return l.publishProgressLocked(ctx)
+}
+
+// CaseCompleted records one terminal task status and refreshes progress.
+func (l *Lifecycle) CaseCompleted(ctx context.Context, taskID string, status CaseStatus, passRate *float64) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.ensureExecutingLocked(); err != nil {
+		return err
+	}
+	if !status.valid() {
+		return fmt.Errorf("invalid case status %q", status)
+	}
+	if err := validatePassRate(passRate); err != nil {
+		return err
+	}
+	task, ok := l.tasks[taskID]
+	if !ok {
+		return fmt.Errorf("unknown task %q", taskID)
+	}
+	if !task.started || task.completed {
+		return fmt.Errorf("task %q is not actively running", taskID)
+	}
+	task.completed = true
+	delete(l.activeTaskIDs, taskID)
+	l.completed++
+	addStatus(&l.resultCounts, status)
+	iteration := l.iterations[task.task.Iteration]
+	iteration.completedN++
+	addStatus(&iteration.result, status)
+	payload := CaseCompletedPayload{
+		TaskFields:     l.taskFields(task.task),
+		CompletedTasks: l.completed,
+		Status:         status,
+		PassRate:       copyPassRate(passRate),
+		DurationMS:     elapsedMS(task.startedAt, l.clock.Now()),
+	}
+	if err := l.publishLocked(ctx, payload); err != nil {
+		return err
+	}
+	return l.publishProgressLocked(ctx)
+}
+
+// IterationCompleted records one iteration after all its planned tasks complete.
+func (l *Lifecycle) IterationCompleted(ctx context.Context, number uint64) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.ensureExecutingLocked(); err != nil {
+		return err
+	}
+	iteration, ok := l.iterations[number]
+	if !ok {
+		return fmt.Errorf("unknown iteration %d", number)
+	}
+	if !iteration.started || iteration.completed {
+		return fmt.Errorf("iteration %d is not actively running", number)
+	}
+	if iteration.completedN != uint64(len(iteration.iteration.Tasks)) {
+		return fmt.Errorf("iteration %d has unfinished tasks", number)
+	}
+	iteration.completed = true
+	return l.publishLocked(ctx, IterationCompletedPayload{
+		Iteration:                number,
+		InvocationCompletedTasks: l.completed,
+		ResultCounts:             iteration.result,
+		DurationMS:               elapsedMS(iteration.startedAt, l.clock.Now()),
+	})
+}
+
+// Finish stops heartbeats and attempts to publish final progress and run_finished.
+func (l *Lifecycle) Finish(ctx context.Context, status RunStatus) error {
+	l.stopHeartbeat()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.ensureActiveLocked(); err != nil {
+		return err
+	}
+	if !status.valid() {
+		return fmt.Errorf("invalid run status %q", status)
+	}
+	if status == RunStatusCompleted && l.completed != l.taskTotal {
+		return fmt.Errorf("completed run has %d of %d terminal tasks", l.completed, l.taskTotal)
+	}
+	if status == RunStatusCompleted {
+		for number, iteration := range l.iterations {
+			if !iteration.completed {
+				return fmt.Errorf("completed run has unfinished iteration %d", number)
+			}
+		}
+	}
+	l.phase = RunPhaseFinalizing
+	clear(l.activeTaskIDs)
+	l.finished = true
+	progressErr := l.publishProgressLocked(ctx)
+	finishedErr := l.publishLastLocked(ctx, RunFinishedPayload{
+		Status:         status,
+		CompletedTasks: l.completed,
+		ResultCounts:   l.resultCounts,
+		DurationMS:     elapsedMS(l.runStartedAt, l.clock.Now()),
+	})
+	if progressErr != nil {
+		return progressErr
+	}
+	return finishedErr
+}
+
+func (l *Lifecycle) taskFields(task Task) TaskFields {
+	return TaskFields{
+		TaskID:        task.ID,
+		Iteration:     task.Iteration,
+		CaseID:        task.CaseID,
+		Configuration: task.Configuration,
+		TaskIndex:     task.Index,
+		TaskTotal:     l.taskTotal,
+		Title:         task.Title,
+	}
+}
+
+func (l *Lifecycle) progressPayloadLocked() RunProgressPayload {
+	return RunProgressPayload{
+		Phase:          l.phase,
+		TaskTotal:      l.taskTotal,
+		CompletedTasks: l.completed,
+		RunningTasks:   uint64(len(l.activeTaskIDs)),
+		ResultCounts:   l.resultCounts,
+		ElapsedMS:      elapsedMS(l.runStartedAt, l.clock.Now()),
+	}
+}
+
+func (l *Lifecycle) publishProgressLocked(ctx context.Context) error {
+	return l.publishLocked(ctx, l.progressPayloadLocked())
+}
+
+func (l *Lifecycle) publishLocked(ctx context.Context, payload Payload) error {
+	return l.recordPublicationError(l.publisher.Publish(ctx, payload))
+}
+
+func (l *Lifecycle) publishLastLocked(ctx context.Context, payload Payload) error {
+	return l.recordPublicationError(l.publisher.PublishLast(ctx, payload))
+}
+
+func (l *Lifecycle) recordPublicationError(err error) error {
+	if err != nil {
+		l.requestHeartbeatStop()
+	}
+	return err
+}
+
+func (l *Lifecycle) ensureActiveLocked() error {
+	if !l.started {
+		return errors.New("lifecycle has not started")
+	}
+	if l.finished {
+		return errors.New("lifecycle already finished")
+	}
+	return nil
+}
+
+func (l *Lifecycle) ensureExecutingLocked() error {
+	if err := l.ensureActiveLocked(); err != nil {
+		return err
+	}
+	if l.phase != RunPhaseExecuting {
+		return fmt.Errorf("lifecycle is in %q phase, not executing", l.phase)
+	}
+	return nil
+}
+
+func (l *Lifecycle) startHeartbeatLocked(ctx context.Context) {
+	if l.interval <= 0 {
+		close(l.heartbeatDone)
+		return
+	}
+	l.heartbeatStarted = true
+	ticker := l.clock.NewTicker(l.interval)
+	go l.runHeartbeat(ctx, ticker)
+}
+
+func (l *Lifecycle) runHeartbeat(ctx context.Context, ticker Ticker) {
+	defer close(l.heartbeatDone)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-l.heartbeatStop:
+			return
+		case <-ticker.C():
+			if err := l.Heartbeat(ctx); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (l *Lifecycle) requestHeartbeatStop() {
+	l.heartbeatStopOnce.Do(func() { close(l.heartbeatStop) })
+}
+
+func (l *Lifecycle) stopHeartbeat() {
+	l.mu.Lock()
+	started := l.heartbeatStarted
+	l.mu.Unlock()
+	l.requestHeartbeatStop()
+	if started {
+		<-l.heartbeatDone
+	}
+}
+
+func snapshotPlan(plan Plan) (map[string]*lifecycleTask, map[uint64]*lifecycleIteration, uint64, error) {
+	if len(plan.Iterations) == 0 {
+		return nil, nil, 0, errors.New("plan must contain at least one iteration")
+	}
+	taskCount := 0
+	for _, iteration := range plan.Iterations {
+		taskCount += len(iteration.Tasks)
+	}
+	if taskCount == 0 || uint64(taskCount) > MaxSafeInteger {
+		return nil, nil, 0, fmt.Errorf("plan task total must be between 1 and %d", MaxSafeInteger)
+	}
+	taskTotal := uint64(taskCount)
+	tasks := make(map[string]*lifecycleTask, taskCount)
+	iterations := make(map[uint64]*lifecycleIteration, len(plan.Iterations))
+	indices := make(map[uint64]struct{}, taskCount)
+	for _, iteration := range plan.Iterations {
+		if err := validatePositiveInteger("iteration", iteration.Number); err != nil {
+			return nil, nil, 0, err
+		}
+		if len(iteration.Tasks) == 0 {
+			return nil, nil, 0, fmt.Errorf("iteration %d must contain at least one task", iteration.Number)
+		}
+		if _, exists := iterations[iteration.Number]; exists {
+			return nil, nil, 0, fmt.Errorf("duplicate iteration %d", iteration.Number)
+		}
+		iterationCopy := Iteration{Number: iteration.Number, Tasks: append([]Task(nil), iteration.Tasks...)}
+		iterations[iteration.Number] = &lifecycleIteration{iteration: iterationCopy}
+		for _, task := range iteration.Tasks {
+			if err := validatePlanTask(task, iteration.Number, taskTotal); err != nil {
+				return nil, nil, 0, err
+			}
+			if _, exists := tasks[task.ID]; exists {
+				return nil, nil, 0, fmt.Errorf("duplicate task ID %q", task.ID)
+			}
+			if _, exists := indices[task.Index]; exists {
+				return nil, nil, 0, fmt.Errorf("duplicate task index %d", task.Index)
+			}
+			indices[task.Index] = struct{}{}
+			tasks[task.ID] = &lifecycleTask{task: task}
+		}
+	}
+	for index := uint64(1); index <= taskTotal; index++ {
+		if _, ok := indices[index]; !ok {
+			return nil, nil, 0, fmt.Errorf("plan is missing task index %d", index)
+		}
+	}
+	return tasks, iterations, taskTotal, nil
+}
+
+func validatePlanTask(task Task, iteration, taskTotal uint64) error {
+	if err := validateNonEmptyString("task_id", task.ID); err != nil {
+		return err
+	}
+	if task.Iteration != iteration {
+		return fmt.Errorf("task %q iteration %d does not match iteration %d", task.ID, task.Iteration, iteration)
+	}
+	if err := validateNonEmptyString("case_id", task.CaseID); err != nil {
+		return err
+	}
+	if !task.Configuration.valid() {
+		return fmt.Errorf("task %q has invalid configuration %q", task.ID, task.Configuration)
+	}
+	if task.Index == 0 || task.Index > taskTotal {
+		return fmt.Errorf("task %q index must be between 1 and %d", task.ID, taskTotal)
+	}
+	return validateString("title", task.Title)
+}
+
+func addStatus(counts *ResultCounts, status CaseStatus) {
+	switch status {
+	case CaseStatusPass:
+		counts.Passed++
+	case CaseStatusFail:
+		counts.Failed++
+	case CaseStatusError:
+		counts.Errored++
+	case CaseStatusSkip:
+		counts.Skipped++
+	}
+}
+
+func validatePassRate(passRate *float64) error {
+	if passRate == nil {
+		return nil
+	}
+	if math.IsNaN(*passRate) || math.IsInf(*passRate, 0) || *passRate < 0 || *passRate > 1 {
+		return errors.New("pass_rate must be finite and between 0 and 1")
+	}
+	return nil
+}
+
+func copyPassRate(passRate *float64) *float64 {
+	if passRate == nil {
+		return nil
+	}
+	value := *passRate
+	return &value
+}
+
+func elapsedMS(start, end time.Time) uint64 {
+	duration := end.Sub(start)
+	if duration <= 0 {
+		return 0
+	}
+	return uint64(duration / time.Millisecond)
+}
+
+func phaseRank(phase RunPhase) int {
+	switch phase {
+	case RunPhasePreparing:
+		return 1
+	case RunPhaseExecuting:
+		return 2
+	case RunPhaseFinalizing:
+		return 3
+	default:
+		return 0
+	}
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time { return time.Now() }
+func (systemClock) NewTicker(interval time.Duration) Ticker {
+	return systemTicker{ticker: time.NewTicker(interval)}
+}
+
+type systemTicker struct {
+	ticker *time.Ticker
+}
+
+func (t systemTicker) C() <-chan time.Time { return t.ticker.C }
+func (t systemTicker) Stop()               { t.ticker.Stop() }

--- a/internal/evalevent/lifecycle_test.go
+++ b/internal/evalevent/lifecycle_test.go
@@ -1,0 +1,399 @@
+package evalevent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+//nolint:gocyclo,cyclop,funlen // The test intentionally verifies the complete lifecycle sequence and payloads.
+func TestLifecyclePublishesTypedSequenceAndFakeClockHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	clock := newManualClock(time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC))
+	sink := newRecordingSink()
+	publisher, err := NewPublisher(PublisherConfig{Sink: sink, Now: clock.Now})
+	if err != nil {
+		t.Fatalf("NewPublisher() error = %v", err)
+	}
+	lifecycle, err := NewLifecycle(publisher, Plan{Iterations: []Iteration{{
+		Number: 3,
+		Tasks: []Task{{
+			ID: "opaque-1", Iteration: 3, CaseID: "目录/case%一", Configuration: ConfigurationWithSkill,
+			Index: 1, Title: "Case one",
+		}},
+	}}}, LifecycleOptions{Clock: clock, HeartbeatInterval: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("NewLifecycle() error = %v", err)
+	}
+	ctx := context.Background()
+	if err := lifecycle.Start(ctx, "qoder-cli", "test-skill"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := lifecycle.SetPhase(ctx, RunPhaseExecuting); err != nil {
+		t.Fatalf("SetPhase() error = %v", err)
+	}
+	if err := lifecycle.IterationStarted(ctx, 3); err != nil {
+		t.Fatalf("IterationStarted() error = %v", err)
+	}
+	if err := lifecycle.CaseStarted(ctx, "opaque-1"); err != nil {
+		t.Fatalf("CaseStarted() error = %v", err)
+	}
+
+	clock.Advance(30 * time.Second)
+	waitForEventCount(t, sink, 7)
+	clock.Advance(2500 * time.Millisecond)
+	passRate := 0.5
+	if err := lifecycle.CaseCompleted(ctx, "opaque-1", CaseStatusFail, &passRate); err != nil {
+		t.Fatalf("CaseCompleted() error = %v", err)
+	}
+	if err := lifecycle.IterationCompleted(ctx, 3); err != nil {
+		t.Fatalf("IterationCompleted() error = %v", err)
+	}
+	if err := lifecycle.Finish(ctx, RunStatusCompleted); err != nil {
+		t.Fatalf("Finish() error = %v", err)
+	}
+	if err := publisher.Close(); err != nil {
+		t.Fatalf("Publisher.Close() error = %v", err)
+	}
+
+	events := sink.snapshot()
+	wantTypes := []Type{
+		EventRunStarted,
+		EventRunProgress,
+		EventRunProgress,
+		EventIterationStarted,
+		EventCaseStarted,
+		EventRunProgress,
+		EventRunProgress,
+		EventCaseCompleted,
+		EventRunProgress,
+		EventIterationCompleted,
+		EventRunProgress,
+		EventRunFinished,
+	}
+	if len(events) != len(wantTypes) {
+		t.Fatalf("event count = %d, want %d", len(events), len(wantTypes))
+	}
+	for i, event := range events {
+		if event.Type != wantTypes[i] {
+			t.Errorf("event[%d].Type = %q, want %q", i, event.Type, wantTypes[i])
+		}
+		if event.SequenceNumber != uint64(i+1) {
+			t.Errorf("event[%d].SequenceNumber = %d, want %d", i, event.SequenceNumber, i+1)
+		}
+		if event.LastEvent != (i == len(events)-1) {
+			t.Errorf("event[%d].LastEvent = %t", i, event.LastEvent)
+		}
+	}
+
+	started := eventPayloadAs[RunStartedPayload](t, events[0])
+	if started.TaskTotal != 1 || started.IterationsTotal != 1 {
+		t.Errorf("run_started totals = %d tasks, %d iterations", started.TaskTotal, started.IterationsTotal)
+	}
+	heartbeat := eventPayloadAs[RunProgressPayload](t, events[6])
+	if heartbeat.Phase != RunPhaseExecuting || heartbeat.RunningTasks != 1 || heartbeat.ElapsedMS != 30000 {
+		t.Errorf("heartbeat payload = %+v", heartbeat)
+	}
+	completed := eventPayloadAs[CaseCompletedPayload](t, events[7])
+	if completed.CaseID != "目录/case%一" || completed.CompletedTasks != 1 || completed.Status != CaseStatusFail || completed.DurationMS != 32500 {
+		t.Errorf("case_completed payload = %+v", completed)
+	}
+	iteration := eventPayloadAs[IterationCompletedPayload](t, events[9])
+	if iteration.InvocationCompletedTasks != 1 || iteration.Failed != 1 || iteration.DurationMS != 32500 {
+		t.Errorf("iteration_completed payload = %+v", iteration)
+	}
+	finished := eventPayloadAs[RunFinishedPayload](t, events[11])
+	if finished.Status != RunStatusCompleted || finished.CompletedTasks != 1 || finished.Failed != 1 || finished.DurationMS != 32500 {
+		t.Errorf("run_finished payload = %+v", finished)
+	}
+
+	clock.Advance(30 * time.Second)
+	if got := len(sink.snapshot()); got != len(events) {
+		t.Errorf("heartbeat continued after Finish: event count = %d, want %d", got, len(events))
+	}
+}
+
+//nolint:gocyclo,cyclop // The test exercises each rejected transition before graceful error finalization.
+func TestLifecycleRejectsIllegalTransitionsAndAllowsPartialErrorFinish(t *testing.T) {
+	t.Parallel()
+
+	sink := newRecordingSink()
+	publisher, err := NewPublisher(PublisherConfig{Sink: sink})
+	if err != nil {
+		t.Fatalf("NewPublisher() error = %v", err)
+	}
+	lifecycle, err := NewLifecycle(publisher, singleTaskPlan(), LifecycleOptions{})
+	if err != nil {
+		t.Fatalf("NewLifecycle() error = %v", err)
+	}
+	ctx := context.Background()
+	if err := lifecycle.Start(ctx, "engine", "skill"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := lifecycle.SetPhase(ctx, RunPhaseExecuting); err != nil {
+		t.Fatalf("SetPhase() error = %v", err)
+	}
+	if err := lifecycle.IterationStarted(ctx, 1); err != nil {
+		t.Fatalf("IterationStarted() error = %v", err)
+	}
+	if err := lifecycle.CaseStarted(ctx, "unknown"); err == nil {
+		t.Fatal("unknown task start succeeded")
+	}
+	if err := lifecycle.CaseStarted(ctx, "task-1"); err != nil {
+		t.Fatalf("CaseStarted() error = %v", err)
+	}
+	eventCount := len(sink.snapshot())
+	if err := lifecycle.CaseStarted(ctx, "task-1"); err == nil {
+		t.Fatal("duplicate task start succeeded")
+	}
+	if err := lifecycle.IterationCompleted(ctx, 1); err == nil {
+		t.Fatal("unfinished iteration completion succeeded")
+	}
+	if len(sink.snapshot()) != eventCount {
+		t.Fatal("illegal transitions published events")
+	}
+	if err := lifecycle.Finish(ctx, RunStatusCompleted); err == nil {
+		t.Fatal("completed Finish() accepted an unfinished task")
+	}
+	if err := lifecycle.Finish(ctx, RunStatusError); err != nil {
+		t.Fatalf("partial error Finish() error = %v", err)
+	}
+	if err := lifecycle.CaseCompleted(ctx, "task-1", CaseStatusPass, nil); err == nil {
+		t.Fatal("case completion after Finish succeeded")
+	}
+
+	events := sink.snapshot()
+	finished := events[len(events)-1]
+	if !finished.LastEvent || finished.Type != EventRunFinished {
+		t.Fatalf("final event = %+v", finished)
+	}
+	payload := eventPayloadAs[RunFinishedPayload](t, finished)
+	if payload.Status != RunStatusError || payload.CompletedTasks != 0 {
+		t.Fatalf("partial run_finished payload = %+v", payload)
+	}
+}
+
+//nolint:gocyclo,cyclop // The test checks concurrent task events and every resulting progress snapshot.
+func TestLifecycleMaintainsProgressInvariantsUnderConcurrency(t *testing.T) {
+	t.Parallel()
+
+	const taskCount = 24
+	tasks := make([]Task, 0, taskCount)
+	for i := 1; i <= taskCount; i++ {
+		tasks = append(tasks, Task{
+			ID: fmt.Sprintf("task-%d", i), Iteration: 1, CaseID: fmt.Sprintf("case-%d", i),
+			Configuration: ConfigurationWithSkill, Index: uint64(i),
+		})
+	}
+	sink := newRecordingSink()
+	publisher, err := NewPublisher(PublisherConfig{Sink: sink})
+	if err != nil {
+		t.Fatalf("NewPublisher() error = %v", err)
+	}
+	lifecycle, err := NewLifecycle(publisher, Plan{Iterations: []Iteration{{Number: 1, Tasks: tasks}}}, LifecycleOptions{})
+	if err != nil {
+		t.Fatalf("NewLifecycle() error = %v", err)
+	}
+	ctx := context.Background()
+	if err := lifecycle.Start(ctx, "engine", "skill"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := lifecycle.SetPhase(ctx, RunPhaseExecuting); err != nil {
+		t.Fatalf("SetPhase() error = %v", err)
+	}
+	if err := lifecycle.IterationStarted(ctx, 1); err != nil {
+		t.Fatalf("IterationStarted() error = %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for _, task := range tasks {
+		wg.Go(func() {
+			if err := lifecycle.CaseStarted(ctx, task.ID); err != nil {
+				t.Errorf("CaseStarted(%s) error = %v", task.ID, err)
+			}
+		})
+	}
+	wg.Wait()
+	for i, task := range tasks {
+		status := CaseStatusPass
+		if i%2 == 1 {
+			status = CaseStatusSkip
+		}
+		wg.Go(func() {
+			if err := lifecycle.CaseCompleted(ctx, task.ID, status, nil); err != nil {
+				t.Errorf("CaseCompleted(%s) error = %v", task.ID, err)
+			}
+		})
+	}
+	wg.Wait()
+	if err := lifecycle.IterationCompleted(ctx, 1); err != nil {
+		t.Fatalf("IterationCompleted() error = %v", err)
+	}
+	if err := lifecycle.Finish(ctx, RunStatusCompleted); err != nil {
+		t.Fatalf("Finish() error = %v", err)
+	}
+
+	events := sink.snapshot()
+	for i, event := range events {
+		if event.SequenceNumber != uint64(i+1) {
+			t.Fatalf("event[%d].SequenceNumber = %d", i, event.SequenceNumber)
+		}
+		progress, ok := event.Payload.(RunProgressPayload)
+		if !ok {
+			continue
+		}
+		if progress.CompletedTasks != progress.total() {
+			t.Errorf("progress completed/count mismatch: %+v", progress)
+		}
+		if progress.CompletedTasks+progress.RunningTasks > progress.TaskTotal {
+			t.Errorf("progress exceeds total: %+v", progress)
+		}
+	}
+	finished := eventPayloadAs[RunFinishedPayload](t, events[len(events)-1])
+	if finished.CompletedTasks != taskCount || finished.Passed != taskCount/2 || finished.Skipped != taskCount/2 {
+		t.Errorf("run_finished counts = %+v", finished)
+	}
+}
+
+func TestLifecycleSnapshotsAndValidatesPlan(t *testing.T) {
+	t.Parallel()
+
+	sink := newRecordingSink()
+	publisher, err := NewPublisher(PublisherConfig{Sink: sink})
+	if err != nil {
+		t.Fatalf("NewPublisher() error = %v", err)
+	}
+	plan := singleTaskPlan()
+	lifecycle, err := NewLifecycle(publisher, plan, LifecycleOptions{})
+	if err != nil {
+		t.Fatalf("NewLifecycle() error = %v", err)
+	}
+	plan.Iterations[0].Tasks[0].CaseID = "mutated"
+	if err := lifecycle.Start(context.Background(), "engine", "skill"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := lifecycle.SetPhase(context.Background(), RunPhaseExecuting); err != nil {
+		t.Fatalf("SetPhase() error = %v", err)
+	}
+	if err := lifecycle.IterationStarted(context.Background(), 1); err != nil {
+		t.Fatalf("IterationStarted() error = %v", err)
+	}
+	if err := lifecycle.CaseStarted(context.Background(), "task-1"); err != nil {
+		t.Fatalf("CaseStarted() error = %v", err)
+	}
+	caseStarted := eventPayloadAs[CaseStartedPayload](t, sink.snapshot()[4])
+	if caseStarted.CaseID != "case/原始%1" {
+		t.Fatalf("snapshotted CaseID = %q", caseStarted.CaseID)
+	}
+
+	invalidPlans := []Plan{
+		{},
+		{Iterations: []Iteration{{Number: 1}}},
+		{Iterations: []Iteration{{Number: 1, Tasks: []Task{{ID: "task", Iteration: 2, CaseID: "case", Configuration: ConfigurationWithSkill, Index: 1}}}}},
+		{Iterations: []Iteration{{Number: 1, Tasks: []Task{{ID: "task", Iteration: 1, CaseID: "case", Configuration: ConfigurationWithSkill, Index: 2}}}}},
+	}
+	for i, invalid := range invalidPlans {
+		if _, err := NewLifecycle(publisher, invalid, LifecycleOptions{}); err == nil {
+			t.Errorf("invalid plan %d was accepted", i)
+		}
+	}
+}
+
+func singleTaskPlan() Plan {
+	return Plan{Iterations: []Iteration{{
+		Number: 1,
+		Tasks: []Task{{
+			ID: "task-1", Iteration: 1, CaseID: "case/原始%1", Configuration: ConfigurationWithSkill, Index: 1,
+		}},
+	}}}
+}
+
+func eventPayloadAs[T Payload](t *testing.T, event Event) T {
+	t.Helper()
+	payload, ok := event.Payload.(T)
+	if !ok {
+		var zero T
+		t.Fatalf("event %q payload type = %T, want %T", event.Type, event.Payload, zero)
+	}
+	return payload
+}
+
+func waitForEventCount(t *testing.T, sink *recordingSink, count int) {
+	t.Helper()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	for len(sink.snapshot()) < count {
+		select {
+		case <-sink.notify:
+		case <-deadline.C:
+			t.Fatalf("event count = %d, want at least %d", len(sink.snapshot()), count)
+		}
+	}
+}
+
+type manualClock struct {
+	mu      sync.Mutex
+	now     time.Time
+	tickers []*manualTicker
+}
+
+func newManualClock(now time.Time) *manualClock {
+	return &manualClock{now: now}
+}
+
+func (c *manualClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *manualClock) NewTicker(interval time.Duration) Ticker {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ticker := &manualTicker{interval: interval, ticks: make(chan time.Time, 16)}
+	c.tickers = append(c.tickers, ticker)
+	return ticker
+}
+
+func (c *manualClock) Advance(duration time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(duration)
+	now := c.now
+	tickers := append([]*manualTicker(nil), c.tickers...)
+	c.mu.Unlock()
+	for _, ticker := range tickers {
+		ticker.advance(duration, now)
+	}
+}
+
+type manualTicker struct {
+	mu       sync.Mutex
+	interval time.Duration
+	elapsed  time.Duration
+	stopped  bool
+	ticks    chan time.Time
+}
+
+func (t *manualTicker) C() <-chan time.Time { return t.ticks }
+
+func (t *manualTicker) Stop() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.stopped = true
+}
+
+func (t *manualTicker) advance(duration time.Duration, now time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.stopped {
+		return
+	}
+	t.elapsed += duration
+	for t.elapsed >= t.interval {
+		t.elapsed -= t.interval
+		t.ticks <- now
+	}
+}

--- a/internal/evalevent/publisher.go
+++ b/internal/evalevent/publisher.go
@@ -1,0 +1,233 @@
+package evalevent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+)
+
+const (
+	maxAttributesSize = 16 * 1024
+	maxAttributeCount = 32
+	maxAttributeKey   = 128
+	maxAttributeValue = 1024
+)
+
+var attributeKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)+$`)
+
+type attributeValidation struct {
+	rejectReserved bool
+}
+
+type publicationOptions struct {
+	lastEvent bool
+}
+
+// EventSink transports fully enveloped events in publication order.
+type EventSink interface {
+	Publish(ctx context.Context, event Event) error
+	Close() error
+}
+
+// PublisherConfig configures an invocation-scoped Publisher.
+type PublisherConfig struct {
+	Sink         EventSink
+	Attributes   map[string]string
+	InvocationID string
+	Now          func() time.Time
+}
+
+// Publisher assigns event identity and serializes concurrent publication.
+type Publisher struct {
+	mu sync.Mutex
+
+	sink         EventSink
+	attributes   map[string]string
+	invocationID string
+	now          func() time.Time
+	nextSequence uint64
+
+	finalized bool
+	closed    bool
+	err       error
+}
+
+// NewPublisher creates one invocation-scoped publisher and takes ownership of its Sink.
+func NewPublisher(cfg PublisherConfig) (*Publisher, error) {
+	if isNilInterface(cfg.Sink) {
+		return nil, errors.New("event sink must not be nil")
+	}
+	attributes, err := copyAndValidateAttributes(cfg.Attributes, attributeValidation{})
+	if err != nil {
+		return nil, err
+	}
+	invocationID := cfg.InvocationID
+	if invocationID == "" {
+		invocationID = uuid.NewString()
+	} else if _, err := uuid.Parse(invocationID); err != nil {
+		return nil, fmt.Errorf("invalid invocation ID: %w", err)
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Publisher{
+		sink:         cfg.Sink,
+		attributes:   attributes,
+		invocationID: invocationID,
+		now:          now,
+		nextSequence: 1,
+	}, nil
+}
+
+// ValidateUserAttributes validates invocation attributes accepted from a CLI caller.
+func ValidateUserAttributes(attributes map[string]string) error {
+	_, err := copyAndValidateAttributes(attributes, attributeValidation{rejectReserved: true})
+	return err
+}
+
+// InvocationID returns the stable UUID assigned to this invocation.
+func (p *Publisher) InvocationID() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.invocationID
+}
+
+// Publish validates and writes one non-final event.
+func (p *Publisher) Publish(ctx context.Context, payload Payload) error {
+	return p.publishEvent(ctx, payload, publicationOptions{})
+}
+
+// PublishLast writes the only event carrying last_event=true and closes publication.
+func (p *Publisher) PublishLast(ctx context.Context, payload Payload) error {
+	return p.publishEvent(ctx, payload, publicationOptions{lastEvent: true})
+}
+
+func (p *Publisher) publishEvent(ctx context.Context, payload Payload, opts publicationOptions) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return errors.New("publisher is closed")
+	}
+	if p.finalized {
+		return errors.New("publisher already published its last event")
+	}
+	if p.err != nil {
+		return p.err
+	}
+	if isNilInterface(payload) {
+		return errors.New("event payload must not be nil")
+	}
+	payload = payload.snapshot()
+	if err := payload.validate(); err != nil {
+		return fmt.Errorf("invalid %s payload: %w", payload.eventType(), err)
+	}
+	if p.nextSequence > MaxSafeInteger {
+		return fmt.Errorf("sequence number exceeds %d", MaxSafeInteger)
+	}
+
+	event := Event{
+		ProtocolVersion: ProtocolVersion,
+		EventVersion:    payload.eventVersion(),
+		SequenceNumber:  p.nextSequence,
+		InvocationID:    p.invocationID,
+		Time:            p.now().UTC(),
+		Type:            payload.eventType(),
+		LastEvent:       opts.lastEvent,
+		Attributes:      copyAttributes(p.attributes),
+		Payload:         payload,
+	}
+	if err := p.sink.Publish(ctx, event); err != nil {
+		p.err = fmt.Errorf("publish %s event: %w", event.Type, err)
+		return p.err
+	}
+	p.nextSequence++
+	if opts.lastEvent {
+		p.finalized = true
+	}
+	return nil
+}
+
+// Err returns the sticky publication or close error without clearing it.
+func (p *Publisher) Err() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.err
+}
+
+// Close idempotently closes the owned Sink and returns all recorded errors.
+func (p *Publisher) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return p.err
+	}
+	p.closed = true
+	if err := p.sink.Close(); err != nil {
+		p.err = errors.Join(p.err, fmt.Errorf("close event sink: %w", err))
+	}
+	return p.err
+}
+
+func copyAndValidateAttributes(attributes map[string]string, validation attributeValidation) (map[string]string, error) {
+	if len(attributes) > maxAttributeCount {
+		return nil, fmt.Errorf("attributes exceed the limit of %d", maxAttributeCount)
+	}
+	cloned := make(map[string]string, len(attributes))
+	for key, value := range attributes {
+		if !utf8.ValidString(key) || len(key) > maxAttributeKey || !attributeKeyPattern.MatchString(key) {
+			return nil, fmt.Errorf("invalid attribute key %q", key)
+		}
+		if validation.rejectReserved && strings.HasPrefix(key, "skill-up.") {
+			return nil, fmt.Errorf("attribute key %q uses the reserved skill-up namespace", key)
+		}
+		if value == "" {
+			return nil, fmt.Errorf("attribute %q has an empty value", key)
+		}
+		if !utf8.ValidString(value) || len(value) > maxAttributeValue {
+			return nil, fmt.Errorf("attribute %q value must be valid UTF-8 and at most %d bytes", key, maxAttributeValue)
+		}
+		cloned[key] = value
+	}
+	encoded, err := json.Marshal(cloned)
+	if err != nil {
+		return nil, fmt.Errorf("encode attributes: %w", err)
+	}
+	if len(encoded) > maxAttributesSize {
+		return nil, fmt.Errorf("serialized attributes exceed %d bytes", maxAttributesSize)
+	}
+	return cloned, nil
+}
+
+func copyAttributes(attributes map[string]string) map[string]string {
+	if len(attributes) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(attributes))
+	maps.Copy(cloned, attributes)
+	return cloned
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}

--- a/internal/evalevent/publisher.go
+++ b/internal/evalevent/publisher.go
@@ -74,8 +74,12 @@ func NewPublisher(cfg PublisherConfig) (*Publisher, error) {
 	invocationID := cfg.InvocationID
 	if invocationID == "" {
 		invocationID = uuid.NewString()
-	} else if _, err := uuid.Parse(invocationID); err != nil {
-		return nil, fmt.Errorf("invalid invocation ID: %w", err)
+	} else {
+		parsedID, err := uuid.Parse(invocationID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid invocation ID: %w", err)
+		}
+		invocationID = parsedID.String()
 	}
 	now := cfg.Now
 	if now == nil {

--- a/internal/evalevent/publisher_test.go
+++ b/internal/evalevent/publisher_test.go
@@ -1,0 +1,201 @@
+package evalevent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPublisherSerializesConcurrentEventsAndPublishesOneLastMarker(t *testing.T) {
+	t.Parallel()
+
+	sink := newRecordingSink()
+	fixedTime := time.Date(2026, 8, 19, 10, 0, 0, 0, time.FixedZone("test", 8*60*60))
+	attributes := map[string]string{"com.example.build_id": "build-1"}
+	publisher, err := NewPublisher(PublisherConfig{
+		Sink:         sink,
+		Attributes:   attributes,
+		InvocationID: "018f8f20-7a7d-7d90-a192-4f5ec8f07a2a",
+		Now:          func() time.Time { return fixedTime },
+	})
+	if err != nil {
+		t.Fatalf("NewPublisher() error = %v", err)
+	}
+	attributes["com.example.build_id"] = "mutated"
+
+	const eventCount = 40
+	var wg sync.WaitGroup
+	for range eventCount {
+		wg.Go(func() {
+			if err := publisher.Publish(context.Background(), validProgressPayload()); err != nil {
+				t.Errorf("Publish() error = %v", err)
+			}
+		})
+	}
+	wg.Wait()
+	if err := publisher.PublishLast(context.Background(), RunFinishedPayload{Status: RunStatusCompleted}); err != nil {
+		t.Fatalf("PublishLast() error = %v", err)
+	}
+	if err := publisher.Publish(context.Background(), validProgressPayload()); err == nil {
+		t.Fatal("Publish() after last event succeeded")
+	}
+	if err := publisher.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	events := sink.snapshot()
+	if len(events) != eventCount+1 {
+		t.Fatalf("event count = %d, want %d", len(events), eventCount+1)
+	}
+	for i, event := range events {
+		if event.SequenceNumber != uint64(i+1) {
+			t.Errorf("event[%d].SequenceNumber = %d, want %d", i, event.SequenceNumber, i+1)
+		}
+		if event.InvocationID != publisher.InvocationID() {
+			t.Errorf("event[%d].InvocationID = %q", i, event.InvocationID)
+		}
+		if event.Time.Location() != time.UTC {
+			t.Errorf("event[%d].Time location = %v, want UTC", i, event.Time.Location())
+		}
+		if event.Attributes["com.example.build_id"] != "build-1" {
+			t.Errorf("event[%d] attributes mutated: %v", i, event.Attributes)
+		}
+		if event.LastEvent != (i == len(events)-1) {
+			t.Errorf("event[%d].LastEvent = %t", i, event.LastEvent)
+		}
+	}
+	if sink.closes() != 1 {
+		t.Errorf("sink close count = %d, want 1", sink.closes())
+	}
+}
+
+func TestPublisherSnapshotsPointerPayload(t *testing.T) {
+	t.Parallel()
+
+	sink := newRecordingSink()
+	publisher, err := NewPublisher(PublisherConfig{Sink: sink})
+	if err != nil {
+		t.Fatalf("NewPublisher() error = %v", err)
+	}
+	rate := 0.25
+	payload := &CaseCompletedPayload{
+		TaskFields: TaskFields{
+			TaskID: "task-1", Iteration: 1, CaseID: "case-1", Configuration: ConfigurationWithSkill,
+			TaskIndex: 1, TaskTotal: 1,
+		},
+		CompletedTasks: 1,
+		Status:         CaseStatusFail,
+		PassRate:       &rate,
+	}
+	if err := publisher.Publish(context.Background(), payload); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	rate = 1
+	payload.Status = CaseStatusPass
+
+	stored, ok := sink.snapshot()[0].Payload.(CaseCompletedPayload)
+	if !ok {
+		t.Fatalf("stored payload type = %T", sink.snapshot()[0].Payload)
+	}
+	if stored.Status != CaseStatusFail || stored.PassRate == nil || *stored.PassRate != 0.25 {
+		t.Fatalf("stored payload was mutated: %+v", stored)
+	}
+}
+
+func TestPublisherStickyFailureAndIdempotentClose(t *testing.T) {
+	t.Parallel()
+
+	publishFailure := errors.New("disk full")
+	closeFailure := errors.New("close failed")
+	sink := newRecordingSink()
+	sink.failAt = 2
+	sink.publishErr = publishFailure
+	sink.closeErr = closeFailure
+	publisher, err := NewPublisher(PublisherConfig{Sink: sink})
+	if err != nil {
+		t.Fatalf("NewPublisher() error = %v", err)
+	}
+	if err := publisher.Publish(context.Background(), validProgressPayload()); err != nil {
+		t.Fatalf("first Publish() error = %v", err)
+	}
+	secondErr := publisher.Publish(context.Background(), validProgressPayload())
+	if !errors.Is(secondErr, publishFailure) {
+		t.Fatalf("second Publish() error = %v, want disk failure", secondErr)
+	}
+	thirdErr := publisher.Publish(context.Background(), validProgressPayload())
+	if !errors.Is(thirdErr, publishFailure) || thirdErr.Error() != secondErr.Error() {
+		t.Fatalf("sticky Publish() error changed: %v vs %v", thirdErr, secondErr)
+	}
+	if len(sink.snapshot()) != 1 {
+		t.Fatalf("sink received %d events after sticky failure, want 1", len(sink.snapshot()))
+	}
+	closeErr := publisher.Close()
+	if !errors.Is(closeErr, publishFailure) || !errors.Is(closeErr, closeFailure) {
+		t.Fatalf("Close() error = %v, want joined publish and close failures", closeErr)
+	}
+	if repeated := publisher.Close(); !errors.Is(repeated, publishFailure) || !errors.Is(repeated, closeFailure) {
+		t.Fatalf("repeated Close() error = %v", repeated)
+	}
+	if publisher.Err().Error() != closeErr.Error() {
+		t.Fatalf("Err() = %v, want Close() result %v", publisher.Err(), closeErr)
+	}
+	if sink.closes() != 1 {
+		t.Fatalf("sink close count = %d, want 1", sink.closes())
+	}
+}
+
+func TestPublisherRejectsInvalidPayloadWithoutConsumingSequence(t *testing.T) {
+	t.Parallel()
+
+	sink := newRecordingSink()
+	publisher, err := NewPublisher(PublisherConfig{Sink: sink})
+	if err != nil {
+		t.Fatalf("NewPublisher() error = %v", err)
+	}
+	if err := publisher.Publish(context.Background(), RunStartedPayload{}); err == nil {
+		t.Fatal("invalid payload was accepted")
+	}
+	var nilPayload *RunStartedPayload
+	if err := publisher.Publish(context.Background(), nilPayload); err == nil {
+		t.Fatal("typed nil payload was accepted")
+	}
+	if err := publisher.Publish(context.Background(), validProgressPayload()); err != nil {
+		t.Fatalf("valid Publish() error = %v", err)
+	}
+	if got := sink.snapshot()[0].SequenceNumber; got != 1 {
+		t.Fatalf("first valid sequence = %d, want 1", got)
+	}
+}
+
+func TestValidateUserAttributes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		attributes map[string]string
+		wantErr    bool
+	}{
+		{name: "valid", attributes: map[string]string{"com.alibaba.aone.eval_task_id": "123"}},
+		{name: "not namespaced", attributes: map[string]string{"build_id": "123"}, wantErr: true},
+		{name: "reserved", attributes: map[string]string{"skill-up.trace_id": "123"}, wantErr: true},
+		{name: "empty value", attributes: map[string]string{"com.example.key": ""}, wantErr: true},
+		{name: "oversized value", attributes: map[string]string{"com.example.key": fmt.Sprintf("%01025d", 1)}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateUserAttributes(tt.attributes)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateUserAttributes() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func validProgressPayload() RunProgressPayload {
+	return RunProgressPayload{Phase: RunPhaseExecuting, TaskTotal: 1}
+}

--- a/internal/evalevent/publisher_test.go
+++ b/internal/evalevent/publisher_test.go
@@ -105,6 +105,21 @@ func TestPublisherSnapshotsPointerPayload(t *testing.T) {
 	}
 }
 
+func TestPublisherCanonicalizesConfiguredInvocationID(t *testing.T) {
+	t.Parallel()
+
+	publisher, err := NewPublisher(PublisherConfig{
+		Sink:         newRecordingSink(),
+		InvocationID: "018f8f207a7d7d90a1924f5ec8f07a2a",
+	})
+	if err != nil {
+		t.Fatalf("NewPublisher() error = %v", err)
+	}
+	if got, want := publisher.InvocationID(), "018f8f20-7a7d-7d90-a192-4f5ec8f07a2a"; got != want {
+		t.Fatalf("InvocationID() = %q, want %q", got, want)
+	}
+}
+
 func TestPublisherStickyFailureAndIdempotentClose(t *testing.T) {
 	t.Parallel()
 

--- a/internal/evalevent/schema_test.go
+++ b/internal/evalevent/schema_test.go
@@ -2,12 +2,15 @@ package evalevent
 
 import (
 	"encoding/json"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"testing"
 )
+
+const schemaBaseURL = "https://raw.githubusercontent.com/alibaba/skill-up/main/schemas/evalevent/v1/"
 
 func TestV1SchemasMatchCoreEventRegistry(t *testing.T) {
 	t.Parallel()
@@ -31,12 +34,17 @@ func TestV1SchemasMatchCoreEventRegistry(t *testing.T) {
 		t.Fatalf("schema file count = %d, want %d", len(entries), len(wantRequired)+1)
 	}
 	for eventType, required := range wantRequired {
-		path := filepath.Join(dir, string(eventType)+"-v1.schema.json")
+		filename := string(eventType) + "-v1.schema.json"
+		path := filepath.Join(dir, filename)
 		doc := readSchema(t, path)
+		if got, want := schemaStringField(t, doc, "$id"), schemaBaseURL+filename; got != want {
+			t.Errorf("%s $id = %q, want %q", path, got, want)
+		}
 		allOf := schemaArray(t, doc, "allOf")
 		if len(allOf) != 2 {
 			t.Fatalf("%s allOf count = %d, want 2", path, len(allOf))
 		}
+		assertEnvelopeReference(t, path, doc, schemaObject(t, allOf[0]))
 		eventSchema := schemaObject(t, allOf[1])
 		properties := schemaObjectField(t, eventSchema, "properties")
 		if got := schemaObjectField(t, properties, "protocol_version")["const"]; got != float64(ProtocolVersion) {
@@ -66,6 +74,9 @@ func TestV1EnvelopeSchemaIsOpenAndRequiresFinalMarkerToBeTrue(t *testing.T) {
 	t.Parallel()
 
 	doc := readSchema(t, filepath.Join(schemaDirectory(t), "envelope.schema.json"))
+	if got, want := schemaStringField(t, doc, "$id"), schemaBaseURL+"envelope.schema.json"; got != want {
+		t.Errorf("envelope $id = %q, want %q", got, want)
+	}
 	if !schemaBoolField(t, doc, "additionalProperties") {
 		t.Fatal("envelope schema must allow unknown optional fields")
 	}
@@ -81,6 +92,21 @@ func TestV1EnvelopeSchemaIsOpenAndRequiresFinalMarkerToBeTrue(t *testing.T) {
 	}
 	if got := schemaObjectField(t, properties, "payload")["type"]; got != "object" {
 		t.Errorf("payload type = %v, want object", got)
+	}
+}
+
+func assertEnvelopeReference(t *testing.T, path string, doc, reference map[string]any) {
+	t.Helper()
+	base, err := url.Parse(schemaStringField(t, doc, "$id"))
+	if err != nil {
+		t.Fatalf("parse %s $id: %v", path, err)
+	}
+	resolved, err := base.Parse(schemaStringField(t, reference, "$ref"))
+	if err != nil {
+		t.Fatalf("resolve %s envelope reference: %v", path, err)
+	}
+	if got, want := resolved.String(), schemaBaseURL+"envelope.schema.json"; got != want {
+		t.Errorf("%s envelope reference resolves to %q, want %q", path, got, want)
 	}
 }
 
@@ -148,6 +174,15 @@ func schemaBoolField(t *testing.T, object map[string]any, field string) bool {
 	value, ok := object[field].(bool)
 	if !ok {
 		t.Fatalf("schema field %q has type %T, want boolean", field, object[field])
+	}
+	return value
+}
+
+func schemaStringField(t *testing.T, object map[string]any, field string) string {
+	t.Helper()
+	value, ok := object[field].(string)
+	if !ok {
+		t.Fatalf("schema field %q has type %T, want string", field, object[field])
 	}
 	return value
 }

--- a/internal/evalevent/schema_test.go
+++ b/internal/evalevent/schema_test.go
@@ -1,0 +1,165 @@
+package evalevent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+)
+
+func TestV1SchemasMatchCoreEventRegistry(t *testing.T) {
+	t.Parallel()
+
+	dir := schemaDirectory(t)
+	wantRequired := map[Type][]string{
+		EventRunStarted:         {"engine", "skill_name", "task_total", "iterations_total"},
+		EventRunProgress:        {"phase", "task_total", "completed_tasks", "running_tasks", "passed", "failed", "errored", "skipped", "elapsed_ms"},
+		EventIterationStarted:   {"iteration"},
+		EventCaseStarted:        {"task_id", "iteration", "case_id", "configuration", "task_index", "task_total", "title"},
+		EventCaseCompleted:      {"task_id", "iteration", "case_id", "configuration", "task_index", "task_total", "title", "completed_tasks", "status", "duration_ms"},
+		EventIterationCompleted: {"iteration", "invocation_completed_tasks", "passed", "failed", "errored", "skipped", "duration_ms"},
+		EventRunFinished:        {"status", "completed_tasks", "passed", "failed", "errored", "skipped", "duration_ms"},
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s) error = %v", dir, err)
+	}
+	if len(entries) != len(wantRequired)+1 {
+		t.Fatalf("schema file count = %d, want %d", len(entries), len(wantRequired)+1)
+	}
+	for eventType, required := range wantRequired {
+		path := filepath.Join(dir, string(eventType)+"-v1.schema.json")
+		doc := readSchema(t, path)
+		allOf := schemaArray(t, doc, "allOf")
+		if len(allOf) != 2 {
+			t.Fatalf("%s allOf count = %d, want 2", path, len(allOf))
+		}
+		eventSchema := schemaObject(t, allOf[1])
+		properties := schemaObjectField(t, eventSchema, "properties")
+		if got := schemaObjectField(t, properties, "protocol_version")["const"]; got != float64(ProtocolVersion) {
+			t.Errorf("%s protocol_version const = %v", path, got)
+		}
+		if got := schemaObjectField(t, properties, "event_version")["const"]; got != float64(EventVersionV1) {
+			t.Errorf("%s event_version const = %v", path, got)
+		}
+		if got := schemaObjectField(t, properties, "event")["const"]; got != string(eventType) {
+			t.Errorf("%s event const = %v, want %q", path, got, eventType)
+		}
+		payload := schemaObjectField(t, properties, "payload")
+		if !schemaBoolField(t, payload, "additionalProperties") {
+			t.Errorf("%s payload must allow additive fields", path)
+		}
+		gotRequired := schemaStrings(t, payload, "required")
+		sort.Strings(gotRequired)
+		want := append([]string(nil), required...)
+		sort.Strings(want)
+		if !equalStringLists(gotRequired, want) {
+			t.Errorf("%s payload required = %v, want %v", path, gotRequired, want)
+		}
+	}
+}
+
+func TestV1EnvelopeSchemaIsOpenAndRequiresFinalMarkerToBeTrue(t *testing.T) {
+	t.Parallel()
+
+	doc := readSchema(t, filepath.Join(schemaDirectory(t), "envelope.schema.json"))
+	if !schemaBoolField(t, doc, "additionalProperties") {
+		t.Fatal("envelope schema must allow unknown optional fields")
+	}
+	if _, exists := doc["oneOf"]; exists {
+		t.Fatal("envelope schema must not use a closed top-level oneOf")
+	}
+	properties := schemaObjectField(t, doc, "properties")
+	if got := schemaObjectField(t, properties, "protocol_version")["const"]; got != float64(ProtocolVersion) {
+		t.Errorf("protocol_version const = %v", got)
+	}
+	if !schemaBoolField(t, schemaObjectField(t, properties, "last_event"), "const") {
+		t.Error("last_event const must be true")
+	}
+	if got := schemaObjectField(t, properties, "payload")["type"]; got != "object" {
+		t.Errorf("payload type = %v, want object", got)
+	}
+}
+
+func schemaDirectory(t *testing.T) string {
+	t.Helper()
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(sourceFile), "..", "..", "schemas", "evalevent", "v1"))
+}
+
+func readSchema(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("Unmarshal(%s) error = %v", path, err)
+	}
+	return doc
+}
+
+func schemaArray(t *testing.T, object map[string]any, field string) []any {
+	t.Helper()
+	value, ok := object[field].([]any)
+	if !ok {
+		t.Fatalf("schema field %q has type %T, want array", field, object[field])
+	}
+	return value
+}
+
+func schemaObject(t *testing.T, value any) map[string]any {
+	t.Helper()
+	object, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("schema value has type %T, want object", value)
+	}
+	return object
+}
+
+func schemaObjectField(t *testing.T, object map[string]any, field string) map[string]any {
+	t.Helper()
+	return schemaObject(t, object[field])
+}
+
+func schemaStrings(t *testing.T, object map[string]any, field string) []string {
+	t.Helper()
+	values := schemaArray(t, object, field)
+	result := make([]string, len(values))
+	for i, value := range values {
+		text, ok := value.(string)
+		if !ok {
+			t.Fatalf("schema field %q item %d has type %T, want string", field, i, value)
+		}
+		result[i] = text
+	}
+	return result
+}
+
+func schemaBoolField(t *testing.T, object map[string]any, field string) bool {
+	t.Helper()
+	value, ok := object[field].(bool)
+	if !ok {
+		t.Fatalf("schema field %q has type %T, want boolean", field, object[field])
+	}
+	return value
+}
+
+func equalStringLists(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/evalevent/test_helpers_test.go
+++ b/internal/evalevent/test_helpers_test.go
@@ -1,0 +1,54 @@
+package evalevent
+
+import (
+	"context"
+	"sync"
+)
+
+type recordingSink struct {
+	mu sync.Mutex
+
+	events     []Event
+	failAt     int
+	publishErr error
+	closeErr   error
+	closeCount int
+	notify     chan struct{}
+}
+
+func newRecordingSink() *recordingSink {
+	return &recordingSink{notify: make(chan struct{}, 256)}
+}
+
+func (s *recordingSink) Publish(_ context.Context, event Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failAt > 0 && len(s.events)+1 == s.failAt {
+		return s.publishErr
+	}
+	s.events = append(s.events, event)
+	select {
+	case s.notify <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (s *recordingSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeCount++
+	return s.closeErr
+}
+
+func (s *recordingSink) snapshot() []Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Event(nil), s.events...)
+}
+
+func (s *recordingSink) closes() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closeCount
+}

--- a/schemas/evalevent/v1/case_completed-v1.schema.json
+++ b/schemas/evalevent/v1/case_completed-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/case_completed-v1.schema.json",
+  "$id": "https://raw.githubusercontent.com/alibaba/skill-up/main/schemas/evalevent/v1/case_completed-v1.schema.json",
   "title": "case_completed event v1",
   "allOf": [
     { "$ref": "envelope.schema.json" },

--- a/schemas/evalevent/v1/case_completed-v1.schema.json
+++ b/schemas/evalevent/v1/case_completed-v1.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/case_completed-v1.schema.json",
+  "title": "case_completed event v1",
+  "allOf": [
+    { "$ref": "envelope.schema.json" },
+    {
+      "type": "object",
+      "properties": {
+        "protocol_version": { "const": 1 },
+        "event_version": { "const": 1 },
+        "event": { "const": "case_completed" },
+        "payload": {
+          "type": "object",
+          "required": [
+            "task_id", "iteration", "case_id", "configuration",
+            "task_index", "task_total", "title", "completed_tasks",
+            "status", "duration_ms"
+          ],
+          "properties": {
+            "task_id": { "type": "string", "minLength": 1 },
+            "iteration": { "$ref": "envelope.schema.json#/$defs/positiveInteger" },
+            "case_id": { "type": "string", "minLength": 1 },
+            "configuration": { "$ref": "envelope.schema.json#/$defs/configuration" },
+            "task_index": { "$ref": "envelope.schema.json#/$defs/positiveInteger" },
+            "task_total": { "$ref": "envelope.schema.json#/$defs/positiveInteger" },
+            "title": { "type": "string" },
+            "completed_tasks": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "status": { "$ref": "envelope.schema.json#/$defs/caseStatus" },
+            "pass_rate": { "type": "number", "minimum": 0, "maximum": 1 },
+            "duration_ms": { "$ref": "envelope.schema.json#/$defs/safeInteger" }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  ]
+}

--- a/schemas/evalevent/v1/case_started-v1.schema.json
+++ b/schemas/evalevent/v1/case_started-v1.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/case_started-v1.schema.json",
+  "title": "case_started event v1",
+  "allOf": [
+    { "$ref": "envelope.schema.json" },
+    {
+      "type": "object",
+      "properties": {
+        "protocol_version": { "const": 1 },
+        "event_version": { "const": 1 },
+        "event": { "const": "case_started" },
+        "payload": {
+          "type": "object",
+          "required": [
+            "task_id", "iteration", "case_id", "configuration",
+            "task_index", "task_total", "title"
+          ],
+          "properties": {
+            "task_id": { "type": "string", "minLength": 1 },
+            "iteration": { "$ref": "envelope.schema.json#/$defs/positiveInteger" },
+            "case_id": { "type": "string", "minLength": 1 },
+            "configuration": { "$ref": "envelope.schema.json#/$defs/configuration" },
+            "task_index": { "$ref": "envelope.schema.json#/$defs/positiveInteger" },
+            "task_total": { "$ref": "envelope.schema.json#/$defs/positiveInteger" },
+            "title": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  ]
+}

--- a/schemas/evalevent/v1/case_started-v1.schema.json
+++ b/schemas/evalevent/v1/case_started-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/case_started-v1.schema.json",
+  "$id": "https://raw.githubusercontent.com/alibaba/skill-up/main/schemas/evalevent/v1/case_started-v1.schema.json",
   "title": "case_started event v1",
   "allOf": [
     { "$ref": "envelope.schema.json" },

--- a/schemas/evalevent/v1/envelope.schema.json
+++ b/schemas/evalevent/v1/envelope.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/envelope.schema.json",
+  "$id": "https://raw.githubusercontent.com/alibaba/skill-up/main/schemas/evalevent/v1/envelope.schema.json",
   "title": "skill-up evaluation event envelope v1",
   "type": "object",
   "required": [

--- a/schemas/evalevent/v1/envelope.schema.json
+++ b/schemas/evalevent/v1/envelope.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/envelope.schema.json",
+  "title": "skill-up evaluation event envelope v1",
+  "type": "object",
+  "required": [
+    "protocol_version",
+    "event_version",
+    "sequence_number",
+    "invocation_id",
+    "time",
+    "event",
+    "payload"
+  ],
+  "properties": {
+    "protocol_version": { "const": 1 },
+    "event_version": { "$ref": "#/$defs/positiveInteger" },
+    "sequence_number": { "$ref": "#/$defs/positiveInteger" },
+    "invocation_id": { "type": "string", "format": "uuid" },
+    "time": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "Z$"
+    },
+    "event": { "type": "string", "minLength": 1 },
+    "last_event": { "const": true },
+    "attributes": {
+      "type": "object",
+      "maxProperties": 32,
+      "propertyNames": {
+        "maxLength": 128,
+        "pattern": "^[a-z][a-z0-9_-]*(\\.[a-z][a-z0-9_-]*)+$"
+      },
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 1024
+      }
+    },
+    "payload": { "type": "object" }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "safeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "positiveInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "configuration": {
+      "enum": ["with_skill", "without_skill"]
+    },
+    "caseStatus": {
+      "enum": ["PASS", "FAIL", "ERROR", "SKIP"]
+    },
+    "runStatus": {
+      "enum": ["COMPLETED", "ERROR", "CANCELLED"]
+    }
+  }
+}

--- a/schemas/evalevent/v1/iteration_completed-v1.schema.json
+++ b/schemas/evalevent/v1/iteration_completed-v1.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/iteration_completed-v1.schema.json",
+  "title": "iteration_completed event v1",
+  "allOf": [
+    { "$ref": "envelope.schema.json" },
+    {
+      "type": "object",
+      "properties": {
+        "protocol_version": { "const": 1 },
+        "event_version": { "const": 1 },
+        "event": { "const": "iteration_completed" },
+        "payload": {
+          "type": "object",
+          "required": [
+            "iteration", "invocation_completed_tasks", "passed", "failed",
+            "errored", "skipped", "duration_ms"
+          ],
+          "properties": {
+            "iteration": { "$ref": "envelope.schema.json#/$defs/positiveInteger" },
+            "invocation_completed_tasks": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "passed": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "failed": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "errored": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "skipped": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "duration_ms": { "$ref": "envelope.schema.json#/$defs/safeInteger" }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  ]
+}

--- a/schemas/evalevent/v1/iteration_completed-v1.schema.json
+++ b/schemas/evalevent/v1/iteration_completed-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/iteration_completed-v1.schema.json",
+  "$id": "https://raw.githubusercontent.com/alibaba/skill-up/main/schemas/evalevent/v1/iteration_completed-v1.schema.json",
   "title": "iteration_completed event v1",
   "allOf": [
     { "$ref": "envelope.schema.json" },

--- a/schemas/evalevent/v1/iteration_started-v1.schema.json
+++ b/schemas/evalevent/v1/iteration_started-v1.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/iteration_started-v1.schema.json",
+  "title": "iteration_started event v1",
+  "allOf": [
+    { "$ref": "envelope.schema.json" },
+    {
+      "type": "object",
+      "properties": {
+        "protocol_version": { "const": 1 },
+        "event_version": { "const": 1 },
+        "event": { "const": "iteration_started" },
+        "payload": {
+          "type": "object",
+          "required": ["iteration"],
+          "properties": {
+            "iteration": { "$ref": "envelope.schema.json#/$defs/positiveInteger" }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  ]
+}

--- a/schemas/evalevent/v1/iteration_started-v1.schema.json
+++ b/schemas/evalevent/v1/iteration_started-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/iteration_started-v1.schema.json",
+  "$id": "https://raw.githubusercontent.com/alibaba/skill-up/main/schemas/evalevent/v1/iteration_started-v1.schema.json",
   "title": "iteration_started event v1",
   "allOf": [
     { "$ref": "envelope.schema.json" },

--- a/schemas/evalevent/v1/run_finished-v1.schema.json
+++ b/schemas/evalevent/v1/run_finished-v1.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/run_finished-v1.schema.json",
+  "title": "run_finished event v1",
+  "allOf": [
+    { "$ref": "envelope.schema.json" },
+    {
+      "type": "object",
+      "properties": {
+        "protocol_version": { "const": 1 },
+        "event_version": { "const": 1 },
+        "event": { "const": "run_finished" },
+        "payload": {
+          "type": "object",
+          "required": [
+            "status", "completed_tasks", "passed", "failed",
+            "errored", "skipped", "duration_ms"
+          ],
+          "properties": {
+            "status": { "$ref": "envelope.schema.json#/$defs/runStatus" },
+            "completed_tasks": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "passed": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "failed": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "errored": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "skipped": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "duration_ms": { "$ref": "envelope.schema.json#/$defs/safeInteger" }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  ]
+}

--- a/schemas/evalevent/v1/run_finished-v1.schema.json
+++ b/schemas/evalevent/v1/run_finished-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/run_finished-v1.schema.json",
+  "$id": "https://raw.githubusercontent.com/alibaba/skill-up/main/schemas/evalevent/v1/run_finished-v1.schema.json",
   "title": "run_finished event v1",
   "allOf": [
     { "$ref": "envelope.schema.json" },

--- a/schemas/evalevent/v1/run_progress-v1.schema.json
+++ b/schemas/evalevent/v1/run_progress-v1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/run_progress-v1.schema.json",
+  "title": "run_progress event v1",
+  "allOf": [
+    { "$ref": "envelope.schema.json" },
+    {
+      "type": "object",
+      "properties": {
+        "protocol_version": { "const": 1 },
+        "event_version": { "const": 1 },
+        "event": { "const": "run_progress" },
+        "payload": {
+          "type": "object",
+          "required": [
+            "phase", "task_total", "completed_tasks", "running_tasks",
+            "passed", "failed", "errored", "skipped", "elapsed_ms"
+          ],
+          "properties": {
+            "phase": {
+              "type": "string",
+              "minLength": 1,
+              "examples": ["preparing", "executing", "finalizing"]
+            },
+            "task_total": { "$ref": "envelope.schema.json#/$defs/positiveInteger" },
+            "completed_tasks": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "running_tasks": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "passed": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "failed": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "errored": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "skipped": { "$ref": "envelope.schema.json#/$defs/safeInteger" },
+            "elapsed_ms": { "$ref": "envelope.schema.json#/$defs/safeInteger" }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  ]
+}

--- a/schemas/evalevent/v1/run_progress-v1.schema.json
+++ b/schemas/evalevent/v1/run_progress-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/run_progress-v1.schema.json",
+  "$id": "https://raw.githubusercontent.com/alibaba/skill-up/main/schemas/evalevent/v1/run_progress-v1.schema.json",
   "title": "run_progress event v1",
   "allOf": [
     { "$ref": "envelope.schema.json" },

--- a/schemas/evalevent/v1/run_started-v1.schema.json
+++ b/schemas/evalevent/v1/run_started-v1.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/run_started-v1.schema.json",
+  "title": "run_started event v1",
+  "allOf": [
+    { "$ref": "envelope.schema.json" },
+    {
+      "type": "object",
+      "properties": {
+        "protocol_version": { "const": 1 },
+        "event_version": { "const": 1 },
+        "event": { "const": "run_started" },
+        "payload": {
+          "type": "object",
+          "required": ["engine", "skill_name", "task_total", "iterations_total"],
+          "properties": {
+            "engine": { "type": "string", "minLength": 1 },
+            "skill_name": { "type": "string", "minLength": 1 },
+            "task_total": { "$ref": "envelope.schema.json#/$defs/positiveInteger" },
+            "iterations_total": { "$ref": "envelope.schema.json#/$defs/positiveInteger" }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  ]
+}

--- a/schemas/evalevent/v1/run_started-v1.schema.json
+++ b/schemas/evalevent/v1/run_started-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/alibaba/skill-up/schemas/evalevent/v1/run_started-v1.schema.json",
+  "$id": "https://raw.githubusercontent.com/alibaba/skill-up/main/schemas/evalevent/v1/run_started-v1.schema.json",
   "title": "run_started event v1",
   "allOf": [
     { "$ref": "envelope.schema.json" },


### PR DESCRIPTION
## Summary

- add the internal typed v1 event envelope and payload validation defined by SUP-0005
- add a concurrency-safe Publisher with invocation identity, contiguous sequence numbers, immutable attributes, one final marker, sticky publication errors, and idempotent close aggregation
- add the invocation Lifecycle state machine with task and iteration accounting, monotonic durations, progress snapshots, and a 30-second heartbeat
- add a synchronous JSONL sink with complete newline-terminated writes, a 1 MiB record limit, and create/truncate semantics
- publish layered v1 JSON Schemas for the common envelope and all seven core event/version tuples

## Compatibility

User-visible changes: none.

The new internal package has no runtime caller and does not register hooks or change any existing command. It has no dependency on CLI, runner, evaluator, judge, report, or UI packages.

## Validation

- make fmt
- make verify
- make test

Part of #206 and implements the protocol approved in SUP-0005.