### PR TITLE
fix(e2e): restore Windows mock runner

### DIFF
--- a/e2e/pipeline_test.go
+++ b/e2e/pipeline_test.go
@@ -57,7 +57,7 @@ func mockEngineEnv(t *testing.T, extra ...string) []string {
 	t.Helper()
 	home, binDir := mockEngineHome(t)
 	env := []string{
-		"PATH=" + binDir + ":" + os.Getenv("PATH"),
+		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
 		"HOME=" + home,
 	}
 	env = append(env, extra...)

--- a/e2e/testdata/mock-engine/engine.sh
+++ b/e2e/testdata/mock-engine/engine.sh
@@ -31,6 +31,25 @@ set -euo pipefail
 
 PROMPT=""
 
+build_judge_results() {
+  local include_passed="$1"
+  local evidence="$2"
+  awk -v include_passed="$include_passed" -v evidence="$evidence" '
+    BEGIN { printf "{\"results\":[" }
+    NF {
+      if (count++ > 0) {
+        printf ","
+      }
+      printf "{\"criterion_id\":\"%s\"", $0
+      if (include_passed == "1") {
+        printf ",\"passed\":true"
+      }
+      printf ",\"evidence\":[\"%s\"],\"failures\":[]}", evidence
+    }
+    END { print "]}" }
+  '
+}
+
 # Parse arguments - qodercli/claude pass: -p "<prompt>". Any other flags
 # (e.g. qwen's --yolo / -m <model>) are skipped harmlessly.
 while [[ $# -gt 0 ]]; do
@@ -88,13 +107,11 @@ if [[ "${MOCK_JUDGE_CORRECTION_RETRY:-}" == "1" ]] && echo "$PROMPT" | grep -q "
   if [[ -n "${MOCK_JUDGE_STATE_FILE:-}" ]]; then
     echo "correction" >> "$MOCK_JUDGE_STATE_FILE"
   fi
-  JSON_RESULTS=$(printf '%s' "$PROMPT" | python3 -c '
-import json, re, sys
-prompt = sys.stdin.read()
-ids = list(dict.fromkeys(re.findall(r"criterion_id\"\s*:\s*\"(criterion-[0-9]+)\"", prompt)))
-items = [{"criterion_id": criterion_id, "passed": True, "evidence": ["Mock engine corrected the response contract"], "failures": []} for criterion_id in ids]
-print(json.dumps({"results": items}))
-')
+  JSON_RESULTS=$(printf '%s' "$PROMPT" |
+    { grep -oE 'criterion_id"[[:space:]]*:[[:space:]]*"criterion-[0-9]+"' || true; } |
+    sed -E 's/.*"(criterion-[0-9]+)"/\1/' |
+    awk '!seen[$0]++' |
+    build_judge_results 1 "Mock engine corrected the response contract")
   echo "$JSON_RESULTS"
   exit "${MOCK_EXIT_CODE:-0}"
 fi
@@ -104,29 +121,18 @@ fi
 # We parse the stable criterion IDs and return a valid JSON response so that
 # agent_judge can succeed in mock/CI scenarios without a real LLM.
 if echo "$PROMPT" | grep -q "Required Response Format" && echo "$PROMPT" | grep -q "## Criteria"; then
-  # Build JSON using python3 for correct escaping of all special characters
-  # (quotes, backslashes, control chars, Unicode, etc.).
-  JSON_RESULTS=$(echo "$PROMPT" | grep -E '^\[criterion-[0-9]+\][[:space:]]+' | python3 -c '
-import json, sys
-items = []
-for line in sys.stdin:
-    text = line.strip()
-    close = text.find("]")
-    criterion_id = text[1:close]
-    items.append({"criterion_id": criterion_id, "passed": True, "evidence": ["Mock engine: criterion satisfied based on agent output analysis"], "failures": []})
-print(json.dumps({"results": items}))
-')
+  JSON_RESULTS=$(printf '%s\n' "$PROMPT" |
+    { grep -E '^\[criterion-[0-9]+\][[:space:]]+' || true; } |
+    sed -E 's/^\[([^]]+)\].*/\1/' |
+    build_judge_results 1 "Mock engine: criterion satisfied based on agent output analysis")
   if [[ "${MOCK_JUDGE_CORRECTION_RETRY:-}" == "1" ]]; then
     if [[ -n "${MOCK_JUDGE_STATE_FILE:-}" ]]; then
       echo "initial" >> "$MOCK_JUDGE_STATE_FILE"
     fi
-    JSON_RESULTS=$(printf '%s' "$JSON_RESULTS" | python3 -c '
-import json, sys
-payload = json.load(sys.stdin)
-for item in payload["results"]:
-    item.pop("passed", None)
-print(json.dumps(payload))
-')
+    JSON_RESULTS=$(printf '%s\n' "$PROMPT" |
+      { grep -E '^\[criterion-[0-9]+\][[:space:]]+' || true; } |
+      sed -E 's/^\[([^]]+)\].*/\1/' |
+      build_judge_results 0 "Mock engine: criterion satisfied based on agent output analysis")
   fi
   echo "$JSON_RESULTS"
   exit "${MOCK_EXIT_CODE:-0}"


### PR DESCRIPTION
## Summary

- use Go platform path separator when adding mock agent binaries to PATH
- replace the mock judge Python dependency with portable shell JSON generation
- restore Windows none-runtime E2E after static preflight was introduced

## Root cause

The shared E2E helper joined PATH entries with a hard-coded colon. Windows requires a semicolon, so preflight could not find the qodercli and qwen mock executables. After fixing discovery, the real runner exposed a second dependency: the deterministic mock judge invoked python3, which is not available on the trusted Windows runner.

## Validation

- make verify
- make test
- make test-action
- full E2E with cache disabled
- targeted mock judge correction E2E with cache disabled
- Windows amd64 E2E test package cross-compilation
- bash -n e2e/testdata/mock-engine/engine.sh
- git diff --check

## Evidence

- original failure: https://github.com/alibaba/skill-up/actions/runs/34450270198
- PATH fix canary: https://github.com/alibaba/skill-up/actions/runs/34452413758
- discarded setup-python canary: https://github.com/alibaba/skill-up/actions/runs/34453454311

Pairs with release PR #238.