### PR TITLE
ci: require the deterministic E2E suite on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
   # Required checks must also run for commits synthesized by Merge Queue.
   merge_group:
 
-# Keep the default gate small and cancel only superseded pull-request work.
-# Expensive engine, sandbox, Windows and release checks live in extended-ci.yml.
+# Keep live engine, sandbox, Windows and release checks outside the default gate,
+# and cancel only superseded pull-request work.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -107,6 +107,7 @@ jobs:
           fi
           echo "::notice::Total coverage: ${pct}%"
 
+  # Keep the displayed name stable because repository rulesets require it.
   e2e-smoke:
     name: E2E Smoke
     needs: classify
@@ -127,8 +128,8 @@ jobs:
           go-version: "1.25.x"
           cache: true
 
-      - name: Run quick e2e smoke
-        run: go test -tags e2e -timeout 1200s -count=1 -v -run 'Test(Pipeline|CLI|Contract|NoneRuntime)_' ./e2e
+      - name: Run deterministic e2e suite
+        run: go test -tags e2e -timeout 1200s -count=1 -v ./e2e
         env:
           SKILL_UP_E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts
 

--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -232,6 +232,7 @@ jobs:
         if: steps.secrets.outputs.available == 'true'
         run: go test -tags e2e -timeout 1800s -count=1 -v -run TestAgent_Codex_OpenSandboxRuntime ./e2e
         env:
+          SKILL_UP_FULL_E2E: "1"
           OPENAI_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
           OPENAI_BASE_URL: https://dashscope.aliyuncs.com/compatible-mode/v1
           OPENAI_MODEL: qwen3.6-plus

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -660,6 +660,7 @@ expect:
 // TestAgent_Codex_NoneRuntime tests codex agent with none runtime.
 func TestAgent_Codex_NoneRuntime(t *testing.T) {
 	t.Parallel()
+	skipIfNotFullE2E(t)
 	if !isCodexInstalled() {
 		t.Skip("codex not installed locally")
 	}
@@ -751,6 +752,7 @@ report:
 }
 
 func TestAgent_Codex_OpenSandboxRuntime(t *testing.T) {
+	skipIfNotFullE2E(t)
 
 	sandboxAPIKey := openSandboxE2EAPIKey()
 	if sandboxAPIKey == "" {
@@ -873,6 +875,8 @@ func isOpenSandboxReadyFailure(stderr string) bool {
 // against a real OpenSandbox runtime. Mirrors TestAgent_Codex_OpenSandboxRuntime
 // so both supported engines have end-to-end coverage of the opensandbox bridge.
 func TestAgent_ClaudeCode_OpenSandboxRuntime(t *testing.T) {
+	skipIfNotFullE2E(t)
+
 	// No skipIfClaudeUnavailable here: the opensandbox runtime bootstraps the
 	// claude CLI inside the sandbox, so the host runner does not need it.
 	sandboxAPIKey := openSandboxE2EAPIKey()
@@ -1595,6 +1599,7 @@ judge:
 // This verifies skill installation and engine invocation work correctly.
 func TestAgent_QoderCLI_NoneRuntime_FullRun(t *testing.T) {
 	t.Parallel()
+	skipIfNotFullE2E(t)
 	if !isQoderCLIInstalled() {
 		t.Skip("qodercli not installed locally")
 	}
@@ -1718,6 +1723,7 @@ expect:
 // Mirrors TestAgent_QoderCLI_NoneRuntime_FullRun.
 func TestAgent_QwenCode_NoneRuntime_FullRun(t *testing.T) {
 	t.Parallel()
+	skipIfNotFullE2E(t)
 	if !isQwenCodeInstalled() {
 		t.Skip("qwen (qwen-code) not installed locally")
 	}
@@ -2005,7 +2011,7 @@ report:
 		t.Fatalf("failed to write eval.yaml: %v", err)
 	}
 
-	result := Run(t, RunConfig{Timeout: 30e9}, "run", evalPath)
+	result := Run(t, RunConfig{Timeout: 30e9, Env: mockEngineEnv(t)}, "run", evalPath)
 
 	if result.ExitCode != 0 {
 		if !strings.Contains(result.Stderr, "evals/should/be/excluded") {

--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMCP_SandboxRealAgents(t *testing.T) {
+	skipIfNotFullE2E(t)
 	skipIfSandboxMCPUnavailable(t)
 
 	evalPath := filepath.Join(getProjectRoot(), "e2e", "testdata", "sandbox-mcp", "evals", "eval.yaml")


### PR DESCRIPTION
## Summary
- run the complete deterministic E2E suite in the required pull-request CI job instead of selecting test families by name
- consistently gate live model and OpenSandbox tests behind `SKILL_UP_FULL_E2E`
- use the mock engine for the eval-directory exclusion test so the required suite cannot consume a local CLI login
- preserve the existing `E2E Smoke` check name for repository ruleset compatibility

## Why
PR #233 added a static agent preflight that changed the invocation sequence of a stateful E2E fixture. `TestEventLogSignalDuringBaselineReturnsNonZero` detected the regression locally, but the required PR job only selected `Pipeline`, `CLI`, `Contract`, and `NoneRuntime` test names, so the event-log test was never run. PR #237 fixed that fixture; this change closes the CI coverage gap so new deterministic E2E test families are required automatically.

Live model, sandbox, Docker, and credential-backed checks remain explicit manual suites because they depend on secrets, quotas, and external services.

## Verification
- `go test -tags e2e -timeout 1200s -count=1 -v ./e2e`
- `make verify`
- `make test`
- `make test-action`
- `make build`