### PR TITLE
fix(agent): isolate qodercli from inherited SDK mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Agent judges selecting a different provider no longer inherit runner credentials
   or endpoints, preventing judge keys from being sent to a runner endpoint.
-- QoderCLI runs now clear an inherited `QODER_AGENT_SDK_ENTRYPOINT` before
-  starting the CLI, preventing SDK-hosted parent processes such as Qoder Work
-  from forcing ordinary JSON invocations into the incompatible SDK protocol.
+- QoderCLI commands now clear an inherited `QODER_AGENT_SDK_ENTRYPOINT`,
+  preventing SDK-hosted parent processes such as Qoder Work from forcing
+  ordinary version checks, runs, resumes, and MCP configuration into the
+  incompatible SDK protocol.
 
 ## [0.10.0] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Agent judges selecting a different provider no longer inherit runner credentials
   or endpoints, preventing judge keys from being sent to a runner endpoint.
+- QoderCLI runs now clear an inherited `QODER_AGENT_SDK_ENTRYPOINT` before
+  starting the CLI, preventing SDK-hosted parent processes such as Qoder Work
+  from forcing ordinary JSON invocations into the incompatible SDK protocol.
 
 ## [0.10.0] - 2026-09-01
 

--- a/internal/agent/mcp_test.go
+++ b/internal/agent/mcp_test.go
@@ -71,8 +71,8 @@ func TestBuildQoderMCPInstallCmd_Stdio(t *testing.T) {
 		t.Fatalf("buildQoderMCPInstallCmd failed: %v", err)
 	}
 	for _, want := range []string{
-		"qodercli mcp remove --scope project 'marker'",
-		"qodercli mcp add --scope project 'marker' -e 'MCP_TOKEN='\"$MCP_TOKEN\" -- 'node' '/tmp/marker-server.mjs'",
+		"env -u QODER_AGENT_SDK_ENTRYPOINT qodercli mcp remove --scope project 'marker'",
+		"env -u QODER_AGENT_SDK_ENTRYPOINT qodercli mcp add --scope project 'marker' -e 'MCP_TOKEN='\"$MCP_TOKEN\" -- 'node' '/tmp/marker-server.mjs'",
 	} {
 		if !strings.Contains(cmd, want) {
 			t.Fatalf("command missing %q:\n%s", want, cmd)
@@ -92,8 +92,8 @@ func TestBuildQoderMCPInstallCmd_CNStdio(t *testing.T) {
 		t.Fatalf("buildQoderMCPInstallCmdForBinary failed: %v", err)
 	}
 	for _, want := range []string{
-		"qodercn mcp remove --scope project 'marker'",
-		"qodercn mcp add --scope project 'marker'",
+		"env -u QODER_AGENT_SDK_ENTRYPOINT qodercn mcp remove --scope project 'marker'",
+		"env -u QODER_AGENT_SDK_ENTRYPOINT qodercn mcp add --scope project 'marker'",
 	} {
 		if !strings.Contains(cmd, want) {
 			t.Fatalf("CN command missing %q:\n%s", want, cmd)

--- a/internal/agent/qodercli.go
+++ b/internal/agent/qodercli.go
@@ -101,10 +101,10 @@ func NewQoderCLIAgent(cfg Config) *QoderCLIAgent {
 		cfg.CheckCmd = "command -v " + profile.binary
 	}
 	if cfg.VersionCmd == "" {
-		cfg.VersionCmd = profile.binary + " --version"
+		cfg.VersionCmd = qoderCLIInvocation(profile.binary) + " --version"
 	}
 	if cfg.RunCmd == "" {
-		cfg.RunCmd = profile.binary + " -p \"%s\" 2>&1"
+		cfg.RunCmd = qoderCLIInvocation(profile.binary) + " -p \"%s\" 2>&1"
 	}
 	if cfg.SkillPath == "" {
 		cfg.SkillPath = ".qoder/skills"
@@ -232,7 +232,7 @@ func buildQoderRunStdinCmdForBinary(binary, promptPath, model string) string {
 	return cmd
 }
 
-// qoderCLIInvocation prevents a nested ordinary CLI run from inheriting the
+// qoderCLIInvocation prevents a nested ordinary CLI invocation from inheriting the
 // Agent SDK marker set by hosts such as Qoder Work. A non-empty marker forces
 // qodercli into the stream-json SDK protocol, which this adapter does not use.
 func qoderCLIInvocation(binary string) string {
@@ -440,7 +440,7 @@ func buildQoderMCPInstallCmd(server runtime.MCPServerConfig) (string, error) {
 }
 
 func buildQoderMCPInstallCmdForBinary(binary string, server runtime.MCPServerConfig) (string, error) {
-	return buildClaudeCompatibleMCPInstallCmd(binary, binary, server)
+	return buildClaudeCompatibleMCPInstallCmd(qoderCLIInvocation(binary), binary, server)
 }
 
 func defaultQoderCLIInstallCmd() string {

--- a/internal/agent/qodercli.go
+++ b/internal/agent/qodercli.go
@@ -54,6 +54,7 @@ const (
 	qoderExposeTokenUsageEnv     = "QODER_EXPOSE_TOKEN_USAGE"   //nolint:gosec // environment variable name, not a credential
 	qoderCNExposeTokenUsageEnv   = "QODERCN_EXPOSE_TOKEN_USAGE" //nolint:gosec // environment variable name, not a credential
 	qoderExposeTokenUsageEnabled = "true"
+	qoderAgentSDKEntrypointEnv   = "QODER_AGENT_SDK_ENTRYPOINT"
 	qoderJSONOutputFlag          = " --output-format json"
 )
 
@@ -212,7 +213,7 @@ func buildQoderRunCmd(instruction, model string) string {
 }
 
 func buildQoderRunCmdForBinary(binary, instruction, model string) string {
-	cmd := binary + " --permission-mode=bypass_permissions" + qoderJSONOutputFlag
+	cmd := qoderCLIInvocation(binary) + " --permission-mode=bypass_permissions" + qoderJSONOutputFlag
 	if model != "" {
 		cmd += " --model " + shellQuote(model)
 	}
@@ -222,13 +223,20 @@ func buildQoderRunCmdForBinary(binary, instruction, model string) string {
 }
 
 func buildQoderRunStdinCmdForBinary(binary, promptPath, model string) string {
-	cmd := "cat " + shellQuote(promptPath) + " | " + binary + " --permission-mode=bypass_permissions" + qoderJSONOutputFlag
+	cmd := "cat " + shellQuote(promptPath) + " | " + qoderCLIInvocation(binary) + " --permission-mode=bypass_permissions" + qoderJSONOutputFlag
 	if model != "" {
 		cmd += " --model " + shellQuote(model)
 	}
 	cmd += " -p -"
 
 	return cmd
+}
+
+// qoderCLIInvocation prevents a nested ordinary CLI run from inheriting the
+// Agent SDK marker set by hosts such as Qoder Work. A non-empty marker forces
+// qodercli into the stream-json SDK protocol, which this adapter does not use.
+func qoderCLIInvocation(binary string) string {
+	return "env -u " + qoderAgentSDKEntrypointEnv + " " + binary
 }
 
 // buildQoderResumeCmd constructs a Global qodercli command that resumes an existing
@@ -238,7 +246,7 @@ func buildQoderResumeCmd(instruction, model, sessionID string) string {
 }
 
 func buildQoderResumeCmdForBinary(binary, instruction, model, sessionID string) string {
-	cmd := binary + " --permission-mode=bypass_permissions" + qoderJSONOutputFlag
+	cmd := qoderCLIInvocation(binary) + " --permission-mode=bypass_permissions" + qoderJSONOutputFlag
 	if model != "" {
 		cmd += " --model " + shellQuote(model)
 	}

--- a/internal/agent/qodercli_test.go
+++ b/internal/agent/qodercli_test.go
@@ -28,8 +28,11 @@ func TestNewQoderCLIAgent(t *testing.T) {
 	if ag.Cfg.CheckCmd != "command -v qodercli" {
 		t.Errorf("expected CheckCmd 'command -v qodercli', got %s", ag.Cfg.CheckCmd)
 	}
-	if ag.Cfg.VersionCmd != "qodercli --version" {
-		t.Errorf("expected VersionCmd 'qodercli --version', got %s", ag.Cfg.VersionCmd)
+	if ag.Cfg.VersionCmd != "env -u QODER_AGENT_SDK_ENTRYPOINT qodercli --version" {
+		t.Errorf("unexpected VersionCmd: %s", ag.Cfg.VersionCmd)
+	}
+	if ag.Cfg.RunCmd != `env -u QODER_AGENT_SDK_ENTRYPOINT qodercli -p "%s" 2>&1` {
+		t.Errorf("unexpected RunCmd: %s", ag.Cfg.RunCmd)
 	}
 
 	if ag.Cfg.SkillPath != ".qoder/skills" {
@@ -47,10 +50,10 @@ func TestNewQoderCLIAgent_CNEdition(t *testing.T) {
 	if ag.Cfg.CheckCmd != "command -v qodercn" {
 		t.Fatalf("CheckCmd = %q, want qodercn", ag.Cfg.CheckCmd)
 	}
-	if ag.Cfg.VersionCmd != "qodercn --version" {
+	if ag.Cfg.VersionCmd != "env -u QODER_AGENT_SDK_ENTRYPOINT qodercn --version" {
 		t.Fatalf("VersionCmd = %q, want qodercn", ag.Cfg.VersionCmd)
 	}
-	if ag.Cfg.RunCmd != `qodercn -p "%s" 2>&1` {
+	if ag.Cfg.RunCmd != `env -u QODER_AGENT_SDK_ENTRYPOINT qodercn -p "%s" 2>&1` {
 		t.Fatalf("RunCmd = %q, want qodercn command", ag.Cfg.RunCmd)
 	}
 	if ag.Cfg.SkillPath != ".qoder/skills" {
@@ -65,7 +68,7 @@ func TestNewQoderCLIAgent_DoesNotEnforceUnsupportedVersion(t *testing.T) {
 	if ag.Cfg.Version != "" {
 		t.Fatalf("Version = %q, want unsupported version constraint omitted", ag.Cfg.Version)
 	}
-	if ag.Cfg.VersionCmd != "qodercli --version" {
+	if ag.Cfg.VersionCmd != "env -u QODER_AGENT_SDK_ENTRYPOINT qodercli --version" {
 		t.Fatalf("VersionCmd = %q, want static version observation", ag.Cfg.VersionCmd)
 	}
 }

--- a/internal/agent/qodercli_test.go
+++ b/internal/agent/qodercli_test.go
@@ -379,6 +379,56 @@ func TestBuildQoderRunCmd_WithoutModel(t *testing.T) {
 	}
 }
 
+func TestBuildQoderCommands_UnsetInheritedAgentSDKMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{
+			name: "global inline run",
+			cmd:  buildQoderRunCmdForBinary("qodercli", "hello", ""),
+			want: "env -u QODER_AGENT_SDK_ENTRYPOINT qodercli --permission-mode=bypass_permissions",
+		},
+		{
+			name: "global stdin run",
+			cmd:  buildQoderRunStdinCmdForBinary("qodercli", "/tmp/prompt", ""),
+			want: "| env -u QODER_AGENT_SDK_ENTRYPOINT qodercli --permission-mode=bypass_permissions",
+		},
+		{
+			name: "global resume",
+			cmd:  buildQoderResumeCmdForBinary("qodercli", "continue", "", "session-1"),
+			want: "env -u QODER_AGENT_SDK_ENTRYPOINT qodercli --permission-mode=bypass_permissions",
+		},
+		{
+			name: "CN inline run",
+			cmd:  buildQoderRunCmdForBinary("qodercn", "hello", ""),
+			want: "env -u QODER_AGENT_SDK_ENTRYPOINT qodercn --permission-mode=bypass_permissions",
+		},
+		{
+			name: "CN stdin run",
+			cmd:  buildQoderRunStdinCmdForBinary("qodercn", "/tmp/prompt", ""),
+			want: "| env -u QODER_AGENT_SDK_ENTRYPOINT qodercn --permission-mode=bypass_permissions",
+		},
+		{
+			name: "CN resume",
+			cmd:  buildQoderResumeCmdForBinary("qodercn", "continue", "", "session-1"),
+			want: "env -u QODER_AGENT_SDK_ENTRYPOINT qodercn --permission-mode=bypass_permissions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if !strings.Contains(tt.cmd, tt.want) {
+				t.Fatalf("command does not unset inherited Agent SDK mode:\n got: %q\nwant: %q", tt.cmd, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildQoderResumeCmd(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Prevent the built-in qodercli adapter from inheriting `QODER_AGENT_SDK_ENTRYPOINT` from SDK-hosted parent processes such as Qoder Work. Without this isolation, nested ordinary qodercli commands are misclassified as Agent SDK sessions and fail with `sdk_invalid_args`.

## Related issues

Closes #240

## Changes

- unset `QODER_AGENT_SDK_ENTRYPOINT` for version checks, inline and file/stdin runs, resumed sessions, and MCP remove/add commands
- apply the same isolation to the global and CN qodercli profiles
- add regression coverage for run, resume, profile-default, and MCP command builders
- document the behavior change in the changelog

## Test plan

- [x] `make test` passes
- [x] `make verify` passes (fmt + vet + lint)
- [x] `make build` passes
- [x] Deterministic QoderCLI single-turn and multi-turn E2E tests with the SDK marker inherited
- [x] Manual run and MCP argument-validation checks with qodercli 1.1.3, 1.1.6, and 1.1.9

## Notes for reviewers

The adapter intentionally remains on qodercli's ordinary `-p --output-format json` protocol. Merely switching to `stream-json` would be incomplete because genuine Agent SDK mode also requires structured stdin, initialization/control messages, and an SDK authentication payload.
