### PR TITLE
docs: prepare v0.11.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.0] - 2026-09-10
+## [0.11.0] - 2026-09-11
 
 ### Added
 - `skill-up run` now supports `--event-log <path>` for a live, ordered v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-09-10
+
 ### Added
 - `skill-up run` now supports `--event-log <path>` for a live, ordered v1
   JSONL evaluation event stream and repeatable `--event-attribute <key=value>`
@@ -556,6 +558,7 @@ The `v0.5.0` release tag is available at
   project and delivers the end-to-end capability to declare eval environments,
   run cases and emit structured reports as described in [README.md](README.md).
 
+[0.11.0]: https://github.com/alibaba/skill-up/releases/tag/v0.11.0
 [0.10.0]: https://github.com/alibaba/skill-up/releases/tag/v0.10.0
 [0.9.1]: https://github.com/alibaba/skill-up/releases/tag/v0.9.1
 [0.9.0]: https://github.com/alibaba/skill-up/releases/tag/v0.9.0


### PR DESCRIPTION
## Summary

- promote the current Unreleased entries into `v0.11.0` dated 2026-09-11
- include the QoderCLI SDK-environment isolation from #242
- add the `v0.11.0` release link

## Release scope

- live JSONL evaluation event logs and invocation correlation attributes
- static agent binary and version preflight with observed version reporting
- protocol-aware model connections and provider-isolated judge credentials
- QoderCLI isolation from an inherited `QODER_AGENT_SDK_ENTRYPOINT`, keeping version checks, runs, resumes, and MCP commands on the ordinary CLI protocol

## Final release candidate

SHA: `ff99094414e9c95a9fb802d09eb62490e07952e4`

## Validation completed

- `make verify`
- `make test`
- `make test-action`
- `make build`
- `make e2e`
- `git diff --check`
- [Extended CI](https://github.com/alibaba/skill-up/actions/runs/34579972209): deterministic Windows E2E, Docker integration, and GoReleaser snapshot
- [Default Linux Model E2E](https://github.com/alibaba/skill-up/actions/runs/34580272673): credentialed none-runtime full-mode suite
- [Windows Model E2E](https://github.com/alibaba/skill-up/actions/runs/34580769013): credentialed live Claude token-usage suite

## Before tagging

- [x] include the E2E preflight fixture fix from #237
- [x] include the Windows mock portability fix from #239
- [x] include #242 and sync `release/v0.11.0` with the resulting `main`
- [x] move the #242 changelog entry into the `v0.11.0` section and finalize the release date
- [x] require the deterministic Extended CI suite to pass on the final release commit
- [x] run credentialed default Linux and Windows Model E2E on the final release commit

All release gates are complete. Release tagging remains maintainer-owned.