### PR TITLE
test(e2e): account for static agent preflight

### DIFF
--- a/e2e/event_log_signal_unix_test.go
+++ b/e2e/event_log_signal_unix_test.go
@@ -336,6 +336,10 @@ func baselineSignalEngineEnv(t *testing.T) []string {
 	}
 	engineScript := `#!/bin/bash
 set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  printf '%s\n' 'qodercli 0.0.0-test'
+  exit 0
+fi
 state_file="${MOCK_STATE_FILE:?}"
 call_number=1
 if [[ -f "$state_file" ]]; then


### PR DESCRIPTION
## Summary
- make the stateful baseline-cancellation Qoder mock answer `--version` without advancing its agent-call counter
- keep the first real agent call immediate and the baseline call blocking for cancellation coverage

## Why
PR #233 added a static version preflight before each case. The fixture counted that inspection as an agent invocation, so the with-skill run slept and the test timed out before the baseline phase.

## Verification
- `go test -tags e2e -v ./e2e -run '^TestEventLogSignalDuringBaselineReturnsNonZero$' -count=1`\n- `make verify`\n- `make test`\n- `make test-action`\n- `make build`\n- `go test -tags e2e -v -parallel 1 ./e2e`\n\nFollow-up to #233.