### PR TITLE
feat(cli): add evaluation event logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `skill-up run` now supports `--event-log <path>` for a live, ordered v1
+  JSONL evaluation event stream and repeatable `--event-attribute <key=value>`
+  values for bounded invocation correlation metadata. Existing runs are
+  unchanged unless the event log is explicitly enabled.
+
 ## [0.10.0] - 2026-09-01
 
 ### Added

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -34,6 +34,8 @@ skill-up run [path] [flags]
 | `--parallelism`        | From config                   | Override `cases.parallelism`. Allowed range: 1–256                                                                                                          |
 | `--baseline`           | From config                   | Override `benchmark.enabled` to `true` for this run                                                                                                         |
 | `--api-key`            | —                             | Pass an API key (higher precedence than env vars)                                                                                                          |
+| `--event-log`          | —                             | Write an ordered v1 JSONL evaluation event stream to a local file. The parent directory must already exist                                                  |
+| `--event-attribute`    | —                             | Attach a namespaced `key=value` string attribute to every event (repeatable; requires `--event-log`)                                                        |
 | `-v, --verbose`        | `0`                           | Increase log verbosity. Default `info`; `-v` / `--verbose` / `--verbose=true` → `debug`; `-vv` / `--verbose=2` → `trace`; `--verbose=false` disables extra detail |
 
 > **Validation scope.** `run` validates the eval-level config plus **only the
@@ -73,11 +75,22 @@ skill-up run ./evals/eval.yaml --format json --format html --format junit
 # Three samples in this command, one folder per run, plus a simple flaky summary
 skill-up run ./evals/eval.yaml --iteration 3
 
+# Produce a live event stream that a CI process can tail while the run is active
+skill-up run ./evals/eval.yaml \
+  --event-log ./events.jsonl \
+  --event-attribute com.example.ci.build_id=build-123
+
 # Auto-detect mode (consumes Anthropic evals.json directly)
 skill-up run --auto
 skill-up run --auto --engine codex
 skill-up run ./my-skill/ --auto
 ```
+
+`--event-log` creates or truncates one file for the invocation. It cannot be
+used with `--dry-run`, and the file must not be placed inside a scheduled
+`iteration-N/` output directory because that directory is recreated during the
+run. Consumers should read only newline-terminated records; the final record of
+a gracefully completed stream carries `last_event: true`.
 
 ### Exit codes
 

--- a/e2e/event_log_signal_unix_test.go
+++ b/e2e/event_log_signal_unix_test.go
@@ -67,10 +67,24 @@ input:
 `)
 
 	eventPath := filepath.Join(dir, "events.jsonl")
+	outputDir := filepath.Join(dir, "artifacts")
+	futureArtifacts := []string{
+		filepath.Join(outputDir, "iteration-2", "keep.txt"),
+		filepath.Join(outputDir, "iteration-3", "keep.txt"),
+	}
+	for _, artifactPath := range futureArtifacts {
+		if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+			t.Fatalf("create future iteration directory: %v", err)
+		}
+		if err := os.WriteFile(artifactPath, []byte("keep"), 0o600); err != nil {
+			t.Fatalf("write future iteration artifact: %v", err)
+		}
+	}
 	cmd := exec.Command(
 		binaryPath,
 		"run", filepath.Join(dir, "evals", "eval.yaml"),
-		"--output-dir", filepath.Join(dir, "artifacts"),
+		"--iteration", "3",
+		"--output-dir", outputDir,
 		"--event-log", eventPath,
 	)
 	cmd.Dir = dir
@@ -129,9 +143,160 @@ input:
 	if last.Event != "run_finished" || !last.LastEvent || last.Payload["status"] != "CANCELLED" {
 		t.Fatalf("last event = %+v, want final CANCELLED run_finished", last)
 	}
+	for _, event := range events {
+		if (event.Event == "iteration_started" || event.Event == "case_started") && event.Payload["iteration"] != float64(1) {
+			t.Fatalf("event emitted for a future iteration after cancellation: %+v", event)
+		}
+	}
+	for _, artifactPath := range futureArtifacts {
+		if data, err := os.ReadFile(artifactPath); err != nil || string(data) != "keep" {
+			t.Fatalf("future iteration artifact changed: path=%s data=%q err=%v", artifactPath, data, err)
+		}
+	}
+}
+
+func TestEventLogSignalDuringBaselineReturnsNonZero(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), `---
+name: event-log-baseline-signal-test
+description: Event log baseline cancellation fixture.
+---
+`)
+	writeFile(t, filepath.Join(dir, "evals", "eval.yaml"), `schema_version: v1alpha1
+environment:
+  type: none
+skills:
+  - source: local_path
+    path: .
+engine:
+  name: qoder-cli
+  model:
+    provider: qoder
+    name: auto
+cases:
+  files:
+    - evals/cases/baseline.yaml
+  defaults:
+    timeout_seconds: 120
+    max_turns: 1
+  parallelism: 1
+judge:
+  type: rule_based
+`)
+	writeFile(t, filepath.Join(dir, "evals", "cases", "baseline.yaml"), `id: baseline-case
+title: Baseline cancellation case
+input:
+  prompt: Find the null pointer bug.
+expect:
+  must_contain:
+    - "null"
+`)
+
+	eventPath := filepath.Join(dir, "events.jsonl")
+	cmd := exec.Command(
+		binaryPath,
+		"run", filepath.Join(dir, "evals", "eval.yaml"),
+		"--baseline",
+		"--parallelism", "1",
+		"--output-dir", filepath.Join(dir, "artifacts"),
+		"--event-log", eventPath,
+	)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"SKILL_UP_CONFIG_DIR="+t.TempDir(),
+		"NO_COLOR=1",
+	)
+	cmd.Env = append(cmd.Env, baselineSignalEngineEnv(t)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+		close(waitCh)
+	}()
+
+	err := waitForMatchingEventOrProcessExit(
+		eventPath,
+		"without_skill case_started",
+		func(event eventLogRecord) bool {
+			return event.Event == "case_started" && event.Payload["configuration"] == "without_skill"
+		},
+		waitCh,
+		10*time.Second,
+	)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		select {
+		case <-waitCh:
+		case <-time.After(5 * time.Second):
+		}
+		t.Fatalf("%v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+		_ = cmd.Process.Kill()
+		<-waitCh
+		t.Fatal(err)
+	}
+
+	var waitErr error
+	select {
+	case waitErr = <-waitCh:
+	case <-time.After(10 * time.Second):
+		_ = cmd.Process.Kill()
+		<-waitCh
+		t.Fatal("skill-up did not exit after cancelling the baseline task")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(waitErr, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("process error = %v, want graceful exit code 1\nstdout:\n%s\nstderr:\n%s", waitErr, stdout.String(), stderr.String())
+	}
+
+	events, err := readCompleteEventLog(eventPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 {
+		t.Fatal("event log is empty")
+	}
+	last := events[len(events)-1]
+	if last.Event != "run_finished" || !last.LastEvent || last.Payload["status"] != "CANCELLED" {
+		t.Fatalf("last event = %+v, want final CANCELLED run_finished", last)
+	}
+	withSkillPassed := false
+	for _, event := range events {
+		if event.Event == "case_completed" &&
+			event.Payload["configuration"] == "with_skill" &&
+			event.Payload["status"] == "PASS" {
+			withSkillPassed = true
+			break
+		}
+	}
+	if !withSkillPassed {
+		t.Fatal("with_skill task did not pass before baseline cancellation")
+	}
 }
 
 func waitForEventOrProcessExit(path, eventName string, waitCh <-chan error, timeout time.Duration) error {
+	return waitForMatchingEventOrProcessExit(
+		path,
+		eventName,
+		func(event eventLogRecord) bool { return event.Event == eventName },
+		waitCh,
+		timeout,
+	)
+}
+
+func waitForMatchingEventOrProcessExit(
+	path string,
+	description string,
+	matches func(eventLogRecord) bool,
+	waitCh <-chan error,
+	timeout time.Duration,
+) error {
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
 	ticker := time.NewTicker(10 * time.Millisecond)
@@ -139,9 +304,9 @@ func waitForEventOrProcessExit(path, eventName string, waitCh <-chan error, time
 	for {
 		select {
 		case err := <-waitCh:
-			return fmt.Errorf("process exited before %s: %w", eventName, err)
+			return fmt.Errorf("process exited before %s: %w", description, err)
 		case <-deadline.C:
-			return fmt.Errorf("timed out waiting for %s", eventName)
+			return fmt.Errorf("timed out waiting for %s", description)
 		case <-ticker.C:
 			events, err := readCompleteEventLog(path)
 			if os.IsNotExist(err) {
@@ -151,11 +316,42 @@ func waitForEventOrProcessExit(path, eventName string, waitCh <-chan error, time
 				return err
 			}
 			for _, event := range events {
-				if event.Event == eventName {
+				if matches(event) {
 					return nil
 				}
 			}
 		}
+	}
+}
+
+func baselineSignalEngineEnv(t *testing.T) []string {
+	t.Helper()
+
+	home, binDir := mockEngineHome(t)
+	enginePath := filepath.Join(binDir, "qodercli")
+	if err := os.Remove(enginePath); err != nil {
+		t.Fatalf("remove qodercli symlink: %v", err)
+	}
+	engineScript := `#!/bin/bash
+set -euo pipefail
+state_file="${MOCK_STATE_FILE:?}"
+call_number=1
+if [[ -f "$state_file" ]]; then
+  call_number=$(( $(<"$state_file") + 1 ))
+fi
+printf '%s\n' "$call_number" > "$state_file"
+if (( call_number > 1 )); then
+  sleep 60
+fi
+printf '%s\n' 'Mock response contains null'
+`
+	if err := os.WriteFile(enginePath, []byte(engineScript), 0o755); err != nil {
+		t.Fatalf("write baseline signal engine: %v", err)
+	}
+	return []string{
+		"PATH=" + binDir + ":" + os.Getenv("PATH"),
+		"HOME=" + home,
+		"MOCK_STATE_FILE=" + filepath.Join(t.TempDir(), "calls"),
 	}
 }
 

--- a/e2e/event_log_signal_unix_test.go
+++ b/e2e/event_log_signal_unix_test.go
@@ -1,0 +1,180 @@
+//go:build e2e && unix
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestEventLogSignalsProduceCancelledFinalEvent(t *testing.T) {
+	tests := []struct {
+		name   string
+		signal os.Signal
+	}{
+		{name: "SIGINT", signal: os.Interrupt},
+		{name: "SIGTERM", signal: syscall.SIGTERM},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testEventLogSignalProducesCancelledFinalEvent(t, tt.signal)
+		})
+	}
+}
+
+func testEventLogSignalProducesCancelledFinalEvent(t *testing.T, terminationSignal os.Signal) {
+	t.Helper()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), `---
+name: event-log-signal-test
+description: Event log signal handling fixture.
+---
+`)
+	writeFile(t, filepath.Join(dir, "evals", "eval.yaml"), `schema_version: v1alpha1
+environment:
+  type: none
+skills:
+  - source: local_path
+    path: .
+engine:
+  name: qoder-cli
+  model:
+    provider: qoder
+    name: auto
+cases:
+  files:
+    - evals/cases/slow.yaml
+  defaults:
+    timeout_seconds: 120
+    max_turns: 1
+  parallelism: 1
+judge:
+  type: rule_based
+`)
+	writeFile(t, filepath.Join(dir, "evals", "cases", "slow.yaml"), `id: slow-case
+title: Slow event case
+input:
+  prompt: Wait for cancellation.
+`)
+
+	eventPath := filepath.Join(dir, "events.jsonl")
+	cmd := exec.Command(
+		binaryPath,
+		"run", filepath.Join(dir, "evals", "eval.yaml"),
+		"--output-dir", filepath.Join(dir, "artifacts"),
+		"--event-log", eventPath,
+	)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"SKILL_UP_CONFIG_DIR="+t.TempDir(),
+		"NO_COLOR=1",
+	)
+	cmd.Env = append(cmd.Env, mockEngineEnv(t, "MOCK_TIMEOUT=60")...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+		close(waitCh)
+	}()
+
+	if err := waitForEventOrProcessExit(eventPath, "case_started", waitCh, 10*time.Second); err != nil {
+		_ = cmd.Process.Kill()
+		select {
+		case <-waitCh:
+		case <-time.After(5 * time.Second):
+		}
+		t.Fatalf("%v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if err := cmd.Process.Signal(terminationSignal); err != nil {
+		_ = cmd.Process.Kill()
+		<-waitCh
+		t.Fatal(err)
+	}
+
+	var waitErr error
+	select {
+	case waitErr = <-waitCh:
+	case <-time.After(10 * time.Second):
+		_ = cmd.Process.Kill()
+		<-waitCh
+		t.Fatal("skill-up did not exit after receiving a termination signal")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(waitErr, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("process error = %v, want graceful exit code 1\nstdout:\n%s\nstderr:\n%s", waitErr, stdout.String(), stderr.String())
+	}
+
+	events, err := readCompleteEventLog(eventPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 {
+		t.Fatal("event log is empty")
+	}
+	last := events[len(events)-1]
+	if last.Event != "run_finished" || !last.LastEvent || last.Payload["status"] != "CANCELLED" {
+		t.Fatalf("last event = %+v, want final CANCELLED run_finished", last)
+	}
+}
+
+func waitForEventOrProcessExit(path, eventName string, waitCh <-chan error, timeout time.Duration) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-waitCh:
+			return fmt.Errorf("process exited before %s: %w", eventName, err)
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for %s", eventName)
+		case <-ticker.C:
+			events, err := readCompleteEventLog(path)
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			for _, event := range events {
+				if event.Event == eventName {
+					return nil
+				}
+			}
+		}
+	}
+}
+
+func readCompleteEventLog(path string) ([]eventLogRecord, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	lines := bytes.Split(data, []byte("\n"))
+	events := make([]eventLogRecord, 0, len(lines)-1)
+	for i, line := range lines[:len(lines)-1] {
+		if len(line) == 0 {
+			continue
+		}
+		var event eventLogRecord
+		if err := json.Unmarshal(line, &event); err != nil {
+			return nil, fmt.Errorf("parse complete event line %d: %w", i+1, err)
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}

--- a/e2e/event_log_signal_unix_test.go
+++ b/e2e/event_log_signal_unix_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 )
 
+const eventLogProcessStartTimeout = 60 * time.Second
+
 func TestEventLogSignalsProduceCancelledFinalEvent(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -105,7 +107,7 @@ input:
 		close(waitCh)
 	}()
 
-	if err := waitForEventOrProcessExit(eventPath, "case_started", waitCh, 10*time.Second); err != nil {
+	if err := waitForEventOrProcessExit(eventPath, "case_started", waitCh, eventLogProcessStartTimeout); err != nil {
 		_ = cmd.Process.Kill()
 		select {
 		case <-waitCh:
@@ -226,7 +228,7 @@ expect:
 			return event.Event == "case_started" && event.Payload["configuration"] == "without_skill"
 		},
 		waitCh,
-		10*time.Second,
+		eventLogProcessStartTimeout,
 	)
 	if err != nil {
 		_ = cmd.Process.Kill()

--- a/e2e/event_log_test.go
+++ b/e2e/event_log_test.go
@@ -1,0 +1,196 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestEventLog_FullLifecycle(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), `---
+name: event-log-test
+description: Event log end-to-end fixture.
+---
+`)
+	writeFile(t, filepath.Join(dir, "evals", "eval.yaml"), `schema_version: v1alpha1
+environment:
+  type: none
+skills:
+  - source: local_path
+    path: .
+engine:
+  name: qoder-cli
+  model:
+    provider: qoder
+    name: auto
+cases:
+  files:
+    - evals/cases/pass.yaml
+  defaults:
+    timeout_seconds: 30
+    max_turns: 1
+  parallelism: 2
+judge:
+  type: rule_based
+`)
+	writeFile(t, filepath.Join(dir, "evals", "cases", "pass.yaml"), `id: pass-case
+title: Passing event case
+input:
+  prompt: Find the null pointer bug.
+expect:
+  must_contain:
+    - "null"
+`)
+
+	outputDir := filepath.Join(dir, "artifacts")
+	result := Run(t, RunConfig{
+		Env:     mockEngineEnv(t),
+		WorkDir: dir,
+		Timeout: 60 * time.Second,
+	},
+		"run", filepath.Join(dir, "evals", "eval.yaml"),
+		"--iteration", "2",
+		"--baseline",
+		"--output-dir", outputDir,
+		"--no-delete",
+		"--event-log", "events.jsonl",
+		"--event-attribute", "com.example.build_id=build-1",
+		"--event-attribute", "com.example.retry=2",
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("event-enabled run failed: exit=%d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "events.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasSuffix(data, []byte("\n")) {
+		t.Fatal("event log does not end with a newline")
+	}
+	lines := bytes.Split(bytes.TrimSuffix(data, []byte("\n")), []byte("\n"))
+	events := make([]eventLogRecord, len(lines))
+	for i, line := range lines {
+		if err := json.Unmarshal(line, &events[i]); err != nil {
+			t.Fatalf("event line %d is invalid JSON: %v\n%s", i+1, err, line)
+		}
+	}
+	if len(events) < 11 {
+		t.Fatalf("event count = %d, want a complete lifecycle", len(events))
+	}
+
+	invocationID := events[0].InvocationID
+	if invocationID == "" {
+		t.Fatal("invocation_id is empty")
+	}
+	lastCount := 0
+	for i, event := range events {
+		if event.ProtocolVersion != 1 || event.EventVersion != 1 {
+			t.Errorf("event %d versions = %d/%d", i+1, event.ProtocolVersion, event.EventVersion)
+		}
+		if event.SequenceNumber != uint64(i+1) {
+			t.Errorf("event %d sequence = %d", i+1, event.SequenceNumber)
+		}
+		if event.InvocationID != invocationID {
+			t.Errorf("event %d invocation = %q, want %q", i+1, event.InvocationID, invocationID)
+		}
+		if event.Attributes["com.example.build_id"] != "build-1" || event.Attributes["com.example.retry"] != "2" {
+			t.Errorf("event %d attributes = %v", i+1, event.Attributes)
+		}
+		if event.LastEvent {
+			lastCount++
+			if i != len(events)-1 {
+				t.Errorf("event %d is marked last before end of stream", i+1)
+			}
+		}
+	}
+	if lastCount != 1 {
+		t.Fatalf("last_event count = %d, want 1", lastCount)
+	}
+
+	if events[0].Event != "run_started" {
+		t.Fatalf("first event = %q, want run_started", events[0].Event)
+	}
+	assertPayloadNumber(t, events[0].Payload, "task_total", 4)
+	assertPayloadNumber(t, events[0].Payload, "iterations_total", 2)
+	if events[1].Event != "run_progress" || events[1].Payload["phase"] != "preparing" {
+		t.Fatalf("second event = %q payload=%v, want preparing progress", events[1].Event, events[1].Payload)
+	}
+
+	startedTasks := make(map[string]eventLogRecord)
+	completedTasks := make(map[string]eventLogRecord)
+	iterationStarted := 0
+	iterationCompleted := 0
+	seenExecuting := false
+	seenFinalizing := false
+	for _, event := range events {
+		switch event.Event {
+		case "run_progress":
+			seenExecuting = seenExecuting || event.Payload["phase"] == "executing"
+			seenFinalizing = seenFinalizing || event.Payload["phase"] == "finalizing"
+		case "iteration_started":
+			iterationStarted++
+		case "iteration_completed":
+			iterationCompleted++
+		case "case_started":
+			startedTasks[event.Payload["task_id"].(string)] = event
+		case "case_completed":
+			completedTasks[event.Payload["task_id"].(string)] = event
+		}
+	}
+	if !seenExecuting || !seenFinalizing {
+		t.Fatalf("progress phases missing: executing=%t finalizing=%t", seenExecuting, seenFinalizing)
+	}
+	if iterationStarted != 2 || iterationCompleted != 2 {
+		t.Fatalf("iteration events = started:%d completed:%d, want 2/2", iterationStarted, iterationCompleted)
+	}
+	if len(startedTasks) != 4 || len(completedTasks) != 4 {
+		t.Fatalf("case events = started:%d completed:%d, want 4/4", len(startedTasks), len(completedTasks))
+	}
+	for taskID, completed := range completedTasks {
+		if _, ok := startedTasks[taskID]; !ok {
+			t.Errorf("completed task %q has no start event", taskID)
+		}
+		if completed.Payload["status"] != "PASS" {
+			t.Errorf("task %q status = %v, want PASS", taskID, completed.Payload["status"])
+		}
+	}
+
+	last := events[len(events)-1]
+	if last.Event != "run_finished" || last.Payload["status"] != "COMPLETED" {
+		t.Fatalf("last event = %q payload=%v, want completed run_finished", last.Event, last.Payload)
+	}
+	assertPayloadNumber(t, last.Payload, "completed_tasks", 4)
+	assertPayloadNumber(t, last.Payload, "passed", 4)
+	for _, iteration := range []string{"iteration-1", "iteration-2"} {
+		if _, err := os.Stat(filepath.Join(outputDir, iteration, "result.json")); err != nil {
+			t.Errorf("missing %s report: %v", iteration, err)
+		}
+	}
+}
+
+type eventLogRecord struct {
+	ProtocolVersion uint64            `json:"protocol_version"`
+	EventVersion    uint64            `json:"event_version"`
+	SequenceNumber  uint64            `json:"sequence_number"`
+	InvocationID    string            `json:"invocation_id"`
+	Event           string            `json:"event"`
+	LastEvent       bool              `json:"last_event"`
+	Attributes      map[string]string `json:"attributes"`
+	Payload         map[string]any    `json:"payload"`
+}
+
+func assertPayloadNumber(t *testing.T, payload map[string]any, name string, want float64) {
+	t.Helper()
+	if got := payload[name]; got != want {
+		t.Fatalf("payload %s = %v, want %v", name, got, want)
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -37,6 +37,8 @@ const (
 	runtimeFlagName        = "runtime"
 	engineKwargFlagName    = "engine-kwarg"
 	engineKwargAlias       = "ek"
+	eventLogFlagName       = "event-log"
+	eventAttributeFlagName = "event-attribute"
 )
 
 // validRuntimeTypes lists the environment.type values accepted by --runtime.
@@ -119,6 +121,8 @@ func init() {
 	runCmd.Flags().Int("iteration", 0, "Repeat selected eval cases N times for stability/flakiness sampling. Positive N writes iteration-<N> artifacts and prints a current-command summary when N > 1. 0 = auto-append one run after the last existing iteration without summarizing history")
 	runCmd.Flags().Bool("no-delete", false, "Skip cleanup of workspace after evaluation (useful for debugging)")
 	runCmd.Flags().Bool("dry-run", false, "Validate and show what would run without executing")
+	runCmd.Flags().String(eventLogFlagName, "", "Write v1 evaluation events as JSON Lines to path")
+	runCmd.Flags().StringArray(eventAttributeFlagName, nil, "Attach a namespaced string attribute to every event (can be specified multiple times)")
 }
 
 func runEval(cmd *cobra.Command, args []string) error {
@@ -140,6 +144,21 @@ func runEval(cmd *cobra.Command, args []string) error {
 	cases, evalCfg, loader, err := loadAndPrepareConfig(ctx, cmd, args, span)
 	if err != nil {
 		return err
+	}
+
+	eventOptions, err := evaluationEventOptionsFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+	if eventOptions.Enabled {
+		dryRun, flagErr := cmd.Flags().GetBool("dry-run")
+		if flagErr != nil {
+			return fmt.Errorf("read --dry-run: %w", flagErr)
+		}
+		if dryRun {
+			return errors.New("--event-log cannot be used with --dry-run")
+		}
+		return runEvalWithEventLog(cmd, cases, evalCfg, loader, eventOptions)
 	}
 
 	if maybeRunDryRun(cmd, cases, evalCfg) {

--- a/internal/cli/run_events.go
+++ b/internal/cli/run_events.go
@@ -153,9 +153,10 @@ func runEvalWithEventLog(
 		evaluateOpts,
 		stream.adapter,
 	)
-	finalErr := stream.finish(context.WithoutCancel(cmd.Context()), eventRunStatus(cmd.Context(), evalErr))
-	if evalErr != nil {
-		return errors.Join(evalErr, finalErr)
+	invocationErr := joinDistinctErrors(evalErr, cmd.Context().Err())
+	finalErr := stream.finish(context.WithoutCancel(cmd.Context()), eventRunStatus(cmd.Context(), invocationErr))
+	if invocationErr != nil {
+		return errors.Join(invocationErr, finalErr)
 	}
 
 	ui.Separator()

--- a/internal/cli/run_events.go
+++ b/internal/cli/run_events.go
@@ -1,0 +1,507 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"github.com/alibaba/skill-up/internal/agent"
+	"github.com/alibaba/skill-up/internal/config"
+	"github.com/alibaba/skill-up/internal/credential"
+	"github.com/alibaba/skill-up/internal/evalevent"
+	"github.com/alibaba/skill-up/internal/evaluator"
+	"github.com/alibaba/skill-up/internal/judge"
+	"github.com/alibaba/skill-up/internal/logging"
+	"github.com/alibaba/skill-up/internal/runner"
+	"github.com/alibaba/skill-up/internal/ui"
+)
+
+type evaluationEventOptions struct {
+	Enabled    bool
+	Path       string
+	Attributes map[string]string
+}
+
+type evaluationEventStream struct {
+	publisher *evalevent.Publisher
+	lifecycle *evalevent.Lifecycle
+	adapter   *evaluationEventAdapter
+}
+
+func evaluationEventOptionsFromFlags(cmd *cobra.Command) (evaluationEventOptions, error) {
+	eventLogFlag := cmd.Flags().Lookup(eventLogFlagName)
+	eventAttributeFlag := cmd.Flags().Lookup(eventAttributeFlagName)
+	if eventLogFlag == nil && eventAttributeFlag == nil {
+		return evaluationEventOptions{}, nil
+	}
+
+	eventLogChanged := eventLogFlag != nil && eventLogFlag.Changed
+	eventAttributeChanged := eventAttributeFlag != nil && eventAttributeFlag.Changed
+	if eventAttributeChanged && !eventLogChanged {
+		return evaluationEventOptions{}, errors.New("--event-attribute requires --event-log")
+	}
+	if !eventLogChanged {
+		return evaluationEventOptions{}, nil
+	}
+
+	path, err := cmd.Flags().GetString(eventLogFlagName)
+	if err != nil {
+		return evaluationEventOptions{}, fmt.Errorf("read --event-log: %w", err)
+	}
+	if path == "" {
+		return evaluationEventOptions{}, errors.New("--event-log path must not be empty")
+	}
+	if path == "-" {
+		return evaluationEventOptions{}, errors.New("--event-log does not support stdout; provide a file path")
+	}
+
+	var attributeValues []string
+	if eventAttributeFlag != nil {
+		attributeValues, err = cmd.Flags().GetStringArray(eventAttributeFlagName)
+		if err != nil {
+			return evaluationEventOptions{}, fmt.Errorf("read --event-attribute: %w", err)
+		}
+	}
+	attributes, err := parseEvaluationEventAttributes(attributeValues)
+	if err != nil {
+		return evaluationEventOptions{}, err
+	}
+
+	return evaluationEventOptions{Enabled: true, Path: path, Attributes: attributes}, nil
+}
+
+func parseEvaluationEventAttributes(values []string) (map[string]string, error) {
+	attributes := make(map[string]string, len(values))
+	for _, value := range values {
+		key, attributeValue, ok := strings.Cut(value, "=")
+		if !ok || key == "" || attributeValue == "" {
+			return nil, fmt.Errorf("invalid --event-attribute %q: expected non-empty key=value", value)
+		}
+		if _, exists := attributes[key]; exists {
+			return nil, fmt.Errorf("duplicate --event-attribute key %q", key)
+		}
+		attributes[key] = attributeValue
+	}
+	if err := evalevent.ValidateUserAttributes(attributes); err != nil {
+		return nil, fmt.Errorf("invalid --event-attribute: %w", err)
+	}
+	return attributes, nil
+}
+
+func runEvalWithEventLog(
+	cmd *cobra.Command,
+	cases []*config.CaseConfig,
+	evalCfg *config.EvalConfig,
+	loader *config.Loader,
+	eventOptions evaluationEventOptions,
+) error {
+	evaluateOpts, err := evaluateOptionsFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+	if len(evaluateOpts.Formats) == 0 {
+		evaluateOpts.Formats = evalCfg.Report.Formats
+	}
+
+	planningRunner := runner.NewRunner(evalCfg, loader, nil, credential.ResolvedAgentConfig{})
+	executionPlan := planningRunner.BuildExecutionPlan(cases, evaluateOpts)
+	eventPlan, err := evaluationEventPlan(executionPlan)
+	if err != nil {
+		return fmt.Errorf("build event plan: %w", err)
+	}
+	eventPath, err := validateEvaluationEventLogPath(eventOptions.Path, executionPlan)
+	if err != nil {
+		return err
+	}
+	stream, err := startEvaluationEventStream(
+		cmd.Context(),
+		eventPath,
+		eventOptions.Attributes,
+		eventPlan,
+		evalCfg.Engine.Name,
+		executionPlan.ReportName,
+	)
+	if err != nil {
+		return err
+	}
+
+	ag, resolver, runnerConfig, err := loadCredentialsAndAgent(cmd, evalCfg)
+	if err != nil {
+		return errors.Join(err, stream.finish(context.WithoutCancel(cmd.Context()), eventRunStatus(cmd.Context(), err)))
+	}
+
+	stream.adapter.setPhase(cmd.Context(), evalevent.RunPhaseExecuting)
+	results, evalErr := executePlannedEvaluation(
+		cmd,
+		evalCfg,
+		loader,
+		resolver,
+		runnerConfig,
+		ag,
+		executionPlan,
+		evaluateOpts,
+		stream.adapter,
+	)
+	finalErr := stream.finish(context.WithoutCancel(cmd.Context()), eventRunStatus(cmd.Context(), evalErr))
+	if evalErr != nil {
+		return errors.Join(evalErr, finalErr)
+	}
+
+	ui.Separator()
+	passed, failed, errored := countResultStatus(results)
+	ui.Summary(passed, failed, errored)
+	return errors.Join(exitStatusError(cmd.ErrOrStderr(), results), finalErr)
+}
+
+func executePlannedEvaluation(
+	cmd *cobra.Command,
+	evalCfg *config.EvalConfig,
+	loader *config.Loader,
+	resolver *credential.Resolver,
+	runnerConfig credential.ResolvedAgentConfig,
+	ag agent.Agent,
+	plan runner.ExecutionPlan,
+	evaluateOpts runner.EvaluateOptions,
+	adapter *evaluationEventAdapter,
+) ([]evaluator.EvalResult, error) {
+	ui.Blank()
+	ui.Stepf("🚀", "Running evaluation (%d cases)", plan.CaseCount)
+
+	evaluateOpts.Observer = &uiProgressObserver{}
+	evaluateOpts.TaskObserver = adapter
+	evaluateOpts.IterationObserver = adapter
+
+	run := runner.NewRunner(evalCfg, loader, resolver, runnerConfig)
+	logging.DebugContextf(cmd.Context(), "Runner: starting evaluation for %d case(s) with agent %s", plan.CaseCount, evalCfg.Engine.Name)
+	results, err := run.EvaluatePlan(cmd.Context(), plan, ag, evaluateOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate cases: %w", err)
+	}
+	return results, nil
+}
+
+func startEvaluationEventStream(
+	ctx context.Context,
+	path string,
+	attributes map[string]string,
+	plan evalevent.Plan,
+	engine string,
+	skillName string,
+) (*evaluationEventStream, error) {
+	if err := evalevent.ValidatePlan(plan); err != nil {
+		return nil, fmt.Errorf("invalid event plan: %w", err)
+	}
+	if err := evalevent.ValidateUserAttributes(attributes); err != nil {
+		return nil, fmt.Errorf("invalid event attributes: %w", err)
+	}
+
+	sink, err := evalevent.NewJSONLFileSink(path)
+	if err != nil {
+		return nil, err
+	}
+	publisher, err := evalevent.NewPublisher(evalevent.PublisherConfig{Sink: sink, Attributes: attributes})
+	if err != nil {
+		return nil, errors.Join(err, sink.Close())
+	}
+	lifecycle, err := evalevent.NewLifecycle(publisher, plan, evalevent.LifecycleOptions{})
+	if err != nil {
+		return nil, errors.Join(err, publisher.Close())
+	}
+	adapter := &evaluationEventAdapter{lifecycle: lifecycle}
+	stream := &evaluationEventStream{publisher: publisher, lifecycle: lifecycle, adapter: adapter}
+	if err := lifecycle.Start(ctx, engine, skillName); err != nil {
+		return nil, joinDistinctErrors(publisher.Close(), err)
+	}
+	return stream, nil
+}
+
+func (s *evaluationEventStream) finish(ctx context.Context, status evalevent.RunStatus) error {
+	finishErr := s.lifecycle.Finish(ctx, status)
+	closeErr := s.publisher.Close()
+	return joinDistinctErrors(closeErr, finishErr, s.adapter.errValue())
+}
+
+func joinDistinctErrors(errs ...error) error {
+	unique := make([]error, 0, len(errs))
+	for _, candidate := range errs {
+		if candidate == nil {
+			continue
+		}
+		duplicate := false
+		for _, existing := range unique {
+			if errors.Is(existing, candidate) || errors.Is(candidate, existing) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			unique = append(unique, candidate)
+		}
+	}
+	return errors.Join(unique...)
+}
+
+func eventRunStatus(ctx context.Context, invocationErr error) evalevent.RunStatus {
+	if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) ||
+		errors.Is(invocationErr, context.Canceled) || errors.Is(invocationErr, context.DeadlineExceeded) {
+		return evalevent.RunStatusCancelled
+	}
+	if invocationErr != nil {
+		return evalevent.RunStatusError
+	}
+	return evalevent.RunStatusCompleted
+}
+
+func evaluationEventPlan(plan runner.ExecutionPlan) (evalevent.Plan, error) {
+	iterations := make([]evalevent.Iteration, 0, len(plan.TaskPlan.Iterations))
+	taskCount := 0
+	for _, iteration := range plan.TaskPlan.Iterations {
+		iterationNumber, err := positiveSafeEventInteger("iteration", iteration.Number)
+		if err != nil {
+			return evalevent.Plan{}, err
+		}
+		tasks := make([]evalevent.Task, 0, len(iteration.Tasks))
+		for _, task := range iteration.Tasks {
+			taskCount++
+			if task.Case == nil {
+				return evalevent.Plan{}, fmt.Errorf("task %q has no case", task.ID)
+			}
+			if task.Iteration != iteration.Number {
+				return evalevent.Plan{}, fmt.Errorf("task %q iteration %d does not match iteration %d", task.ID, task.Iteration, iteration.Number)
+			}
+			if task.GlobalTotal != plan.TaskPlan.TaskTotal {
+				return evalevent.Plan{}, fmt.Errorf("task %q total %d does not match plan total %d", task.ID, task.GlobalTotal, plan.TaskPlan.TaskTotal)
+			}
+			index, err := positiveSafeEventInteger("task index", task.GlobalIndex)
+			if err != nil {
+				return evalevent.Plan{}, fmt.Errorf("task %q: %w", task.ID, err)
+			}
+			configuration, err := evaluationEventConfiguration(task.Configuration)
+			if err != nil {
+				return evalevent.Plan{}, fmt.Errorf("task %q: %w", task.ID, err)
+			}
+			tasks = append(tasks, evalevent.Task{
+				ID:            task.ID,
+				Iteration:     iterationNumber,
+				CaseID:        task.Case.ID,
+				Configuration: configuration,
+				Index:         index,
+				Title:         task.Case.Title,
+			})
+		}
+		iterations = append(iterations, evalevent.Iteration{Number: iterationNumber, Tasks: tasks})
+	}
+	if taskCount != plan.TaskPlan.TaskTotal {
+		return evalevent.Plan{}, fmt.Errorf("expanded task count %d does not match plan total %d", taskCount, plan.TaskPlan.TaskTotal)
+	}
+	return evalevent.Plan{Iterations: iterations}, nil
+}
+
+func positiveSafeEventInteger(name string, value int) (uint64, error) {
+	if value < 1 || uint64(value) > evalevent.MaxSafeInteger {
+		return 0, fmt.Errorf("%s must be between 1 and %d", name, evalevent.MaxSafeInteger)
+	}
+	return uint64(value), nil
+}
+
+func evaluationEventConfiguration(configuration string) (evalevent.Configuration, error) {
+	switch configuration {
+	case evaluator.ConfigurationWithSkill:
+		return evalevent.ConfigurationWithSkill, nil
+	case evaluator.ConfigurationWithoutSkill:
+		return evalevent.ConfigurationWithoutSkill, nil
+	default:
+		return "", fmt.Errorf("unsupported task configuration %q", configuration)
+	}
+}
+
+func validateEvaluationEventLogPath(path string, plan runner.ExecutionPlan) (string, error) {
+	canonicalPath, err := canonicalEventLogPath(path)
+	if err != nil {
+		return "", fmt.Errorf("invalid --event-log path %q: %w", path, err)
+	}
+	workspacePath, err := canonicalizePotentialPath(plan.WorkspaceDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve evaluation workspace: %w", err)
+	}
+	if canonicalPath == workspacePath {
+		return "", fmt.Errorf("--event-log path %q conflicts with the evaluation workspace", path)
+	}
+	for _, iteration := range plan.TaskPlan.Iterations {
+		iterationPath, err := canonicalizePotentialPath(filepath.Join(plan.WorkspaceDir, fmt.Sprintf("iteration-%d", iteration.Number)))
+		if err != nil {
+			return "", fmt.Errorf("resolve iteration %d workspace: %w", iteration.Number, err)
+		}
+		if pathWithin(iterationPath, canonicalPath) {
+			return "", fmt.Errorf("--event-log path %q resolves inside scheduled iteration directory %q", path, iterationPath)
+		}
+	}
+	return canonicalPath, nil
+}
+
+func canonicalEventLogPath(path string) (string, error) {
+	absolutePath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	_, err = os.Lstat(absolutePath)
+	if err == nil {
+		resolvedPath, resolveErr := filepath.EvalSymlinks(absolutePath)
+		if resolveErr != nil {
+			return "", resolveErr
+		}
+		resolvedInfo, statErr := os.Stat(resolvedPath)
+		if statErr != nil {
+			return "", statErr
+		}
+		if resolvedInfo.IsDir() {
+			return "", errors.New("path is a directory")
+		}
+		return filepath.Clean(resolvedPath), nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	parent := filepath.Dir(absolutePath)
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		return "", fmt.Errorf("parent directory: %w", err)
+	}
+	if !parentInfo.IsDir() {
+		return "", errors.New("parent path is not a directory")
+	}
+	resolvedParent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return "", fmt.Errorf("resolve parent directory: %w", err)
+	}
+	return filepath.Join(resolvedParent, filepath.Base(absolutePath)), nil
+}
+
+func canonicalizePotentialPath(path string) (string, error) {
+	absolutePath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	current := absolutePath
+	missing := make([]string, 0)
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			resolved, resolveErr := filepath.EvalSymlinks(current)
+			if resolveErr != nil {
+				return "", resolveErr
+			}
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return filepath.Clean(resolved), nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("no existing ancestor for %q", path)
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
+}
+
+func pathWithin(parent, child string) bool {
+	relative, err := filepath.Rel(parent, child)
+	if err != nil || filepath.IsAbs(relative) {
+		return false
+	}
+	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
+}
+
+type evaluationEventAdapter struct {
+	lifecycle *evalevent.Lifecycle
+
+	mu  sync.Mutex
+	err error
+}
+
+func (a *evaluationEventAdapter) setPhase(ctx context.Context, phase evalevent.RunPhase) {
+	a.record(a.lifecycle.SetPhase(eventObserverContext(ctx), phase))
+}
+
+func (a *evaluationEventAdapter) OnIterationStart(ctx context.Context, iteration evaluator.IterationPlan) {
+	number, err := positiveSafeEventInteger("iteration", iteration.Number)
+	if err != nil {
+		a.record(err)
+		return
+	}
+	a.record(a.lifecycle.IterationStarted(eventObserverContext(ctx), number))
+}
+
+func (a *evaluationEventAdapter) OnIterationComplete(ctx context.Context, iteration evaluator.IterationPlan, _ []evaluator.EvalResult) {
+	number, err := positiveSafeEventInteger("iteration", iteration.Number)
+	if err != nil {
+		a.record(err)
+		return
+	}
+	a.record(a.lifecycle.IterationCompleted(eventObserverContext(ctx), number))
+}
+
+func (a *evaluationEventAdapter) OnTaskStart(ctx context.Context, task evaluator.PlannedTask) {
+	a.record(a.lifecycle.CaseStarted(eventObserverContext(ctx), task.ID))
+}
+
+func (a *evaluationEventAdapter) OnTaskComplete(ctx context.Context, task evaluator.PlannedTask, result evaluator.EvalResult) {
+	status, err := evaluationEventCaseStatus(result.Status)
+	if err != nil {
+		a.record(fmt.Errorf("task %q: %w", task.ID, err))
+		return
+	}
+	var passRate *float64
+	if result.Grading != nil {
+		value := result.Grading.Summary.PassRate
+		passRate = &value
+	}
+	a.record(a.lifecycle.CaseCompleted(eventObserverContext(ctx), task.ID, status, passRate))
+}
+
+func eventObserverContext(ctx context.Context) context.Context {
+	// These callbacks describe work that already happened. Preserve context
+	// values, but do not let graceful cancellation poison the synchronous file
+	// publisher before the final CANCELLED event can be attempted.
+	return context.WithoutCancel(ctx)
+}
+
+func (a *evaluationEventAdapter) record(err error) {
+	if err == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.err == nil {
+		a.err = err
+	}
+}
+
+func (a *evaluationEventAdapter) errValue() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.err
+}
+
+func evaluationEventCaseStatus(status judge.Status) (evalevent.CaseStatus, error) {
+	switch status {
+	case judge.StatusPass:
+		return evalevent.CaseStatusPass, nil
+	case judge.StatusFail:
+		return evalevent.CaseStatusFail, nil
+	case judge.StatusError:
+		return evalevent.CaseStatusError, nil
+	case judge.StatusSkip:
+		return evalevent.CaseStatusSkip, nil
+	default:
+		return "", fmt.Errorf("unsupported case status %q", status)
+	}
+}

--- a/internal/cli/run_events.go
+++ b/internal/cli/run_events.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -101,6 +103,9 @@ func runEvalWithEventLog(
 	loader *config.Loader,
 	eventOptions evaluationEventOptions,
 ) error {
+	restoreSignalContext := installEvaluationSignalContext(cmd)
+	defer restoreSignalContext()
+
 	evaluateOpts, err := evaluateOptionsFromFlags(cmd)
 	if err != nil {
 		return err
@@ -157,6 +162,16 @@ func runEvalWithEventLog(
 	passed, failed, errored := countResultStatus(results)
 	ui.Summary(passed, failed, errored)
 	return errors.Join(exitStatusError(cmd.ErrOrStderr(), results), finalErr)
+}
+
+func installEvaluationSignalContext(cmd *cobra.Command) func() {
+	parent := cmd.Context()
+	ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+	cmd.SetContext(ctx)
+	return func() {
+		stop()
+		cmd.SetContext(parent)
+	}
 }
 
 func executePlannedEvaluation(
@@ -330,7 +345,7 @@ func validateEvaluationEventLogPath(path string, plan runner.ExecutionPlan) (str
 	if err != nil {
 		return "", fmt.Errorf("resolve evaluation workspace: %w", err)
 	}
-	if canonicalPath == workspacePath {
+	if pathsReferToSameFile(canonicalPath, workspacePath) {
 		return "", fmt.Errorf("--event-log path %q conflicts with the evaluation workspace", path)
 	}
 	for _, iteration := range plan.TaskPlan.Iterations {
@@ -413,11 +428,39 @@ func canonicalizePotentialPath(path string) (string, error) {
 }
 
 func pathWithin(parent, child string) bool {
+	if existingDirectoryContains(parent, child) {
+		return true
+	}
 	relative, err := filepath.Rel(parent, child)
 	if err != nil || filepath.IsAbs(relative) {
 		return false
 	}
 	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
+}
+
+func existingDirectoryContains(parent, child string) bool {
+	parentInfo, err := os.Stat(parent)
+	if err != nil || !parentInfo.IsDir() {
+		return false
+	}
+	for current := child; ; current = filepath.Dir(current) {
+		currentInfo, currentErr := os.Stat(current)
+		if currentErr == nil && currentInfo.IsDir() && os.SameFile(parentInfo, currentInfo) {
+			return true
+		}
+		if next := filepath.Dir(current); next == current {
+			return false
+		}
+	}
+}
+
+func pathsReferToSameFile(left, right string) bool {
+	if left == right {
+		return true
+	}
+	leftInfo, leftErr := os.Stat(left)
+	rightInfo, rightErr := os.Stat(right)
+	return leftErr == nil && rightErr == nil && os.SameFile(leftInfo, rightInfo)
 }
 
 type evaluationEventAdapter struct {

--- a/internal/cli/run_events_test.go
+++ b/internal/cli/run_events_test.go
@@ -192,6 +192,40 @@ func TestValidateEvaluationEventLogPathInsideIteration(t *testing.T) {
 	}
 }
 
+func TestValidateEvaluationEventLogPathInsideCaseInsensitiveIteration(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	actualIteration := filepath.Join(workspace, "Iteration-1")
+	if err := os.MkdirAll(actualIteration, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scheduledIteration := filepath.Join(workspace, "iteration-1")
+	actualInfo, err := os.Stat(actualIteration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduledInfo, err := os.Stat(scheduledIteration)
+	if os.IsNotExist(err) {
+		t.Skip("filesystem is case-sensitive")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(actualInfo, scheduledInfo) {
+		t.Skip("filesystem resolves case variants to different directories")
+	}
+
+	_, err = validateEvaluationEventLogPath(
+		filepath.Join(actualIteration, "events.jsonl"),
+		eventPathTestPlan(workspace),
+	)
+	if err == nil || !strings.Contains(err.Error(), "inside scheduled iteration directory") {
+		t.Fatalf("error = %v, want case-insensitive iteration conflict", err)
+	}
+}
+
 func TestValidateEvaluationEventLogPathWorkspaceCollision(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/run_events_test.go
+++ b/internal/cli/run_events_test.go
@@ -1,0 +1,492 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/alibaba/skill-up/internal/config"
+	"github.com/alibaba/skill-up/internal/evalevent"
+	"github.com/alibaba/skill-up/internal/evaluator"
+	"github.com/alibaba/skill-up/internal/judge"
+	"github.com/alibaba/skill-up/internal/runner"
+)
+
+type evaluationEventOptionsTestCase struct {
+	name       string
+	values     map[string][]string
+	wantErr    string
+	wantPath   string
+	wantAttrs  map[string]string
+	wantEnable bool
+}
+
+func TestEvaluationEventOptionsFromFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []evaluationEventOptionsTestCase{
+		{name: "disabled"},
+		{
+			name:    "attribute requires log",
+			values:  map[string][]string{eventAttributeFlagName: {"com.example.build_id=1"}},
+			wantErr: "--event-attribute requires --event-log",
+		},
+		{
+			name:    "empty log",
+			values:  map[string][]string{eventLogFlagName: {""}},
+			wantErr: "path must not be empty",
+		},
+		{
+			name:    "stdout rejected",
+			values:  map[string][]string{eventLogFlagName: {"-"}},
+			wantErr: "does not support stdout",
+		},
+		{
+			name: "invalid attribute",
+			values: map[string][]string{
+				eventLogFlagName:       {"events.jsonl"},
+				eventAttributeFlagName: {"missing-delimiter"},
+			},
+			wantErr: "expected non-empty key=value",
+		},
+		{
+			name: "duplicate attribute",
+			values: map[string][]string{
+				eventLogFlagName:       {"events.jsonl"},
+				eventAttributeFlagName: {"com.example.build_id=1", "com.example.build_id=2"},
+			},
+			wantErr: "duplicate --event-attribute key",
+		},
+		{
+			name: "reserved attribute",
+			values: map[string][]string{
+				eventLogFlagName:       {"events.jsonl"},
+				eventAttributeFlagName: {"skill-up.internal=value"},
+			},
+			wantErr: "reserved skill-up namespace",
+		},
+		{
+			name: "valid",
+			values: map[string][]string{
+				eventLogFlagName: {"events.jsonl"},
+				eventAttributeFlagName: {
+					"com.example.build_id=build=1",
+					"com.example.retry=2",
+				},
+			},
+			wantPath: "events.jsonl",
+			wantAttrs: map[string]string{
+				"com.example.build_id": "build=1",
+				"com.example.retry":    "2",
+			},
+			wantEnable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checkEvaluationEventOptions(t, tt)
+		})
+	}
+}
+
+func checkEvaluationEventOptions(t *testing.T, tt evaluationEventOptionsTestCase) {
+	t.Helper()
+	cmd := newEvaluationEventFlagCommand()
+	for name, values := range tt.values {
+		for _, value := range values {
+			if err := cmd.Flags().Set(name, value); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	got, err := evaluationEventOptionsFromFlags(cmd)
+	if tt.wantErr != "" {
+		if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+			t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Enabled != tt.wantEnable || got.Path != tt.wantPath {
+		t.Fatalf("options = %+v, want enabled=%t path=%q", got, tt.wantEnable, tt.wantPath)
+	}
+	if len(got.Attributes) != len(tt.wantAttrs) {
+		t.Fatalf("attributes = %v, want %v", got.Attributes, tt.wantAttrs)
+	}
+	for key, value := range tt.wantAttrs {
+		if got.Attributes[key] != value {
+			t.Errorf("attribute %q = %q, want %q", key, got.Attributes[key], value)
+		}
+	}
+}
+
+func newEvaluationEventFlagCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "run"}
+	cmd.Flags().String(eventLogFlagName, "", "")
+	cmd.Flags().StringArray(eventAttributeFlagName, nil, "")
+	return cmd
+}
+
+func TestValidateEvaluationEventLogPathSafePath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(workspace, "events.jsonl")
+	got, err := validateEvaluationEventLogPath(path, eventPathTestPlan(workspace))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(resolvedWorkspace, "events.jsonl")
+	if got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
+func TestValidateEvaluationEventLogPathMissingParent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	_, err := validateEvaluationEventLogPath(
+		filepath.Join(root, "missing", "events.jsonl"),
+		eventPathTestPlan(workspace),
+	)
+	if err == nil || !strings.Contains(err.Error(), "parent directory") {
+		t.Fatalf("error = %v, want missing parent error", err)
+	}
+}
+
+func TestValidateEvaluationEventLogPathInsideIteration(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	iteration := filepath.Join(workspace, "iteration-1")
+	if err := os.MkdirAll(iteration, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := validateEvaluationEventLogPath(filepath.Join(iteration, "events.jsonl"), eventPathTestPlan(workspace))
+	if err == nil || !strings.Contains(err.Error(), "inside scheduled iteration directory") {
+		t.Fatalf("error = %v, want iteration conflict", err)
+	}
+}
+
+func TestValidateEvaluationEventLogPathWorkspaceCollision(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	_, err := validateEvaluationEventLogPath(workspace, eventPathTestPlan(workspace))
+	if err == nil || !strings.Contains(err.Error(), "conflicts with the evaluation workspace") {
+		t.Fatalf("error = %v, want workspace conflict", err)
+	}
+}
+
+func TestValidateEvaluationEventLogPathSymlinkIntoIteration(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires additional privileges on Windows")
+	}
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	iteration := filepath.Join(workspace, "iteration-1")
+	if err := os.MkdirAll(iteration, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(root, "alias")
+	if err := os.Symlink(iteration, alias); err != nil {
+		t.Fatal(err)
+	}
+	_, err := validateEvaluationEventLogPath(filepath.Join(alias, "events.jsonl"), eventPathTestPlan(workspace))
+	if err == nil || !strings.Contains(err.Error(), "inside scheduled iteration directory") {
+		t.Fatalf("error = %v, want symlink iteration conflict", err)
+	}
+}
+
+func eventPathTestPlan(workspace string) runner.ExecutionPlan {
+	return runner.ExecutionPlan{
+		WorkspaceDir: workspace,
+		TaskPlan: evaluator.Plan{Iterations: []evaluator.IterationPlan{
+			{Number: 1},
+		}},
+	}
+}
+
+func TestStartEvaluationEventStreamValidatesBeforeTruncating(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	const original = "keep me\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := startEvaluationEventStream(
+		context.Background(),
+		path,
+		nil,
+		evalevent.Plan{},
+		"test-engine",
+		"test-skill",
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid event plan") {
+		t.Fatalf("error = %v, want invalid plan", err)
+	}
+	content, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(content) != original {
+		t.Fatalf("event log was truncated: %q", content)
+	}
+}
+
+func TestRunEvalRejectsDryRunBeforeOpeningEventLog(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	const original = "existing stream\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newRunPhaseTestCommand(t)
+	if err := cmd.Flags().Set("dry-run", testFlagBoolTrue); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set(eventLogFlagName, path); err != nil {
+		t.Fatal(err)
+	}
+	err := runEval(cmd, []string{testEvalPath})
+	if err == nil || !strings.Contains(err.Error(), "--event-log cannot be used with --dry-run") {
+		t.Fatalf("error = %v, want dry-run conflict", err)
+	}
+	content, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(content) != original {
+		t.Fatalf("event log was modified: %q", content)
+	}
+}
+
+func TestEvaluationEventStreamContinuesStateAfterSinkFailure(t *testing.T) {
+	t.Parallel()
+
+	sink := &failOnPublishSink{failAt: 3}
+	publisher, err := evalevent.NewPublisher(evalevent.PublisherConfig{Sink: sink})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := evalevent.Plan{Iterations: []evalevent.Iteration{{
+		Number: 1,
+		Tasks: []evalevent.Task{{
+			ID:            "task-1",
+			Iteration:     1,
+			CaseID:        "case-1",
+			Configuration: evalevent.ConfigurationWithSkill,
+			Index:         1,
+			Title:         "Case 1",
+		}},
+	}}}
+	lifecycle, err := evalevent.NewLifecycle(publisher, plan, evalevent.LifecycleOptions{HeartbeatInterval: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := &evaluationEventAdapter{lifecycle: lifecycle}
+	stream := &evaluationEventStream{publisher: publisher, lifecycle: lifecycle, adapter: adapter}
+	ctx := context.Background()
+	if err := lifecycle.Start(ctx, "test-engine", "test-skill"); err != nil {
+		t.Fatal(err)
+	}
+
+	iteration := evaluator.IterationPlan{Number: 1}
+	task := evaluator.PlannedTask{ID: "task-1"}
+	adapter.setPhase(ctx, evalevent.RunPhaseExecuting)
+	adapter.OnIterationStart(ctx, iteration)
+	adapter.OnTaskStart(ctx, task)
+	adapter.OnTaskComplete(ctx, task, evaluator.EvalResult{
+		Status: judge.StatusPass,
+		Grading: &judge.Result{Summary: judge.ResultSummary{
+			PassRate: 1,
+		}},
+	})
+	adapter.OnIterationComplete(ctx, iteration, nil)
+
+	err = stream.finish(ctx, evalevent.RunStatusCompleted)
+	if err == nil || !strings.Contains(err.Error(), "forced event write failure") {
+		t.Fatalf("finish error = %v, want sink failure", err)
+	}
+	if strings.Count(err.Error(), "publish run_progress event") != 1 {
+		t.Fatalf("sink failure was aggregated more than once: %v", err)
+	}
+	if sink.publishCount() != 3 {
+		t.Fatalf("publish attempts = %d, want 3", sink.publishCount())
+	}
+}
+
+func TestEvaluationEventAdapterCanFinalizeAfterInvocationCancellation(t *testing.T) {
+	t.Parallel()
+
+	sink := &failOnPublishSink{}
+	publisher, err := evalevent.NewPublisher(evalevent.PublisherConfig{Sink: sink})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := evalevent.Plan{Iterations: []evalevent.Iteration{{
+		Number: 1,
+		Tasks: []evalevent.Task{{
+			ID:            "task-1",
+			Iteration:     1,
+			CaseID:        "case-1",
+			Configuration: evalevent.ConfigurationWithSkill,
+			Index:         1,
+		}},
+	}}}
+	lifecycle, err := evalevent.NewLifecycle(publisher, plan, evalevent.LifecycleOptions{HeartbeatInterval: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := &evaluationEventAdapter{lifecycle: lifecycle}
+	stream := &evaluationEventStream{publisher: publisher, lifecycle: lifecycle, adapter: adapter}
+	if err := lifecycle.Start(context.Background(), "test-engine", "test-skill"); err != nil {
+		t.Fatal(err)
+	}
+
+	cancelledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	iteration := evaluator.IterationPlan{Number: 1}
+	task := evaluator.PlannedTask{ID: "task-1"}
+	adapter.setPhase(cancelledContext, evalevent.RunPhaseExecuting)
+	adapter.OnIterationStart(cancelledContext, iteration)
+	adapter.OnTaskStart(cancelledContext, task)
+	adapter.OnTaskComplete(cancelledContext, task, evaluator.EvalResult{Status: judge.StatusError})
+	adapter.OnIterationComplete(cancelledContext, iteration, nil)
+
+	if err := stream.finish(context.WithoutCancel(cancelledContext), evalevent.RunStatusCancelled); err != nil {
+		t.Fatal(err)
+	}
+	if sink.publishCount() != 11 {
+		t.Fatalf("published events = %d, want 11", sink.publishCount())
+	}
+}
+
+type failOnPublishSink struct {
+	mu       sync.Mutex
+	failAt   int
+	writes   int
+	closed   bool
+	closeErr error
+}
+
+func (s *failOnPublishSink) Publish(_ context.Context, _ evalevent.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.writes++
+	if s.writes == s.failAt {
+		return errors.New("forced event write failure")
+	}
+	return nil
+}
+
+func (s *failOnPublishSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return s.closeErr
+}
+
+func (s *failOnPublishSink) publishCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.writes
+}
+
+func TestEvaluationEventPlan(t *testing.T) {
+	t.Parallel()
+
+	caseConfig := &config.CaseConfig{ID: "case-1", Title: "Case 1"}
+	taskPlan := evaluator.BuildPlan(
+		[]*config.CaseConfig{caseConfig},
+		3,
+		2,
+		[]string{evaluator.ConfigurationWithSkill, evaluator.ConfigurationWithoutSkill},
+	)
+	got, err := evaluationEventPlan(runner.ExecutionPlan{TaskPlan: taskPlan})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Iterations) != 2 || got.Iterations[0].Number != 3 || got.Iterations[1].Number != 4 {
+		t.Fatalf("iterations = %+v", got.Iterations)
+	}
+	if len(got.Iterations[0].Tasks) != 2 || got.Iterations[0].Tasks[0].Index != 1 || got.Iterations[1].Tasks[1].Index != 4 {
+		t.Fatalf("tasks = %+v", got.Iterations)
+	}
+	if got.Iterations[0].Tasks[1].Configuration != evalevent.ConfigurationWithoutSkill {
+		t.Fatalf("configuration = %q", got.Iterations[0].Tasks[1].Configuration)
+	}
+}
+
+func TestEvaluationEventPlanRejectsInconsistentTaskMetadata(t *testing.T) {
+	t.Parallel()
+
+	caseConfig := &config.CaseConfig{ID: "case-1"}
+	taskPlan := evaluator.BuildPlan(
+		[]*config.CaseConfig{caseConfig},
+		1,
+		1,
+		[]string{evaluator.ConfigurationWithSkill},
+	)
+	taskPlan.Iterations[0].Tasks[0].Iteration = 2
+	_, err := evaluationEventPlan(runner.ExecutionPlan{TaskPlan: taskPlan})
+	if err == nil || !strings.Contains(err.Error(), "does not match iteration") {
+		t.Fatalf("error = %v, want iteration mismatch", err)
+	}
+}
+
+func TestEventRunStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		cancelledContext bool
+		err              error
+		want             evalevent.RunStatus
+	}{
+		{name: "completed", want: evalevent.RunStatusCompleted},
+		{name: "error", err: errors.New("boom"), want: evalevent.RunStatusError},
+		{name: "cancelled error", err: context.Canceled, want: evalevent.RunStatusCancelled},
+		{name: "cancelled context", cancelledContext: true, want: evalevent.RunStatusCancelled},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			if tt.cancelledContext {
+				cancelled, cancel := context.WithCancel(ctx)
+				cancel()
+				ctx = cancelled
+			}
+			if got := eventRunStatus(ctx, tt.err); got != tt.want {
+				t.Fatalf("status = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -59,6 +59,8 @@ func newRunPhaseTestCommand(t *testing.T) *cobra.Command {
 	cmd.Flags().Int("iteration", 0, "")
 	cmd.Flags().Bool("no-delete", false, "")
 	cmd.Flags().Bool("dry-run", false, "")
+	cmd.Flags().String(eventLogFlagName, "", "")
+	cmd.Flags().StringArray(eventAttributeFlagName, nil, "")
 	return cmd
 }
 

--- a/internal/evalevent/lifecycle.go
+++ b/internal/evalevent/lifecycle.go
@@ -92,6 +92,18 @@ type lifecycleIteration struct {
 	completedN uint64
 }
 
+// ValidatePlan validates an immutable lifecycle plan without opening a Sink.
+func ValidatePlan(plan Plan) error {
+	tasks, iterations, taskTotal, err := snapshotPlan(plan)
+	if err != nil {
+		return err
+	}
+	if uint64(len(tasks)) != taskTotal || len(iterations) != len(plan.Iterations) {
+		return errors.New("validated plan snapshot is inconsistent")
+	}
+	return nil
+}
+
 // NewLifecycle validates and snapshots a plan without importing runner or evaluator types.
 func NewLifecycle(publisher *Publisher, plan Plan, opts LifecycleOptions) (*Lifecycle, error) {
 	if publisher == nil {

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -207,6 +207,9 @@ func (e *defaultEvaluator) EvaluatePlan(ctx context.Context, tasks []PlannedTask
 		attribute.Bool("skill_up.baseline.enabled", e.withBaseline),
 	)
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if e.ag != nil {
 		if err := e.ag.CheckCredentials(ctx); err != nil {
 			return nil, fmt.Errorf("agent credential check failed: %w", err)
@@ -218,10 +221,28 @@ func (e *defaultEvaluator) EvaluatePlan(ctx context.Context, tasks []PlannedTask
 	totalCases := len(tasks)
 
 	var wg sync.WaitGroup
+	scheduled := 0
+
+scheduleTasks:
 	for i, t := range tasks {
-		wg.Add(1)
-		sem <- struct{}{}
+		if ctx.Err() != nil {
+			break
+		}
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			break scheduleTasks
+		}
+		// If cancellation raced with acquiring a slot, return it without
+		// launching another task.
+		if ctx.Err() != nil {
+			<-sem
+			break
+		}
+
 		caseNum := i + 1
+		wg.Add(1)
+		scheduled++
 		go func(idx int, plannedTask PlannedTask, cn int) {
 			defer wg.Done()
 			defer func() { <-sem }()
@@ -247,6 +268,10 @@ func (e *defaultEvaluator) EvaluatePlan(ctx context.Context, tasks []PlannedTask
 	}
 	wg.Wait()
 
+	results = results[:scheduled]
+	if err := ctx.Err(); err != nil {
+		return results, err
+	}
 	return results, nil
 }
 

--- a/internal/evaluator/plan_test.go
+++ b/internal/evaluator/plan_test.go
@@ -2,6 +2,7 @@ package evaluator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -150,9 +151,61 @@ func TestEvaluatePlanNotifiesTaskAndProgressObservers(t *testing.T) {
 	}
 }
 
+func TestEvaluatePlanStopsSchedulingAfterCancellation(t *testing.T) {
+	t.Parallel()
+
+	cases := []*config.CaseConfig{
+		{ID: "case-1", Title: "Case 1", Input: config.Input{Prompt: "one"}},
+		{ID: "case-2", Title: "Case 2", Input: config.Input{Prompt: "two"}},
+		{ID: "case-3", Title: "Case 3", Input: config.Input{Prompt: "three"}},
+	}
+	plan := BuildPlan(cases, 1, 1, []string{ConfigurationWithSkill})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	taskObserver := &cancelOnFirstTaskStartObserver{
+		recordingTaskObserver: &recordingTaskObserver{},
+		cancel:                cancel,
+	}
+	e := newTestEvaluator(EvalOptions{
+		Concurrency: 1,
+		Agent:       &mockAgent{name: "test", output: "ok"},
+		EvalCfg: &config.EvalConfig{
+			Environment: config.Environment{Type: "none"},
+		},
+		TaskObserver: taskObserver,
+	})
+
+	results, err := e.EvaluatePlan(ctx, plan.Iterations[0].Tasks)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("EvaluatePlan error = %v, want context.Canceled", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want only the scheduled task", len(results))
+	}
+	wantTaskEvents := []string{
+		"start:task-1:1:with_skill",
+		"complete:task-1:1:with_skill",
+	}
+	if got := taskObserver.snapshot(); !equalStrings(got, wantTaskEvents) {
+		t.Fatalf("task events = %v, want %v", got, wantTaskEvents)
+	}
+}
+
 type recordingTaskObserver struct {
 	mu     sync.Mutex
 	events []string
+}
+
+type cancelOnFirstTaskStartObserver struct {
+	*recordingTaskObserver
+
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (o *cancelOnFirstTaskStartObserver) OnTaskStart(_ context.Context, task PlannedTask) {
+	o.record("start", task)
+	o.once.Do(o.cancel)
 }
 
 func (o *recordingTaskObserver) OnTaskStart(_ context.Context, task PlannedTask) {

--- a/internal/runner/execution_plan_test.go
+++ b/internal/runner/execution_plan_test.go
@@ -2,9 +2,11 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 
@@ -118,6 +120,72 @@ func TestEvaluatePlanForwardsIterationAndGlobalTaskBoundaries(t *testing.T) {
 	}
 }
 
+func TestEvaluatePlanStopsBeforeFutureIterationAfterCancellation(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "test-skill")
+	evalsDir := filepath.Join(skillDir, "evals")
+	if err := os.MkdirAll(evalsDir, 0o755); err != nil {
+		t.Fatalf("create evals directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: test-skill\n---\n"), 0o600); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	workspaceDir := filepath.Join(root, "workspace")
+	futureArtifact := filepath.Join(workspaceDir, "iteration-2", "keep.txt")
+	if err := os.MkdirAll(filepath.Dir(futureArtifact), 0o755); err != nil {
+		t.Fatalf("create future iteration directory: %v", err)
+	}
+	if err := os.WriteFile(futureArtifact, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write future iteration artifact: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	origNewEvaluator := newEvaluator
+	t.Cleanup(func() { newEvaluator = origNewEvaluator })
+	evaluateCalls := 0
+	newEvaluator = func(evaluator.EvalOptions) evaluator.Evaluator {
+		return evaluatorStub{evaluateAll: func(context.Context, []*config.CaseConfig) ([]evaluator.EvalResult, error) {
+			evaluateCalls++
+			cancel()
+			return []evaluator.EvalResult{{CaseID: "case-1", Configuration: evaluator.ConfigurationWithSkill}}, nil
+		}}
+	}
+
+	r := NewRunner(&config.EvalConfig{
+		Environment: config.Environment{Type: "none"},
+		Cases:       config.CasesConfig{Parallelism: 1},
+	}, config.NewLoader(filepath.Join(evalsDir, "eval.yaml")), nil, credential.ResolvedAgentConfig{})
+	observer := &recordingExecutionObserver{}
+	opts := EvaluateOptions{
+		OutputDir:         workspaceDir,
+		Iteration:         2,
+		IterationObserver: observer,
+	}
+	plan := r.BuildExecutionPlan([]*config.CaseConfig{{
+		ID:    "case-1",
+		Title: "Case 1",
+	}}, opts)
+
+	results, err := r.EvaluatePlan(ctx, plan, &runnerTestAgent{}, opts)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("EvaluatePlan error = %v, want context.Canceled", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("len(results) = %d, want no completed iterations", len(results))
+	}
+	if evaluateCalls != 1 {
+		t.Fatalf("evaluator calls = %d, want 1", evaluateCalls)
+	}
+	if got, want := observer.snapshot(), []string{"iteration-start:1"}; !equalStringSlices(got, want) {
+		t.Fatalf("observer events = %v, want %v", got, want)
+	}
+	if data, readErr := os.ReadFile(futureArtifact); readErr != nil || string(data) != "keep" {
+		t.Fatalf("future iteration artifact changed: data=%q err=%v", data, readErr)
+	}
+}
+
 type recordingExecutionObserver struct {
 	mu     sync.Mutex
 	events []string
@@ -152,13 +220,5 @@ func (o *recordingExecutionObserver) snapshot() []string {
 }
 
 func equalStringSlices(got, want []string) bool {
-	if len(got) != len(want) {
-		return false
-	}
-	for i := range got {
-		if got[i] != want[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(got, want)
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -93,11 +93,17 @@ func (r *Runner) InitWorkspace(outputDir, skillName string, iteration int) error
 }
 
 func (r *Runner) setupWorkspace(ctx context.Context, outputDir, skillName string, iteration int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	ws, err := report.NewIterationWorkspace(outputDir, skillName, iteration)
 	if err != nil {
 		return fmt.Errorf("failed to create iteration workspace: %w", err)
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := os.RemoveAll(ws.IterationDir()); err != nil {
 		return fmt.Errorf("failed to clean iteration workspace: %w", err)
 	}
@@ -183,6 +189,9 @@ func (r *Runner) EvaluatePlan(ctx context.Context, plan ExecutionPlan, ag agent.
 	)
 	allResults := make([]evaluator.EvalResult, 0, plan.TaskPlan.TaskTotal)
 	for _, iteration := range plan.TaskPlan.Iterations {
+		if err := ctx.Err(); err != nil {
+			return allResults, err
+		}
 		iterationStartTime := r.now()
 		runNumber := iteration.Number
 		if err := r.setupWorkspace(ctx, plan.WorkspaceDir, plan.SkillName, runNumber); err != nil {
@@ -217,6 +226,9 @@ func (r *Runner) EvaluatePlan(ctx context.Context, plan ExecutionPlan, ag agent.
 
 		results, err := ev.EvaluatePlan(ctx, iteration.Tasks)
 		if err != nil {
+			return allResults, err
+		}
+		if err := ctx.Err(); err != nil {
 			return allResults, err
 		}
 		if opts.IterationObserver != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -46,6 +46,28 @@ func TestRunner_InitWorkspace(t *testing.T) {
 	}
 }
 
+func TestRunner_SetupWorkspacePreservesArtifactsWhenCancelled(t *testing.T) {
+	r := NewRunner(&config.EvalConfig{}, nil, nil, credential.ResolvedAgentConfig{})
+	tmpDir := t.TempDir()
+	artifactPath := filepath.Join(tmpDir, "iteration-1", "keep.txt")
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		t.Fatalf("create iteration directory: %v", err)
+	}
+	if err := os.WriteFile(artifactPath, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := r.setupWorkspace(ctx, tmpDir, "test-skill", 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("setupWorkspace error = %v, want context.Canceled", err)
+	}
+	if data, readErr := os.ReadFile(artifactPath); readErr != nil || string(data) != "keep" {
+		t.Fatalf("artifact changed after cancelled setup: data=%q err=%v", data, readErr)
+	}
+}
+
 func TestRunner_WriteResults_WithSkillOnly(t *testing.T) {
 	r := NewRunner(&config.EvalConfig{}, nil, nil, credential.ResolvedAgentConfig{})
 


### PR DESCRIPTION
## Summary

- add opt-in --event-log output and repeatable --event-attribute metadata
- connect the deterministic execution plan and runner observers to the evaluation event lifecycle
- validate output paths before opening the JSONL file and preserve graceful finalization on cancellation
- document the CLI contract and add unit and end-to-end coverage

## Compatibility

The existing evaluation path is unchanged when --event-log is omitted. No event objects, files, or heartbeat work are created in that mode, and existing stdout, reports, and exit behavior are preserved.

When event output is enabled, sink errors are returned with the command result according to SUP-0005.

## Testing

- make fmt
- make verify
- env -u QODER_PERSONAL_ACCESS_TOKEN make test
- env -u QODER_PERSONAL_ACCESS_TOKEN make GOFLAGS="-buildvcs=false -parallel=1" e2e

Builds on #228 and #229.
Addresses #206.